### PR TITLE
[BUGFIX] resolveExclude does not get recognized at all

### DIFF
--- a/Classes/ViewHelpers/Page/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/AbstractMenuViewHelper.php
@@ -232,6 +232,10 @@ abstract class Tx_Vhs_ViewHelpers_Page_AbstractMenuViewHelper extends Tx_Fluid_C
 				continue;
 			} elseif ($page['nav_hide'] == 1 && $this->arguments['showHidden'] < 1) {
 				continue;
+			} else if ($page['tx_realurl_exclude'] == 1 && $this->arguments['resolveExclude'] == 1) {
+				continue;
+			} else if ($page['tx_cooluri_exclude'] == 1 && $this->arguments['resolveExclude'] == 1) {
+				continue;
 			} elseif ($page['l18n_cfg'] == 1 && $GLOBALS['TSFE']->sys_language_uid == 0) {
 				continue;
 			} elseif ($page['l18n_cfg'] == 2 && $GLOBALS['TSFE']->sys_language_uid != 0) {


### PR DESCRIPTION
Hi Claus,

as I noticed the 'resolveExclude' parameter does not get recognized when the pages get filtered. I added the check for 'tx_realurl_exclud' and 'tx_cooluri_exclude'

Cheers
