### PR TITLE
[BUGFIX] Fix typo causing fatal error

### DIFF
--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -158,7 +158,7 @@ class Tx_Vhs_ViewHelpers_Format_EliminateViewHelper extends Tx_Fluid_Core_ViewHe
 	 * @return string
 	 */
 	protected function eliminateUnixBreaks($content) {
-		$content = str_replcace("\n", '', $content);
+		$content = str_replace("\n", '', $content);
 		return $content;
 	}
 


### PR DESCRIPTION
Typo in `Tx_Vhs_ViewHelpers_Format_EliminateViewHelper::eliminateUnixBreaks()` caused a fatal error.
