### PR TITLE
[FEATURE] Add JSON de-/encode ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
@@ -1,0 +1,55 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * Converts the JSON encoded argument into a PHP variable
+ *
+ * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ * @package Vhs
+ * @subpackage ViewHelpers\Format\Json
+ */
+class Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+
+	/**
+	 * @param string $json
+	 * @return mixed
+	 */
+	public function render($json = '') {
+		if ('' === $json) {
+			$json = $this->renderChildren();
+			if ('' === $json) {
+				return;
+			}
+		}
+
+		$value = json_decode($json, TRUE);
+
+		if (json_last_error() !== JSON_ERROR_NONE) {
+			throw new Tx_Fluid_Core_ViewHelper_Exception('The provided argument is invalid JSON.', 1358440054);            
+		}
+
+		return $value;
+	}
+}

--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -1,0 +1,55 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * Returns a string containing the JSON representation of the argument
+ *
+ * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ * @package Vhs
+ * @subpackage ViewHelpers\Format\Json
+ */
+class Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper extends Tx_Fluid_Core_ViewHelper_AbstractViewHelper {
+
+	/**
+	 * @param mixed $value
+	 * @return string
+	 */
+	public function render($value = NULL) {
+		if (NULL === $value) {
+			$value = $this->renderChildren();
+			if (NULL === $value) {
+				return '{}';
+			}
+		}
+
+		$json = json_encode($value);
+
+		if (json_last_error() !== JSON_ERROR_NONE) {
+			throw new Tx_Fluid_Core_ViewHelper_Exception('The provided argument cannot be converted into JSON.', 1358440181);            
+		}
+
+		return $json;
+	}
+}

--- a/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
@@ -1,0 +1,74 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ * @package Vhs
+ */
+class Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelperTest extends Tx_Extbase_Tests_Unit_BaseTestCase {
+
+	/**
+	 * @test
+	 */
+	public function returnsNullForEmptyArguments() {
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(''));
+
+		$this->assertNull($viewHelper->render());
+	}
+	
+	/**
+	 * @test
+	 */
+	public function returnsExpectedValueForProvidedArguments() {
+		
+		$fixture = '{"foo":"bar","bar":true,"baz":1,"foobar":null}';
+
+		$expected = array(
+			'foo'    => 'bar', 
+			'bar'    => TRUE, 
+			'baz'    => 1, 
+			'foobar' => NULL,
+		);
+
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($fixture));
+
+		$this->assertEquals($expected, $viewHelper->render());
+	}
+
+	/**
+	 * @test
+	 */
+	public function throwsExceptionForInvalidArgument() {
+		$invalidJson = "{'foo': 'bar'}";
+
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($invalidJson));
+
+		$this->setExpectedException('Tx_Fluid_Core_ViewHelper_Exception');
+		$this->assertEquals('null', $viewHelper->render());        
+	}
+}

--- a/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
@@ -1,0 +1,72 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ * @package Vhs
+ */
+class Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelperTest extends Tx_Extbase_Tests_Unit_BaseTestCase {
+
+	/**
+	 * @test
+	 */
+	public function returnsEmptyJsonObjectForEmptyArguments() {
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
+
+		$this->assertEquals('{}', $viewHelper->render());
+	}
+	
+	/**
+	 * @test
+	 */
+	public function returnsExpectedStringForProvidedArguments() {
+		
+		$fixture = array(
+			'foo'    => 'bar', 
+			'bar'    => TRUE, 
+			'baz'    => 1, 
+			'foobar' => NULL,
+		);
+
+		$expected = '{"foo":"bar","bar":true,"baz":1,"foobar":null}';
+
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($fixture));
+
+		$this->assertEquals($expected, $viewHelper->render());
+	}
+
+	/**
+	 * @test
+	 */
+	public function throwsExceptionForInvalidArgument() {
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue("\xB1\x31"));
+
+		$this->setExpectedException('Tx_Fluid_Core_ViewHelper_Exception');
+		$this->assertEquals('null', $viewHelper->render());        
+	}
+}


### PR DESCRIPTION
I needed a ViewHelper to encode an array into JSON to configure a javascript library and while I was at it I created one for the opposite direction.
