### PR TITLE
[FEATURE] DateTime support in Format / Json / Encode ViewHelper

### DIFF
--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -2,7 +2,7 @@
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *  (c) 2013 Claus Due <claus@wildside.dk>, Wildside A/S
  *
  *  All rights reserved
  *
@@ -50,6 +50,7 @@
  * or m:n recursive relation is in fact a JavaScript. Not doing so may
  * result in fatal JavaScript errors in the client browser.
  *
+ * @author Claus Due <claus@wildside.dk>, Wildside A/S
  * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
  * @package Vhs
  * @subpackage ViewHelpers\Format\Json
@@ -96,7 +97,7 @@ class Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper extends Tx_Fluid_Core_View
 
 		$json = json_encode($value);
 
-		if (json_last_error() !== JSON_ERROR_NONE) {
+		if (JSON_ERROR_NONE !== json_last_error()) {
 			throw new Tx_Fluid_Core_ViewHelper_Exception('The provided argument cannot be converted into JSON.', 1358440181);
 		}
 

--- a/Tests/Fixtures/Domain/Model/Foo.php
+++ b/Tests/Fixtures/Domain/Model/Foo.php
@@ -1,0 +1,70 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
+ * @package Vhs
+ */
+class Tx_Vhs_Tests_Fixtures_Domain_Model_Foo extends Tx_Extbase_DomainObject_AbstractEntity {
+
+    /**
+     * @var string
+     */
+    protected $bar;
+
+    /**
+     * @var Tx_Extbase_Persistence_ObjectStorage<Tx_Vhs_Tests_Fixtures_Domain_Model_Foo>
+     */
+    protected $children;
+
+    public function __construct() {
+        $this->bar = 'baz';
+        $this->children = new Tx_Extbase_Persistence_ObjectStorage();
+    }
+
+    /**
+     * @return string
+     */
+    public function getBar() {
+        return $this->bar;
+    }
+
+    /**
+     * @return Tx_Extbase_Persistence_ObjectStorage<Tx_Vhs_Tests_Fixtures_Domain_Model_Foo>
+     */
+    public function getChildren() {
+        return $this->children;
+    }
+
+    /**
+     * @param Tx_Vhs_Tests_Fixtures_Domain_Model_Foo $child
+     * @return Tx_Vhs_Tests_Fixtures_Domain_Model_Foo
+     */
+    public function addChild(Tx_Vhs_Tests_Fixtures_Domain_Model_Foo $child) {
+        $this->children->attach($child);
+
+        return $this;
+    }
+}

--- a/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/DecodeViewHelperTest.php
@@ -38,18 +38,18 @@ class Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelperTest extends Tx_Extbase_Tes
 
 		$this->assertNull($viewHelper->render());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function returnsExpectedValueForProvidedArguments() {
-		
+
 		$fixture = '{"foo":"bar","bar":true,"baz":1,"foobar":null}';
 
 		$expected = array(
-			'foo'    => 'bar', 
-			'bar'    => TRUE, 
-			'baz'    => 1, 
+			'foo'    => 'bar',
+			'bar'    => TRUE,
+			'baz'    => 1,
 			'foobar' => NULL,
 		);
 
@@ -69,6 +69,6 @@ class Tx_Vhs_ViewHelpers_Format_Json_DecodeViewHelperTest extends Tx_Extbase_Tes
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($invalidJson));
 
 		$this->setExpectedException('Tx_Fluid_Core_ViewHelper_Exception');
-		$this->assertEquals('null', $viewHelper->render());        
+		$this->assertEquals('null', $viewHelper->render());
 	}
 }

--- a/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
@@ -38,16 +38,16 @@ class Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelperTest extends Tx_Extbase_Tes
 
 		$this->assertEquals('{}', $viewHelper->render());
 	}
-	
+
 	/**
 	 * @test
 	 */
 	public function returnsExpectedStringForProvidedArguments() {
-		
+
 		$fixture = array(
-			'foo'    => 'bar', 
-			'bar'    => TRUE, 
-			'baz'    => 1, 
+			'foo'    => 'bar',
+			'bar'    => TRUE,
+			'baz'    => 1,
 			'foobar' => NULL,
 		);
 
@@ -67,6 +67,41 @@ class Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelperTest extends Tx_Extbase_Tes
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue("\xB1\x31"));
 
 		$this->setExpectedException('Tx_Fluid_Core_ViewHelper_Exception');
-		$this->assertEquals('null', $viewHelper->render());        
+		$this->assertEquals('null', $viewHelper->render());
+	}
+
+	/**
+	 * @test
+	 */
+	public function returnsJsConsumableTimestamps() {
+		$date = new \DateTime('now');
+		$jsTimestamp = $date->getTimestamp()*1000;
+
+		$fixture = array('foo' => $date, 'bar' => array('baz' => $date));
+		$expected = sprintf('{"foo":%s,"bar":{"baz":%s}}', $jsTimestamp, $jsTimestamp);
+
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($fixture));
+
+		$this->assertEquals($expected, $viewHelper->render());
+	}
+
+	/**
+	 * @test
+	 */
+	public function convertsDomainObjectsIntoAssocArrays() {
+		$foo1 = $this->objectManager->get('Tx_Vhs_Tests_Fixtures_Domain_Model_Foo');
+		$foo2 = $this->objectManager->get('Tx_Vhs_Tests_Fixtures_Domain_Model_Foo');
+		$foo3 = $this->objectManager->get('Tx_Vhs_Tests_Fixtures_Domain_Model_Foo');
+		$foo1->addChild($foo2);
+		$foo2->addChild($foo3);
+
+		$expectedRegex = '/\{"bar"\:"baz","children"\:\{"[a-f0-9]+"\:\{"bar"\:"baz","children"\:\{"[a-f0-9]+"\:\{"bar"\:"baz","children"\:\[\],"pid"\:null,"uid"\:null\}\},"pid"\:null,"uid"\:null\}\},"pid"\:null,"uid"\:null\}/';
+
+		$viewHelper = $this->getMock('Tx_Vhs_ViewHelpers_Format_Json_EncodeViewHelper', array('renderChildren'));
+		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($foo1));
+
+
+		$this->assertRegexp($expectedRegex, $viewHelper->render());
 	}
 }

--- a/ext_autoload.php
+++ b/ext_autoload.php
@@ -1,0 +1,6 @@
+<?php
+$path = t3lib_extMgm::extPath('vhs') . 'Tests/Fixtures/';
+return array(
+	'tx_vhs_tests_fixtures_domain_model_foo' => $path . 'Domain/Model/Foo.php',
+);
+?>


### PR DESCRIPTION
This one adds full DateTime support in the JSON encoding ViewHelper - with the option to specify a custom format which DateTimes are converted into. The default conversion is done by UNIXTIME \* 1000 which creates a UNIX epoch stamp ready for JavaScript's Date object.

@dreipunktnull once again, would you mind being my QA? :)
