### PR TITLE
[BUGFIX] Make arguments act as documented

### DIFF
--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -119,10 +119,10 @@ class Tx_Vhs_ViewHelpers_Page_LanguageMenuViewHelper extends Tx_Fluid_Core_ViewH
 			} else {
 				$class = '';
 			}
-			if (FALSE === (boolean) $var['current'] || (TRUE === (boolean) $var['current'] && TRUE === (boolean) $this->arguments['linkCurrent'])) {
-				$html[] = '<' . $tagName . $class . '><a href="' . htmlspecialchars($var['url']) . '">' . $this->getLayout($var) . '</a></' . $tagName . '>';
-			} else {
+			if (TRUE === (boolean) $var['current'] && FALSE === (boolean) $this->arguments['linkCurrent'])) {
 				$html[] = '<' . $tagName . $class . '>' . $this->getLayout($var) . '</' . $tagName . '>';
+			} else {
+				$html[] = '<' . $tagName . $class . '><a href="' . htmlspecialchars($var['url']) . '">' . $this->getLayout($var) . '</a></' . $tagName . '>';
 			}
 		}
 		return implode(LF, $html);


### PR DESCRIPTION
According to the docs the argument 'layout' expects 'flag', 'name', 'flag,name' or 'name,flag' as values but the relevant code checked for values 0,1 or 2. Argument 'linkCurrent' rendered all languages as links regardless of current language.
