### PR TITLE
[BUGFIX] force close tag "script"

### DIFF
--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -290,6 +290,7 @@ class Tx_Vhs_ViewHelpers_AssetViewHelper extends Tx_Vhs_ViewHelpers_Asset_Abstra
 					$tagBuilder->setContent($content);
 				} else {
 					$tagBuilder->addAttribute('src', $file);
+					$tagBuilder->forceClosingTag(TRUE);
 				}
 				break;
 			case 'css':


### PR DESCRIPTION
Tag "script" must be closed for not messing up the page. Actually, the
self-closing XML syntax <script /> is correct XML, but for it to work
in practice, the web server also needs to send the XML mime-type
like application/xhtml+xml and not as text/html which is not something
we want by default.
