### PR TITLE
[BUGFIX] Remove duplicate argument initialization

### DIFF
--- a/Classes/ViewHelpers/LViewHelper.php
+++ b/Classes/ViewHelpers/LViewHelper.php
@@ -45,14 +45,15 @@
 class Tx_Vhs_ViewHelpers_LViewHelper extends Tx_Fluid_ViewHelpers_TranslateViewHelper implements t3lib_Singleton {
 
 	/**
-	 * @param string $key
-	 * @param string $default
-	 * @param boolean $htmlEscape
-	 * @param array $arguments
-	 * @param string $extensionName
+	 * Render method
 	 * @return string
 	 */
-	public function render($key = NULL, $default = NULL, $htmlEscape = TRUE, array $arguments = NULL, $extensionName = NULL) {
+	public function render() {
+		$key = $this->arguments['key'];
+		$default = $this->arguments['default'];
+		$htmlEscape = $this->arguments['htmlEscape'];
+		$arguments = $this->arguments['arguments'];
+		$extensionName = $this->arguments['extensionName'];
 		if (NULL === $key) {
 			$key = $this->renderChildren();
 		}


### PR DESCRIPTION
(At least in 6.0) this lead to an error as the viewhelper arguments are initialized in the parent class **and** in the render method. 
