### PR TITLE
[FEATURE] Rewrite and cache files referenced by CSS files

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -162,7 +162,12 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 * @return mixed
 	 */
 	public function build() {
-		return $this->getContent();
+		if (FALSE === isset($this->arguments['path'])) {
+			return $this->getContent();
+		}
+		$absolutePathAndFilename = t3lib_div::getFileAbsFileName($this->arguments['path']);
+		$content = file_get_contents($absolutePathAndFilename);
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
This parses CSS sources when not included as standalone files, caching and relocating files referenced from the CSS such as background images and imports.

Does not work recursively, i.e. does not parse imported files for additional referenced files. Files imported by @import statement get copied to typo3temp but any resources therein do not get copied.
