### PR TITLE
[BUXFIX] SortViewHelper to work with numberic properties

### DIFF
--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -119,7 +119,7 @@ class Tx_Vhs_ViewHelpers_Iterator_SortViewHelper extends Tx_Fluid_Core_ViewHelpe
 				$index = $this->getSortValue($object);
 			}
 			while (isset($sorted[$index])) {
-				$index .= '1';
+				$index .= TRUE === is_int($index) ? '.1' : '1';
 			}
 			$sorted[$index] = $object;
 		}
@@ -161,7 +161,7 @@ class Tx_Vhs_ViewHelpers_Iterator_SortViewHelper extends Tx_Fluid_Core_ViewHelpe
 				$index = $this->getSortValue($item);
 			}
 			while (isset($sorted[$index])) {
-				$index .= '1';
+				$index .= TRUE === is_int($index) ? '.1' : '1';
 			}
 			$sorted[$index] = $item;
 		}


### PR DESCRIPTION
If you have an numberic property which you want to sortby this causes
problems when you have more than one element this that value on sortby
property.

Right now a this rewrites a numberic value from 1 to 11 for example
which will mess up the sorting.

With this change ksort would handle the index as float and not integer
and sorting will work as expected for numberic properties too.
