### PR TITLE
[BUGFIX] Disable cache if positive in Once and Security ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Once/AbstractOnceViewHelper.php
+++ b/Classes/ViewHelpers/Once/AbstractOnceViewHelper.php
@@ -111,4 +111,21 @@ abstract class Tx_Vhs_ViewHelpers_Once_AbstractOnceViewHelper extends Tx_Fluid_C
 		return (isset(self::$identifiers[$identifier]) === TRUE);
 	}
 
+	/**
+	 * Override: forcibly disables page caching - a TRUE condition
+	 * in this ViewHelper means page content would be depending on
+	 * the current visitor's session/cookie/auth etc.
+	 *
+	 * Returns value of "then" attribute.
+	 * If then attribute is not set, iterates through child nodes and renders ThenViewHelper.
+	 * If then attribute is not set and no ThenViewHelper and no ElseViewHelper is found, all child nodes are rendered
+	 *
+	 * @return string rendered ThenViewHelper or contents of <f:if> if no ThenViewHelper was found
+	 * @api
+	 */
+	protected function renderThenChild() {
+		$GLOBALS['TSFE']->no_cache = 1;
+		return parent::renderThenChild();
+	}
+
 }

--- a/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
+++ b/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
@@ -251,4 +251,21 @@ abstract class Tx_Vhs_ViewHelpers_Security_AbstractSecurityViewHelper extends Tx
 		return $GLOBALS['BE_USER']->user;
 	}
 
+	/**
+	 * Override: forcibly disables page caching - a TRUE condition
+	 * in this ViewHelper means page content would be depending on
+	 * the current visitor's session/cookie/auth etc.
+	 *
+	 * Returns value of "then" attribute.
+	 * If then attribute is not set, iterates through child nodes and renders ThenViewHelper.
+	 * If then attribute is not set and no ThenViewHelper and no ElseViewHelper is found, all child nodes are rendered
+	 *
+	 * @return string rendered ThenViewHelper or contents of <f:if> if no ThenViewHelper was found
+	 * @api
+	 */
+	protected function renderThenChild() {
+		$GLOBALS['TSFE']->no_cache = 1;
+		return parent::renderThenChild();
+	}
+
 }


### PR DESCRIPTION
Fixes: #116

This change overrides the `renderThenChild` method in the abstract classes for Once and Security scope ViewHelpers. When a positive condition is encountered, the output should be considered specific to the current visitor only - achieved by simply preventing caching of the page being rendered.
