### PR TITLE
getName always returns same md5 value if "name" attribute not set

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -244,13 +244,13 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 */
 	public function getName() {
 		$assetSettings = $this->getAssetSettings();
-		if (TRUE === isset($assetSettings['name'])) {
+		if (TRUE === (isset($assetSettings['name']) && FALSE === empty($assetSettings['name']))) {
 			$name = $assetSettings['name'];
 		} else {
-			$name = md5(implode('', array_values($assetSettings)));
+			$name = md5(serialize($assetSettings));
 		}
 		if (TRUE === (boolean) $assetSettings['fluid']) {
-			$name .= '-' . md5(implode('', array_values($this->getVariables())));
+			$name .= '-' . md5(zerialize($this->getVariables()));
 		}
 		return $name;
 	}


### PR DESCRIPTION
Related to #146
When name attribute is not set (case of JS files), getName always returned the same md5 value. This is because array_values($assetSettings) always returned an empty value.
Furthermore i corrected the test on the name attribute as for #145.
