### PR TITLE
[BUGFIX] Change check on Asset "path" to cover 4.5 misbehavior

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -162,7 +162,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 * @return mixed
 	 */
 	public function build() {
-		if (FALSE === isset($this->arguments['path'])) {
+		if (FALSE === isset($this->arguments['path']) || TRUE === empty($this->arguments['path'])) {
 			return $this->getContent();
 		}
 		$absolutePathAndFilename = t3lib_div::getFileAbsFileName($this->arguments['path']);


### PR DESCRIPTION
Instead of using isset() which always returns TRUE for the ArrayAccess used in 4.5's Fluid, the check needs to be extended.

Replaces: #150
