### PR TITLE
[BUGFIX] Name generation for assets buggy on 4.5

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -244,13 +244,13 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 */
 	public function getName() {
 		$assetSettings = $this->getAssetSettings();
-		if (TRUE === isset($assetSettings['name'])) {
+		if (TRUE === isset($assetSettings['name']) && FALSE === empty($assetSettings['name'])) {
 			$name = $assetSettings['name'];
 		} else {
-			$name = md5(implode('', array_values($assetSettings)));
+			$name = md5(serialize($assetSettings));
 		}
 		if (TRUE === (boolean) $assetSettings['fluid']) {
-			$name .= '-' . md5(implode('', array_values($this->getVariables())));
+			$name .= '-' . md5(serialize($this->getVariables()));
 		}
 		return $name;
 	}


### PR DESCRIPTION
This fixes some issues with incomplete (always-TRUE) checks on 4.5 and uses serialize() to avoid collisions on ArrayAccess sameness which would often occur on 4.5.

Replaces: #149
