### PR TITLE
[BUGFIX] Method Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper::getCon...

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -268,10 +268,10 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 */
 	protected function getContent() {
 		$assetSettings = $this->getAssetSettings();
-		if (FALSE === isset($assetSettings['content'])) {
-			$content = $this->renderChildren();
-		} else {
+		if (TRUE === isset($assetSettings['content']) && FALSE === empty($assetSettings['content'])) {
 			$content = $assetSettings['content'];
+		} else {
+			$content = $this->renderChildren();
 		}
 		if (TRUE === (boolean) $assetSettings['trim']) {
 			$lines = explode(LF, $content);


### PR DESCRIPTION
...tent returns an empty value when using VH tag content

Fixes an issue where asset content would be returned empty on 4.5 when tag content is used instead of content attribute due to isset() always returning TRUE

Fixed by using an extended check.
