### PR TITLE
[TASK] Use rawurlencode()/rawurldecode() to unify usage

### DIFF
--- a/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
@@ -40,7 +40,7 @@ class Tx_Vhs_ViewHelpers_Format_Url_DecodeViewHelper extends Tx_Fluid_Core_ViewH
 		if (NULL === $content) {
 			$content = $this->renderChildren();
 		}
-		return urldecode($content);
+		return rawurldecode($content);
 	}
 
 }

--- a/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
@@ -40,7 +40,7 @@ class Tx_Vhs_ViewHelpers_Format_Url_EncodeViewHelper extends Tx_Fluid_Core_ViewH
 		if (NULL === $content) {
 			$content = $this->renderChildren();
 		}
-		return urlencode($content);
+		return rawurlencode($content);
 	}
 
 }


### PR DESCRIPTION
Fluid comes with its own `<f:format.urlencode />` ViewHelper which is a) not available in TYPO3 4.5 and b) uses `rawurlencode()`
