### PR TITLE
[BUGFIX] Root page is always active with useShortcutData

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -212,6 +212,9 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends Tx_Fl
 	 * @return boolean
 	 */
 	protected function isActive($pageUid, $rootLine) {
+		if (1 < count($rootLine)) {
+			array_pop($rootLine);
+		}
 		foreach ($rootLine as $page) {
 			if ($page['uid'] == $pageUid) {
 				return TRUE;


### PR DESCRIPTION
When the root page is a regular page and has a shortcut pointing at it to make it visible in the menu it would always be active.
