### PR TITLE
[TASK] Enable cache clearing hook to delete cached asset files

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -627,4 +627,14 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 		return $content;
 	}
 
+	/**
+	 * @return void
+	 */
+	public function clearCacheCommand() {
+		$assetCacheFiles = glob(t3lib_div::getFileAbsFileName('typo3temp/vhs-assets-*'));
+		foreach ($assetCacheFiles as $assetCacheFile) {
+			unlink($assetCacheFile);
+		}
+	}
+
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,3 +5,4 @@ if (!defined('TYPO3_MODE')) {
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAll';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_eofe'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAllUncached';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:vhs/Classes/Service/AssetService.php:&Tx_Vhs_Service_AssetService->clearCacheCommand';


### PR DESCRIPTION
Cached asset files in typo3temp were never deleted thus making changes to included assets without changing their names wouldn't have any effect.
