### PR TITLE
[TASK] Use valid HTML comment delimiters

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -180,7 +180,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 			$uncachedSuffix = 'Uncached';
 		} else {
 			$uncachedSuffix = '';
-			$dependenciesString = '<!---- VhsAssetsDependenciesLoaded ' . implode(',', array_keys($assets)) . ' ----!>';
+			$dependenciesString = '<!---- VhsAssetsDependenciesLoaded ' . implode(',', array_keys($assets)) . ' ---->';
 			$this->insertAssetsAtMarker('DependenciesLoaded', $dependenciesString);
 		}
 		$this->insertAssetsAtMarker('Header' . $uncachedSuffix, $header);
@@ -194,8 +194,8 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	 * @return void
 	 */
 	private function insertAssetsAtMarker($markerName, $assets) {
-		if (FALSE === strpos($GLOBALS['TSFE']->content, '<!---- VhsAssets' . $markerName . ' ----!>')) {
-			$assetMarker = '<!---- VhsAssets' . $markerName . ' ----!>';
+		if (FALSE === strpos($GLOBALS['TSFE']->content, '<!---- VhsAssets' . $markerName . ' ---->')) {
+			$assetMarker = '<!---- VhsAssets' . $markerName . ' ---->';
 			$inFooter = FALSE !== strpos($markerName, 'Footer');
 			$tag = TRUE === $inFooter ? '</body>' : '</head>';
 			$GLOBALS['TSFE']->content = str_replace($tag, $assetMarker . LF . $tag, $GLOBALS['TSFE']->content);
@@ -205,7 +205,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 		} else {
 			$chunk = $assets;
 		}
-		$GLOBALS['TSFE']->content = str_replace('<!---- VhsAssets' . $markerName . ' ----!>', $chunk, $GLOBALS['TSFE']->content);
+		$GLOBALS['TSFE']->content = str_replace('<!---- VhsAssets' . $markerName . ' ---->', $chunk, $GLOBALS['TSFE']->content);
 	}
 
 	/**


### PR DESCRIPTION
This changes the comment end delimiter to '---->' (without '!') to avoid
parsing errors due to HTML comment cleanup as done by some extensions
like EXT:sourceopt and to meet the HTML comment syntax as described by
the W3C:
http://www.w3.org/TR/html-markup/syntax.html#comments
