### PR TITLE
[TASK] Use valid HTML comment delimiters (finally)

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -182,7 +182,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 			$uncachedSuffix = 'Uncached';
 		} else {
 			$uncachedSuffix = '';
-			$dependenciesString = '<!---- VhsAssetsDependenciesLoaded ' . implode(',', array_keys($assets)) . ' ---->';
+			$dependenciesString = '<!-- VhsAssetsDependenciesLoaded ' . implode(',', array_keys($assets)) . ' -->';
 			$this->insertAssetsAtMarker('DependenciesLoaded', $dependenciesString);
 		}
 		$this->insertAssetsAtMarker('Header' . $uncachedSuffix, $header);
@@ -196,8 +196,8 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	 * @return void
 	 */
 	private function insertAssetsAtMarker($markerName, $assets) {
-		if (FALSE === strpos($GLOBALS['TSFE']->content, '<!---- VhsAssets' . $markerName . ' ---->')) {
-			$assetMarker = '<!---- VhsAssets' . $markerName . ' ---->';
+		if (FALSE === strpos($GLOBALS['TSFE']->content, '<!-- VhsAssets' . $markerName . ' -->')) {
+			$assetMarker = '<!-- VhsAssets' . $markerName . ' -->';
 			$inFooter = FALSE !== strpos($markerName, 'Footer');
 			$tag = TRUE === $inFooter ? '</body>' : '</head>';
 			$GLOBALS['TSFE']->content = str_replace($tag, $assetMarker . LF . $tag, $GLOBALS['TSFE']->content);
@@ -207,7 +207,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 		} else {
 			$chunk = $assets;
 		}
-		$GLOBALS['TSFE']->content = str_replace('<!---- VhsAssets' . $markerName . ' ---->', $chunk, $GLOBALS['TSFE']->content);
+		$GLOBALS['TSFE']->content = str_replace('<!-- VhsAssets' . $markerName . ' -->', $chunk, $GLOBALS['TSFE']->content);
 	}
 
 	/**


### PR DESCRIPTION
The previous commit on this (846e418) only removed the '!' char in the
comment end delimiter, but did not actually adjust the comment delimiters
to meet the HTML comment syntax as described by the W3C
(http://www.w3.org/TR/html-markup/syntax.html#comments) as stated in the
commit message.

This commit finally does by adjusting the delimiters to the usual syntax
('<!-- ... -->').

I'm so sorry for the mess!!
