### PR TITLE
[BUGFIX] Type cast array to enable setting of values

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -358,7 +358,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 		$name = $this->arguments['name'];
 		$groupName = $this->arguments['group'];
 		$settings = $this->getSettings();
-		$assetSettings = $this->arguments;
+		$assetSettings = (array) $this->arguments;
 		$assetSettings['type'] = $this->getType();
 		if (TRUE === (isset($settings['assetGroup'][$groupName]) && is_array($settings['assetGroup'][$groupName]))) {
 			$assetSettings = t3lib_div::array_merge_recursive_overrule($assetSettings, $settings['assetGroup'][$groupName]);


### PR DESCRIPTION
In TYPO3 4.5 this leads to an exception as direct setting of arguments is not allowed in a viewhelper class
