### PR TITLE
[FEATURE] Attribute "as" on all menu ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -62,9 +62,9 @@ class Tx_Vhs_ViewHelpers_Page_BreadCrumbViewHelper extends Tx_Vhs_ViewHelpers_Pa
 			return NULL;
 		}
 		$this->backupVariables();
-		$this->templateVariableContainer->add('rootLine', $rootLine);
+		$this->templateVariableContainer->add($this->arguments['as'], $rootLine);
 		$output = $this->renderContent($rootLine);
-		$this->templateVariableContainer->remove('rootLine');
+		$this->templateVariableContainer->remove($this->arguments['as']);
 		$this->restoreVariables();
 		return $output;
 	}

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -71,6 +71,7 @@ class Tx_Vhs_ViewHelpers_Page_LanguageMenuViewHelper extends Tx_Fluid_Core_ViewH
 		$this->registerArgument('flagPath', 'string', 'Overwrites the path to the flag folder', FALSE, 'typo3/sysext/t3skin/images/flags/');
 		$this->registerArgument('flagImageType', 'string', 'Sets type of flag image: png, gif, jpeg', FALSE, 'png');
 		$this->registerArgument('linkCurrent', 'boolean', 'Sets flag to link current language or not', FALSE, TRUE);
+		$this->registerArgument('as', 'string', 'If used, stores the menu pages as an array in a variable named according to this value and renders the tag content - which means automatic rendering is disabled if this attribute is used', FALSE, 'languageMenu');
 	}
 
 	/**
@@ -82,10 +83,10 @@ class Tx_Vhs_ViewHelpers_Page_LanguageMenuViewHelper extends Tx_Fluid_Core_ViewH
 		$this->cObj = t3lib_div::makeInstance('tslib_cObj');
 		$this->tagName = $this->arguments['tagName'];
 		$this->languageMenu = $this->parseLanguageMenu($this->arguments['order'], $this->arguments['labelOverwrite']);
-		$this->templateVariableContainer->add('languageMenu', $this->languageMenu);
+		$this->templateVariableContainer->add($this->arguments['as'], $this->languageMenu);
 		$content = $this->renderChildren();
+		$this->templateVariableContainer->remove($this->arguments['as']);
 		if (strlen(trim($content)) === 0) {
-			$this->templateVariableContainer->remove('languageMenu');
 			$content = $this->autoRender($this->languageMenu);
 		}
 		return $content;

--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -98,6 +98,8 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends Tx_Fl
 		$this->registerArgument('doktypes', 'mixed', 'CSV list or array of allowed doktypes from constant names or integer values, i.e. 1,254 or DEFAULT,SYSFOLDER,SHORTCUT or just default,sysfolder,shortcut');
 		$this->registerArgument('excludeSubpageTypes', 'mixed', 'CSV list or array of doktypes to not consider as subpages. Can be constant names or integer values, i.e. 1,254 or DEFAULT,SYSFOLDER,SHORTCUT or just default,sysfolder,shortcut', FALSE, 'SYSFOLDER');
 		$this->registerArgument('deferred', 'boolean', 'If TRUE, does not output the tag content UNLESS a v:page.menu.deferred child ViewHelper is both used and triggered. This allows you to create advanced conditions while still using automatic rendering', FALSE, FALSE);
+		$this->registerArgument('as', 'string', 'If used, stores the menu pages as an array in a variable named according to this value and renders the tag content - which means automatic rendering is disabled if this attribute is used', FALSE, 'menu');
+		$this->registerArgument('rootLineAs', 'string', 'If used, stores the menu root line as an array in a variable named according to this value and renders the tag content - which means automatic rendering is disabled if this attribute is used', FALSE, 'rootLine');
 	}
 
 	/**
@@ -636,13 +638,13 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends Tx_Fl
 		$rootLine = $this->parseMenu($rootLineData, $rootLineData);
 		$this->cleanTemplateVariableContainer();
 		$this->backupVariables();
-		$this->templateVariableContainer->add('menu', $menu);
-		$this->templateVariableContainer->add('rootLine', $rootLine);
+		$this->templateVariableContainer->add($this->arguments['as'], $menu);
+		$this->templateVariableContainer->add($this->arguments['rootLineAs'], $rootLine);
 		$this->initalizeSubmenuVariables();
 		$output = $this->renderContent($menu);
 		$this->cleanupSubmenuVariables();
-		$this->templateVariableContainer->remove('menu');
-		$this->templateVariableContainer->remove('rootLine');
+		$this->templateVariableContainer->remove($this->arguments['as']);
+		$this->templateVariableContainer->remove($this->arguments['rootLineAs']);
 		$this->restoreVariables();
 		return $output;
 	}

--- a/Classes/ViewHelpers/Page/Menu/BrowseViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/BrowseViewHelper.php
@@ -120,9 +120,9 @@ class Tx_Vhs_ViewHelpers_Page_Menu_BrowseViewHelper extends Tx_Vhs_ViewHelpers_P
 			$menu[$lastUid]['linktext'] = $this->getCustomLabelOrPageTitle('labelLast', $menu[$lastUid]);
 		}
 		$this->backupVariables();
-		$this->templateVariableContainer->add('menu', $menu);
+		$this->templateVariableContainer->add($this->arguments['as'], $menu);
 		$output = $this->renderContent($menu);
-		$this->templateVariableContainer->remove('menu');
+		$this->templateVariableContainer->remove($this->arguments['as']);
 		$this->restoreVariables();
 		return $output;
 	}

--- a/Classes/ViewHelpers/Page/Menu/DirectoryViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/DirectoryViewHelper.php
@@ -71,9 +71,9 @@ class Tx_Vhs_ViewHelpers_Page_Menu_DirectoryViewHelper extends Tx_Vhs_ViewHelper
 		}
 		$menu = $this->parseMenu($menuData, $rootLineData);
 		$this->backupVariables();
-		$this->templateVariableContainer->add('menu', $menu);
+		$this->templateVariableContainer->add($this->arguments['as'], $menu);
 		$output = $this->renderContent($menu);
-		$this->templateVariableContainer->remove('menu');
+		$this->templateVariableContainer->remove($this->arguments['as']);
 		$this->restoreVariables();
 		return $output;
 	}

--- a/Classes/ViewHelpers/Page/Menu/ListViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/ListViewHelper.php
@@ -70,9 +70,9 @@ class Tx_Vhs_ViewHelpers_Page_Menu_ListViewHelper extends Tx_Vhs_ViewHelpers_Pag
 		}
 		$menu = $this->parseMenu($menuData, $rootLineData);
 		$this->backupVariables();
-		$this->templateVariableContainer->add('menu', $menu);
+		$this->templateVariableContainer->add($this->arguments['as'], $menu);
 		$output = $this->renderContent($menu);
-		$this->templateVariableContainer->remove('menu');
+		$this->templateVariableContainer->remove($this->arguments['as']);
 		$this->restoreVariables();
 		return $output;
 	}


### PR DESCRIPTION
Use of this argument allows setting the name of the variable that should contain the menu structure (note: in addition to the "menu" variable).

Fixes: #177
