### PR TITLE
[FEATURE] Add configuration option to disable assets cache

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -275,6 +275,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	private function writeCachedMergedFileAndReturnTag($assets, $type) {
 		$ttl = (TRUE === isset($GLOBALS['TSFE']->tmpl->setup['config.']['cache_period']) && $GLOBALS['TSFE']->tmpl->setup['config.']['cache_period'] !== 0)
 			? $GLOBALS['TSFE']->tmpl->setup['config.']['cache_period'] : 10800;
+		$disableCache = (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup']['disableCache'];
 		$source = '';
 		$assetName = implode('-', array_keys($assets));
 		if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['mergedAssetsUseHashedFilename']) {
@@ -282,7 +283,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 		}
 		$fileRelativePathAndFilename = 'typo3temp/vhs-assets-' . $assetName . '.'.  $type;
 		$fileAbsolutePathAndFilename = t3lib_div::getFileAbsFileName($fileRelativePathAndFilename);
-		if (FALSE === file_exists($fileAbsolutePathAndFilename) || filectime($fileAbsolutePathAndFilename) < time() - $ttl) {
+		if (FALSE === file_exists($fileAbsolutePathAndFilename) || filectime($fileAbsolutePathAndFilename) < time() - $ttl || TRUE === $disableCache) {
 			foreach ($assets as $name => $asset) {
 				$settings = $this->extractAssetSettings($asset);
 				if (TRUE === (isset($settings['namedChunks']) && 0 < $settings['namedChunks']) || FALSE === isset($settings['namedChunks'])) {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+  # cat=basic/enable; type=boolean; label=Development Mode: Disable cache to generate merged assets file on every request.
+disableCache = 0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,8 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = unserialize($_EXTCONF);
+
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAll';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_eofe'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAllUncached';
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->clearCacheCommand';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:vhs/Classes/Service/AssetService.php:&Tx_Vhs_Service_AssetService->clearCacheCommand';


### PR DESCRIPTION
This adds a switch to the extension's configuration to disable caching of merged assets by regenerating the merged file on every request. Useful in development stage.
