### PR TITLE
[TASK] Add CSS assets to header by default

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -338,15 +338,6 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	}
 
 	/**
-	 * @param string $content
-	 * @return Tx_Vhs_Asset
-	 */
-	public function setContent($content) {
-		$this->content = $content;
-		return $this;
-	}
-
-	/**
 	 * @param string $name
 	 * @return Tx_Vhs_Asset
 	 */
@@ -363,6 +354,15 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 			return file_get_contents(t3lib_div::getFileAbsFileName($this->path));
 		}
 		return $this->content;
+	}
+
+	/**
+	 * @param string $content
+	 * @return Tx_Vhs_Asset
+	 */
+	public function setContent($content) {
+		$this->content = $content;
+		return $this;
 	}
 
 	/**
@@ -484,6 +484,13 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function getMovable() {
+		return $this->movable;
+	}
+
+	/**
 	 * @param boolean $movable
 	 * @return $this
 	 */
@@ -495,8 +502,8 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	/**
 	 * @return boolean
 	 */
-	public function getMovable() {
-		return $this->movable;
+	public function getRemoved() {
+		return $this->removed;
 	}
 
 	/**
@@ -506,13 +513,6 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	public function setRemoved($removed) {
 		$this->removed = $removed;
 		return $this;
-	}
-
-	/**
-	 * @return boolean
-	 */
-	public function getRemoved() {
-		return $this->removed;
 	}
 
 	/**


### PR DESCRIPTION
When adding assets using TS CSS files would be added to the footer by default. This patch changes this default depending on the asset's type. Discussed in and fixes #215.
