### PR TITLE
[BUGFIX] Correct parsing of argument doktypes

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -250,6 +250,8 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends Tx_Fl
 				if (NULL !== $typeNumber) {
 					$parsed[$index] = $typeNumber;
 				}
+			} else {
+				$parsed[$index] = intval($type);
 			}
 		}
 		return $parsed;


### PR DESCRIPTION
This patch was missing in the last PR. Fixes #228
