### PR TITLE
[BUGFIX] Support edge-case URLs of secondary Asset files

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -537,7 +537,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 			$match = trim($match, '\'" ');
 			if (FALSE === strpos($match, ':') && !preg_match('/url\\s*\\(/i', $match)) {
 				$checksum = md5($match);
-				if (preg_match('/([^"\'\?#]+)(.+)?/', $match, $items)) {
+				if (preg_match('/([^\?#]+)(.+)?/', $match, $items)) {
 					list(,$path, $suffix) = $items;
 				} else {
 					$path = $match;


### PR DESCRIPTION
For example, an URL like `/file.css?#iefix` would cause an error when attempting to copy the file `/file.css` which you have invalid chars appended to the name.

Fixes: #216
