### PR TITLE
[BUGFIX] Checksum gets lost when processing dependencies

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -388,11 +388,12 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	private function sortAssetsByDependency($assets) {
 		$placed = array();
 		$compilables = array();
+		$assetNames = array_combine(array_keys($assets), array_keys($assets));
 		while ($asset = array_shift($assets)) {
 			$postpone = FALSE;
 			/** @var $asset Tx_Vhs_ViewHelpers_Asset_AssetInterface */
 			$assetSettings = $this->extractAssetSettings($asset);
-			$name = $assetSettings['name'];
+			$name = array_shift($assetNames);
 			$dependencies = $assetSettings['dependencies'];
 			if (FALSE === is_array($dependencies)) {
 				$dependencies = t3lib_div::trimExplode(',', $assetSettings['dependencies'], TRUE);
@@ -408,6 +409,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 						break;
 					}
 					$assets[$name] = $asset;
+					$assetNames[$name] = $name;
 					$postpone = TRUE;
 				}
 			}


### PR DESCRIPTION
Asset names containing the checksum are saved as array keys which get lost during the processing of dependencies. Hopefully fixes #210.
