### PR TITLE
[TASK] Be a bit less eager to remove Asset files

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -61,6 +61,11 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	private static $buildComplete = FALSE;
 
 	/**
+	 * @var boolean
+	 */
+	private static $cacheCleared = FALSE;
+
+	/**
 	 * @param Tx_Extbase_Configuration_ConfigurationManagerInterface $configurationManager
 	 * @return void
 	 */
@@ -636,13 +641,21 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	}
 
 	/**
+	 * @param array $parameters
 	 * @return void
 	 */
-	public function clearCacheCommand() {
+	public function clearCacheCommand($parameters) {
+		if (TRUE === self::$cacheCleared) {
+			return;
+		}
+		if ('all' !== $parameters['cacheCmd']) {
+			return;
+		}
 		$assetCacheFiles = glob(t3lib_div::getFileAbsFileName('typo3temp/vhs-assets-*'));
 		foreach ($assetCacheFiles as $assetCacheFile) {
 			unlink($assetCacheFile);
 		}
+		self::$cacheCleared = TRUE;
 	}
 
 }


### PR DESCRIPTION
This should help improve VHS's performance greatly on sites which use a lot of Assets; before this change, VHS would remove Asset files on any type of cache clearing and would not hesitate to remove Asset files multiple times in one Request. After this change removal of files is only ever allowed once per Request and is only done when clearing _all_ caches in the backend, ensuring it doesn't happen too often (e.g. whenever an editor saves a page or clears the page content cache).
