### PR TITLE
[BUGFIX] Override default value for argument 'as' in deferred menu VH

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/DeferredViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/DeferredViewHelper.php
@@ -38,6 +38,15 @@
 class Tx_Vhs_ViewHelpers_Page_Menu_DeferredViewHelper extends Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper {
 
 	/**
+	 * Initialize
+	 * @return void
+	 */
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->overrideArgument('as', 'string', 'If used, stores the menu pages as an array in a variable named according to this value and renders the tag content - which means automatic rendering is disabled if this attribute is used', FALSE, NULL);
+	}
+
+	/**
 	 * @return string
 	 * @throws Exception
 	 */


### PR DESCRIPTION
Due to the new default value for argument 'as' in menu related ViewHelpers automatic rendering was disabled in deferred menu ViewHelper.
