### PR TITLE
[BUGFIX] Parent menu instance should be cloned

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -116,7 +116,7 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends Tx_Fl
 			return NULL;
 		}
 		$variables = $this->templateVariableContainer->getAll();
-		$this->viewHelperVariableContainer->addOrUpdate('Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper', 'parentInstance', $this);
+		$this->viewHelperVariableContainer->addOrUpdate('Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper', 'parentInstance', clone($this));
 		$this->viewHelperVariableContainer->addOrUpdate('Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper', 'variables', $variables);
 	}
 


### PR DESCRIPTION
Parent menu instances stored in the template variable container were always treated as 'original' thus invoking the template variable cleaning method after rendering.
