### PR TITLE
[BUGFIX] Check if asset exists before copying to avoid PHP warnings

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -398,7 +398,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	private function sortAssetsByDependency($assets) {
 		$placed = array();
 		$compilables = array();
-		$assetNames = array_combine(array_keys($assets), array_keys($assets));
+		$assetNames = (0 < count($assets)) ? array_combine(array_keys($assets), array_keys($assets)) : array();
 		while ($asset = array_shift($assets)) {
 			$postpone = FALSE;
 			/** @var $asset Tx_Vhs_ViewHelpers_Asset_AssetInterface */


### PR DESCRIPTION
This patch adds a check for existence of linked assets before trying to copy them. This avoids possible PHP warnings and skips manipulation of the source uri in case the file doesn't exist.
