### PR TITLE
[BUGFIX] Tx_Extbase_Object_ObjectManagerInterface::create() is deprecated

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -318,7 +318,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 	 */
 	private function generateTagForAssetType($type, $content, $file = NULL) {
 		/** @var $tagBuilder Tx_Fluid_Core_ViewHelper_TagBuilder */
-		$tagBuilder = $this->objectManager->create('Tx_Fluid_Core_ViewHelper_TagBuilder');
+		$tagBuilder = $this->objectManager->get('Tx_Fluid_Core_ViewHelper_TagBuilder');
 		switch ($type) {
 			case 'js':
 				$tagBuilder->setTagName('script');
@@ -479,7 +479,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 			$fileContents = file_get_contents($templatePathAndFilename);
 		}
 		/** @var $view Tx_Fluid_View_StandaloneView */
-		$view = $this->objectManager->create('Tx_Fluid_View_StandaloneView');
+		$view = $this->objectManager->get('Tx_Fluid_View_StandaloneView');
 		$view->setTemplateSource($fileContents);
 		$view->assignMultiple($variables);
 		$content = $view->render();

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -120,7 +120,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 */
 	public function injectObjectManager(Tx_Extbase_Object_ObjectManagerInterface $objectManager) {
 		$this->objectManager = $objectManager;
-		$this->tagBuilder = $this->objectManager->create('Tx_Fluid_Core_ViewHelper_TagBuilder');
+		$this->tagBuilder = $this->objectManager->get('Tx_Fluid_Core_ViewHelper_TagBuilder');
 	}
 
 	/**

--- a/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
+++ b/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
@@ -99,7 +99,7 @@ abstract class Tx_Vhs_ViewHelpers_Render_AbstractRenderViewHelper extends Tx_Flu
 	 */
 	protected function getPreparedView() {
 		/** @var $view Tx_Fluid_View_StandaloneView */
-		$view = $this->objectManager->create('Tx_Fluid_View_StandaloneView');
+		$view = $this->objectManager->get('Tx_Fluid_View_StandaloneView');
 		return $view;
 	}
 

--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -97,7 +97,7 @@ class Tx_Vhs_ViewHelpers_Render_RequestViewHelper extends Tx_Vhs_ViewHelpers_Ren
 		}
 		$temporaryContentObject = new tslib_cObj();
 		/** @var Tx_Extbase_MVC_Web_Request $request */
-		$request = $this->objectManager->create($this->requestType);
+		$request = $this->objectManager->get($this->requestType);
 		$request->setControllerActionName($action);
 		$request->setControllerName($controller);
 		$request->setPluginName($pluginName);
@@ -105,7 +105,7 @@ class Tx_Vhs_ViewHelpers_Render_RequestViewHelper extends Tx_Vhs_ViewHelpers_Ren
 		$request->setArguments($arguments);
 		try {
 			/** @var Tx_Extbase_MVC_ResponseInterface $response */
-			$response = $this->objectManager->create($this->responseType);
+			$response = $this->objectManager->get($this->responseType);
 			$this->configurationManager->setContentObject($temporaryContentObject);
 			$this->configurationManager->setConfiguration(
 				$this->configurationManager->getConfiguration(


### PR DESCRIPTION
Fixed by calling Tx_Extbase_Object_ObjectManagerInterface::get() instead.
