### PR TITLE
[BUGFIX] Missing vendorName property in <v:render.request /> ViewHelper

### DIFF
--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -104,8 +104,10 @@ class Tx_Vhs_ViewHelpers_Render_RequestViewHelper extends Tx_Vhs_ViewHelpers_Ren
 		$request->setControllerName($controller);
 		$request->setPluginName($pluginName);
 		$request->setControllerExtensionName($extensionName);
-		$request->setControllerVendorName($vendorName);
 		$request->setArguments($arguments);
+		if (NULL !== $vendorName) {
+			$request->setControllerVendorName($vendorName);
+		}
 		try {
 			/** @var Tx_Extbase_MVC_ResponseInterface $response */
 			$response = $this->objectManager->get($this->responseType);


### PR DESCRIPTION
The <v:render.request /> viewhelper leaks of a vendorName property to
render namespaced extensions (extensions created since 6.x)
