### PR TITLE
[DOC] Added Info about plugin has to be cached to use TitleViewHelper and MetaViewHelper

### DIFF
--- a/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
@@ -26,6 +26,9 @@
 /**
  * ViewHelper used to render a meta tag
  *
+ * If you use the ViewHelper in a plugin it has to be USER
+ * not USER_INT, what means it has to be cached!
+ *
  * @author Georg Ringer
  * @package Vhs
  * @subpackage ViewHelpers\Page\Header

--- a/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
@@ -36,6 +36,9 @@
  * or 2 (two) to indicate that the TS-controlled page title
  * must be disabled. A value of 2 (two) ensures that the title
  * used in this ViewHelper will be used in the rendered page.
+ * 
+ * If you use the ViewHelper in a plugin it has to be USER
+ * not USER_INT, what means it has to be cached!
  *
  * #### Why can I not forcibly override the title?
  *


### PR DESCRIPTION
A plugin or controlleraction has to be cached to be able to affect the titlewith this viewhelper.

Added information to doccomments about this.
