### PR TITLE
[FEATURE] StdWrap for Assets

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -99,6 +99,11 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	protected $content = NULL;
 
 	/**
+	 * @var array
+	 */
+	protected $stdWrap = array();
+
+	/**
 	 * @var string
 	 */
 	protected $path = NULL;
@@ -238,9 +243,13 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	public function build() {
 		$path = $this->getPath();
 		if (TRUE === empty($path)) {
-			return $this->getContent();
+			$content = $this->getContent();
+		} else {
+			$content = file_get_contents($path);
 		}
-		$content = file_get_contents($path);
+		if (FALSE === empty($this->stdWrap)) {
+			$content = $GLOBALS['TSFE']->cObj->stdWrap($content, $this->stdWrap);
+		}
 		return $content;
 	}
 
@@ -365,6 +374,22 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	 */
 	public function setContent($content) {
 		$this->content = $content;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getStdWrap() {
+		return $this->stdWrap;
+	}
+
+	/**
+	 * @param array $stdWrap
+	 * @return Tx_Vhs_Asset
+	 */
+	public function setStdWrap($stdWrap) {
+		$this->stdWrap = $stdWrap;
 		return $this;
 	}
 

--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -162,7 +162,7 @@ class Tx_Vhs_Service_AssetService implements t3lib_Singleton {
 				// no settings exist, but don't allow a NULL value. This prevents cache clobbering.
 				self::$settingsCache = array();
 			} else {
-				self::$settingsCache = t3lib_div::removeDotsFromTS($allTypoScript['plugin.']['tx_vhs.']['settings.']);
+				self::$settingsCache = Tx_Vhs_Utility_SettingsUtility::removeDotsFromSettings($allTypoScript['plugin.']['tx_vhs.']['settings.'], array('stdWrap'));
 			}
 		}
 		$settings = (array) self::$settingsCache;

--- a/Classes/Utility/SettingsUtility.php
+++ b/Classes/Utility/SettingsUtility.php
@@ -1,0 +1,61 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Erik Frister <erik.frister@aijko.de>, aijko
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Settings Utility
+ *
+ * Utility for handling settings
+ *
+ * @author Erik Frister <erik.frister@aijko.de>, aijko
+ * @package Vhs
+ * @subpackage Utility
+ */
+class Tx_Vhs_Utility_SettingsUtility {
+
+	/**
+	 * Removes the dots from a settings array, with the option to keep the dots for specific properties
+	 *
+	 * @param array $settings TypoScript Settings with dots
+	 * @param array $keepDotsForProperties array of properties to keep dots for
+	 * @return array
+	 */
+	public static function removeDotsFromSettings($settings, $keepDotsForProperties) {
+		$out = array();
+		foreach ($settings as $key => $value) {
+			if (is_array($value)) {
+				$key = rtrim($key, '.');
+				if (!in_array($key, $keepDotsForProperties)) {
+					$out[$key] = self::removeDotsFromSettings($value, $keepDotsForProperties);
+				} else {
+					$out[$key] = $value;
+				}
+			} else {
+				$out[$key] = $value;
+			}
+		}
+		return $out;
+	}
+
+}

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -86,6 +86,11 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	protected $tagBuilder;
 
 	/**
+	 * @var t3lib_TSparser
+	 */
+	protected $typoScriptParser;
+
+	/**
 	 * Example types: raw, meta, css, js.
 	 *
 	 * If a LESS stylesheet is being compiled the "type"
@@ -121,6 +126,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	public function injectObjectManager(Tx_Extbase_Object_ObjectManagerInterface $objectManager) {
 		$this->objectManager = $objectManager;
 		$this->tagBuilder = $this->objectManager->get('Tx_Fluid_Core_ViewHelper_TagBuilder');
+		$this->typoScriptParser = $this->objectManager->get('t3lib_TSparser');
 	}
 
 	/**
@@ -141,6 +147,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 		$this->registerArgument('allowMoveToFooter', 'boolean', 'If TRUE, allows this Asset to be included in the document footer rather than the header. Should never be allowed for CSS.', FALSE, TRUE);
 		$this->registerArgument('trim', 'boolean', 'If FALSE, disables the per-default enabled trimming of whitespace off beginnings and ends of lines in the Asset content body', FALSE, TRUE);
 		$this->registerArgument('namedChunks', 'boolean', 'If FALSE, hides the comment containing the name of each of Assets which is merged in a merged file. Disable to avoid a bit more output at the cost of transparency', FALSE, FALSE);
+		$this->registerArgument('stdWrap', 'string', 'An optional string of stdWrap functions which you use inside the Asset, be it standalone or inline. When set, the content or path resource will be modified using stdWrap', FALSE, NULL);
 	}
 
 	/**
@@ -286,6 +293,11 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 			$content = $assetSettings['content'];
 		} else {
 			$content = $this->renderChildren();
+		}
+		if (FALSE === empty($assetSettings['stdWrap'])) {
+			$this->typoScriptParser->parse($assetSettings['stdWrap']);
+			$setupWithDots = $this->typoScriptParser->setup;
+			$content = $GLOBALS['TSFE']->cObj->stdWrap($content, $setupWithDots);
 		}
 		if (TRUE === (boolean) $assetSettings['trim']) {
 			$lines = explode(LF, $content);


### PR DESCRIPTION
I'd like to contribute the stdWrap functionality for any asset content.

The specific use case for me was adding dynamic pixel-tracking javascript files (like Google Analytics or Omniture) that depend on accessing system values like getIndpEnv:TYPO3_HOST_ONLY or specific userFunc's to have the content be dynamic. I think there are a lot more use cases where it makes sense to generate the javascript dynamically, while still having it use the enhanced dependency management that VHS offers.

I'd be willing to add unit tests for this as well. My first intention is to get feedback if this functionality, in the current or modified form, is of interest to you.

Example using TypoScript.
https://gist.github.com/efrister/6792430

Example using the ViewHelper.
https://gist.github.com/efrister/6792420
