### PR TITLE
Fix missing parameter which causes the child element not to be appended.

### DIFF
--- a/Classes/ViewHelpers/Media/VideoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VideoViewHelper.php
@@ -93,7 +93,7 @@ class Tx_Vhs_ViewHelpers_Media_VideoViewHelper extends Tx_Vhs_ViewHelpers_Media_
 			}
 			$type = 'video/' . strtolower($source['type']);
 			$src = $this->preprocessSourceUri($src);
-			$this->renderChildTag('source', array('src' => $src, 'type' => $type), 'append');
+			$this->renderChildTag('source', array('src' => $src, 'type' => $type), FALSE, 'append');
 		}
 		$tagAttributes = array(
 			'width'   => $this->arguments['width'],


### PR DESCRIPTION
The missing parameter causes the renderChildTag() method to have the $mode parameter set to 'none', which in turn causes that the child tag is not appended to the parent tag's existing content.
