### PR TITLE
[BUGFIX] Allow for passing first argument of math viewhelpers via chaine...

### DIFF
--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -88,7 +88,7 @@ abstract class Tx_Vhs_ViewHelpers_Math_AbstractSingleMathViewHelper extends Tx_F
 	 */
 	protected function getInlineArgument() {
 		$a = $this->renderChildren();
-		if (TRUE === isset($this->arguments['a'])) {
+		if (NULL === $a && TRUE === isset($this->arguments['a'])) {
 			$a = $this->arguments['a'];
 		}
 		if (NULL === $a && TRUE === (boolean) $this->arguments['fail']) {


### PR DESCRIPTION
...d inline notation

This makes e.g. following notation work:
{collection -> v:iterator.extract(key: 'property') -> v:math.sum()}

fixes #347
