### PR TITLE
[FEATURE] Added v:page.header.canonical to render canonical tag

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -178,4 +178,29 @@ class Tx_Vhs_Service_PageSelectService implements t3lib_Singleton {
 		return self::$cachedRootLines[$key];
 	}
 
+	/**
+	 * Checks if a page for a specific language should be hidden
+	 *
+	 * @param integer $pageUid
+	 * @param integer $languageUid
+	 * @param integer $normalWhenNoLanguage
+	 * @return boolean
+	 */
+	public function hidePageForLanguageUid($pageUid, $languageUid, $normalWhenNoLanguage = FALSE) {
+		$l18nCfg = $GLOBALS['TSFE']->page['l18n_cfg'];
+		$hideIfNotTranslated = t3lib_div::hideIfNotTranslated($l18nCfg);
+		$hideIfDefaultLanguage = t3lib_div::hideIfDefaultLanguage($l18nCfg);
+
+		$pageOverlay = 0 !== $languageUid ? $this->getPageOverlay($pageUid, $languageUid) : array();
+
+		// $hideIfDefaultLanguage must be compared to 0, because t3lib_div returns an integer and not a boolean as promised
+		if (((FALSE === $hideIfNotTranslated && TRUE === $normalWhenNoLanguage) || 0 === $languageUid || 0 !== count($pageOverlay)) &&
+			(0 === $hideIfDefaultLanguage || (0 !== $languageUid && 0 !== count($pageOverlay)))) {
+
+			return FALSE;
+		}
+
+		return TRUE;
+	}
+
 }

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -1,0 +1,108 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Returns the current canonical url in a link tag.
+ *
+ * @author Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
+ * @package Vhs
+ * @subpackage ViewHelpers\Page\Header
+ */
+class Tx_Vhs_ViewHelpers_Page_Header_CanonicalViewHelper extends  Tx_Fluid_Core_ViewHelper_AbstractTagBasedViewHelper {
+
+	/**
+	 * @var Tx_Vhs_Service_PageSelectService
+	 */
+	protected $pageSelect;
+
+	/**
+	 * @param Tx_Vhs_Service_PageSelectService $pageSelectService
+	 * @return void
+	 */
+	public function injectPageSelectService(Tx_Vhs_Service_PageSelectService $pageSelectService) {
+		$this->pageSelect = $pageSelectService;
+	}
+
+	/**
+	 * @var string
+	 */
+	protected $tagName = 'link';
+
+	/**
+	 * Initialize
+	 *
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerUniversalTagAttributes();
+		$this->registerArgument('pageUid', 'integer', 'The page uid to check', FALSE, 0);
+		$this->registerArgument('normalWhenNoLanguage', 'boolean', 'If TRUE, a missing page overlay should be ignored', FALSE, FALSE);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function render() {
+		if (TYPO3_MODE == 'BE') {
+			return;
+		}
+
+		$pageUid = $this->arguments['pageUid'];
+		$normalWhenNoLanguage = $this->arguments['normalWhenNoLanguage'];
+
+		if (0 === $pageUid) {
+			$pageUid = $GLOBALS['TSFE']->id;
+		}
+
+		$currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
+		$languageUid = 0;
+		if (FALSE === $this->pageSelect->hidePageForLanguageUid($pageUid, $currentLanguageUid, $normalWhenNoLanguage)) {
+			$languageUid = $currentLanguageUid;
+		} else if (0 !== $currentLanguageUid) {
+			if (TRUE === $this->pageSelect->hidePageForLanguageUid($pageUid, 0, $normalWhenNoLanguage)) {
+				return;
+			}
+		}
+
+		$uriBuilder = $this->controllerContext->getUriBuilder();
+		$uri = $uriBuilder->reset()
+			->setTargetPageUid($pageUid)
+			->setCreateAbsoluteUri(TRUE)
+			->setArguments(array('L' => $languageUid))
+			->build();
+
+		$this->tag->addAttribute('rel', 'canonical');
+		$this->tag->addAttribute('href', $uri);
+
+		$renderedTag = $this->tag->render();
+
+		if (1 === intval($GLOBALS['TSFE']->config['config']['disableAllHeaderCode'])) {
+			return $renderedTag;
+		}
+
+		$GLOBALS['TSFE']->getPageRenderer()->addMetaTag($renderedTag);
+	}
+
+}


### PR DESCRIPTION
Hey,

the attached commit adds the possibility to include a canonical link tag. This will magically (not really) render it as a tag on the spot or via the page renderer. The link is chosen based on the language settings for the page as defined by `TMENU`. I included that part in the `PageSelectService` since in `vhs` the very same thing is scattered around classes.
