### PR TITLE
[BUGFIX] Avoid double inclusion when dealing with PHP < 5.3.7

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,6 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAll';
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_eofe'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->buildAllUncached';
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:vhs/Classes/Service/AssetService.php:Tx_Vhs_Service_AssetService->clearCacheCommand';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'Tx_Vhs_Service_AssetService->buildAll';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['hook_eofe'][] = 'Tx_Vhs_Service_AssetService->buildAllUncached';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'Tx_Vhs_Service_AssetService->clearCacheCommand';


### PR DESCRIPTION
Avoid double inclusion when dealing with PHP < 5.3.7

You don't need (and sould not) put the full path to your class in this declaration since your class is already included by your autoloader.

Closes #352
