### PR TITLE
[BUGFIX] Correctly treat overwrite setting of assets

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -200,7 +200,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 		$name = $this->getName();
 		$overwrite = $this->getOverwrite();
 		$slotFree = FALSE === isset($GLOBALS['VhsAssets'][$name]);
-		if (FALSE === ($overwrite && $slotFree)) {
+		if (FALSE === ($overwrite || $slotFree)) {
 			return;
 		}
 		$this->content = $this->getContent();


### PR DESCRIPTION
In asset ViewHelpers the overwrite property looks broken to me. Setting overwrite to FALSE leads to that asset never beeing included, even if there was a "slotFree" a.k.a. no other asset defined with that name.
