### PR TITLE
[TASK] Remove legacy dependency and adjust composer namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,5 @@
 {
-    "name": "ft3/vhs",
+    "name": "fluidtypo3/vhs",
     "description": "The vhs package from FluidTYPO3",
-    "require": {
-        "composer/installers": "*"
-    },
     "type": "typo3-cms-extension"
 }


### PR DESCRIPTION
I removed the composer installer legacy dependency which causes problems with composer create-project commands.

This is being shipped by whatever installs the ext.

Also, referring to the namespace (not dependant to it) I renamed the vendor namespace.
