### PR TITLE
[FEATURE] Enable assets to be dependency only

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -84,6 +84,11 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	protected $dependencies = array();
 
 	/**
+	 * @var boolean
+	 */
+	protected $isDependency = FALSE;
+
+	/**
 	 * @var string
 	 */
 	protected $type = NULL;
@@ -285,6 +290,22 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	public function setDependencies($dependencies) {
 		$this->dependencies = $dependencies;
 		return $this;
+	}
+
+	/**
+	 * @param boolean $isDependency
+	 * @return Tx_Vhs_Asset
+	 */
+	public function setIsDependency($isDependency) {
+		$this->isDependency = (boolean) $isDependency;
+		return $this;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getIsDependency() {
+		return $this->isDependency;
 	}
 
 	/**

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -133,6 +133,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 		$this->registerArgument('name', 'string', 'Optional name of the content. If multiple occurrences of the same name happens, behavior is defined by argument "overwrite"');
 		$this->registerArgument('overwrite', 'boolean', 'If set to FALSE and a relocated string with "name" already exists, does not overwrite the existing relocated string. Default behavior is to overwrite.', FALSE, TRUE);
 		$this->registerArgument('dependencies', 'string', 'CSV list of other named assets upon which this asset depends. When included, this asset will always load after its dependencies');
+		$this->registerArgument('isDependency', 'boolean', 'If TRUE, this asset is only included when declared as dependency of another asset', FALSE, FALSE);
 		$this->registerArgument('group', 'string', 'Optional name of a logical group (created dynamically just by using the name) to which this particular asset belongs.', FALSE, 'fluid');
 		$this->registerArgument('debug', 'boolean', 'If TRUE, outputs information about this ViewHelper when the tag is used. Two master debug switches exist in TypoScript; see documentation about Page / Asset ViewHelper');
 		$this->registerArgument('standalone', 'boolean', 'If TRUE, excludes this Asset from any concatenation which may be applied');


### PR DESCRIPTION
This patch adds a new option `isDependency` to assets enabling them to only be included when some other asset depends on them. Should close #317.
