### PR TITLE
[TASK] Deprecating v:if.client.*

### DIFF
--- a/Classes/ViewHelpers/If/Client/IsBrowserViewHelper.php
+++ b/Classes/ViewHelpers/If/Client/IsBrowserViewHelper.php
@@ -24,6 +24,10 @@
  ***************************************************************/
 
 /**
+ * ### Will be removed in 2.0
+ *
+ * Please don't do user agent sniffing. This is bad practice.
+ *
  * ### Condition: Client's Browser
  *
  * Condition ViewHelper which renders the `then` child if client's
@@ -49,6 +53,7 @@
  *         </f:else>
  *     </v:if.client.isBrowser>
  *
+ * @deprecated
  * @author Andreas Lappe <nd@kaeufli.ch>, kaeufli.ch
  * @package Vhs
  * @subpackage ViewHelpers\If\Client

--- a/Classes/ViewHelpers/If/Client/IsMobileViewHelper.php
+++ b/Classes/ViewHelpers/If/Client/IsMobileViewHelper.php
@@ -24,6 +24,10 @@
  ***************************************************************/
 
 /**
+ * ### Will be removed in 2.0
+ *
+ * Please don't do user agent sniffing. This is bad practice.
+ *
  * ### Condition: Client is mobile device or not
  *
  * Condition ViewHelper which renders the `then` child if client
@@ -35,6 +39,7 @@
  * to TRUE to treat them as mobile devices though it's more reliable
  * to check for maximum screen dimensions clientside.
  *
+ * @deprecated
  * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
  * @package Vhs
  * @subpackage ViewHelpers\If\Client

--- a/Classes/ViewHelpers/If/Client/IsSystemViewHelper.php
+++ b/Classes/ViewHelpers/If/Client/IsSystemViewHelper.php
@@ -24,6 +24,10 @@
  ***************************************************************/
 
 /**
+ * ### Will be removed in 2.0
+ *
+ * Please don't do user agent sniffing. This is bad practice.
+ *
  * ### Condition: Client's System
  *
  * A condition ViewHelper which renders the `then` child if client's
@@ -35,6 +39,7 @@
  *         Thank you for using Mac!
  *     </v:condition.system>
  *
+ * @deprecated
  * @author Andreas Lappe <nd@kaeufli.ch>, kaeufli.ch
  * @package Vhs
  * @subpackage ViewHelpers\If\Client


### PR DESCRIPTION
User agent sniffing is bad practice. We shouldn't support it. It also doesn't make sense in a template context, as most users will have it cached, which leads to unwanted behavior that we have to deal with on support.

> [13:10:44] @cedricziel   thats bad practice and i think we should educate 1st: why it is 2nd: that the core does this, if you want conditional stylesheets etc
> [13:10:59] @cedricziel     1+
> [13:11:06] @cedricziel     one less paintpoint
