### PR TITLE
[FEATURE] Loosen static property visibility to allow access in extension classes

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -40,32 +40,32 @@ class Tx_Vhs_Service_PageSelectService implements t3lib_Singleton {
 	/**
 	 * @var t3lib_pageSelect
 	 */
-	private static $pageSelect;
+	protected static $pageSelect;
 
 	/**
 	 * @var t3lib_pageSelect
 	 */
-	private static $pageSelectHidden;
+	protected static $pageSelectHidden;
 
 	/**
 	 * @var array
 	 */
-	private static $cachedPages = array();
+	protected static $cachedPages = array();
 
 	/**
 	 * @var array
 	 */
-	private static $cachedOverlays = array();
+	protected static $cachedOverlays = array();
 
 	/**
 	 * @var array
 	 */
-	private static $cachedMenus = array();
+	protected static $cachedMenus = array();
 
 	/**
 	 * @var array
 	 */
-	private static $cachedRootLines = array();
+	protected static $cachedRootLines = array();
 
 	/**
 	 * Initialize t3lib_pageSelect objects


### PR DESCRIPTION
The static properties' visibility in the PageSelectService seem too strict at the moment (_private_), as they don't allow being accessed from extension classes this way.
