### PR TITLE
[FEATURE] Add ViewHelper for rendering TS-Header

### DIFF
--- a/Classes/ViewHelpers/Render/HeaderViewHelper.php
+++ b/Classes/ViewHelpers/Render/HeaderViewHelper.php
@@ -1,0 +1,52 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Denys Koch <koch@louis.info>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * ViewHelper used to render content header from raw records typically fetched
+ * with <v:content.get(column: '0', render: FALSE) />
+ *
+ * @author Denys Koch, <koch@louis.info>
+ * @package Vhs
+ * @subpackage ViewHelpers\Render
+ */
+class Tx_Vhs_ViewHelpers_Render_HeaderViewHelper extends Tx_Vhs_ViewHelpers_Content_AbstractContentViewHelper {
+
+	/**
+	 * Render method
+	 *
+	 * @param array $record
+	 * @return string
+	 */
+	public function render(array $record = array()) {
+		if (FALSE === isset($record['uid'])) {
+			return NULL;
+		}
+		$localContentObject = clone $this->contentObject;
+		$localContentObject->data = $record;
+		$allTypoScript = $this->configurationManager->getConfiguration(Tx_Extbase_Configuration_ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+		$content = $localContentObject->cObjGetSingle($allTypoScript['lib.']['stdheader'], $allTypoScript['lib.']['stdheader.']);
+		return $content;
+	}
+}


### PR DESCRIPTION
I wrote this ViewHelper for rendering only the stdHeader of an record. Useful for custom fluid-only wraps and in combination of clearing the fluidcontent stdheader:

```
tt_content.fluidcontent_content.10 >
```
