### PR TITLE
[BUGFIX] Removed prefix slash from namespaces class strings

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -166,7 +166,7 @@ class Tx_Vhs_Asset implements Tx_Vhs_ViewHelpers_Asset_AssetInterface {
 	 */
 	public static function getInstance() {
 		/** @var $asset Tx_Vhs_Asset */
-		$asset = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager')->get('Tx_Vhs_Asset');
+		$asset = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager')->get('Tx_Vhs_Asset');
 		return $asset;
 	}
 

--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -92,8 +92,8 @@ class Tx_Vhs_Service_AssetService implements \TYPO3\CMS\Core\SingletonInterface 
 			return;
 		}
 		if (FALSE === $this->objectManager instanceof \TYPO3\CMS\Extbase\Object\ObjectManager) {
-			$this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager');
-			$this->configurationManager = $this->objectManager->get('\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
+			$this->objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+			$this->configurationManager = $this->objectManager->get('TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
 		}
 		$settings = $this->getSettings();
 		$cached = (boolean) $cached;
@@ -332,7 +332,7 @@ class Tx_Vhs_Service_AssetService implements \TYPO3\CMS\Core\SingletonInterface 
 	 */
 	private function generateTagForAssetType($type, $content, $file = NULL) {
 		/** @var $tagBuilder \TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder */
-		$tagBuilder = $this->objectManager->get('\TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
+		$tagBuilder = $this->objectManager->get('TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
 		switch ($type) {
 			case 'js':
 				$tagBuilder->setTagName('script');

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -120,7 +120,7 @@ abstract class Tx_Vhs_ViewHelpers_Asset_AbstractAssetViewHelper
 	 */
 	public function injectObjectManager(\TYPO3\CMS\Extbase\Object\ObjectManagerInterface $objectManager) {
 		$this->objectManager = $objectManager;
-		$this->tagBuilder = $this->objectManager->get('\TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
+		$this->tagBuilder = $this->objectManager->get('TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
 	}
 
 	/**

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -142,7 +142,7 @@ class Tx_Vhs_ViewHelpers_Iterator_SortViewHelper extends \TYPO3\CMS\Fluid\Core\V
 	 */
 	protected function sortObjectStorage($storage) {
 		/** @var \TYPO3\CMS\Extbase\Object\ObjectManager $objectManager */
-		$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager');
+		$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
 		/** @var Tx_Extbase_Persistence_ObjectStorage $temp */
 		$temp = $objectManager->get('Tx_Extbase_Persistence_ObjectStorage');
 		foreach ($storage as $item) {

--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -61,7 +61,7 @@ class Tx_Vhs_ViewHelpers_Page_Header_AlternateViewHelper extends \TYPO3\CMS\Flui
 	 */
 	public function injectObjectManager(\TYPO3\CMS\Extbase\Object\ObjectManagerInterface $objectManager) {
 		$this->objectManager = $objectManager;
-		$this->tagBuilder = $this->objectManager->get('\TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
+		$this->tagBuilder = $this->objectManager->get('TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder');
 	}
 
 	/**

--- a/Classes/ViewHelpers/Var/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Var/ConvertViewHelper.php
@@ -64,7 +64,7 @@ class Tx_Vhs_ViewHelpers_Var_ConvertViewHelper extends \TYPO3\CMS\Fluid\Core\Vie
 		}
 		if (NULL !== $value) {
 			if ('ObjectStorage' === $type && 'array' === gettype($value)) {
-				$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager');
+				$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
 				$storage = $objectManager->get('Tx_Extbase_Persistence_ObjectStorage');
 				foreach ($value as $item) {
 					$storage->attach($item);
@@ -102,7 +102,7 @@ class Tx_Vhs_ViewHelpers_Var_ConvertViewHelper extends \TYPO3\CMS\Fluid\Core\Vie
 						$value = array();
 						break;
 					case 'ObjectStorage':
-						$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager');
+						$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
 						$value = $objectManager->get('Tx_Extbase_Persistence_ObjectStorage');
 						break;
 					default:

--- a/Tests/Unit/AssetTest.php
+++ b/Tests/Unit/AssetTest.php
@@ -186,7 +186,7 @@ class Tx_Vhs_AssetTest extends Tx_Extbase_Tests_Unit_BaseTestCase {
 		$file = $this->getAbsoluteAssetFixturePath();
 		$asset = Tx_Vhs_Asset::createFromFile($file);
 		$gettableProperties = \TYPO3\CMS\Extbase\Reflection\ObjectAccess::getGettablePropertyNames($asset);
-		$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('\TYPO3\CMS\Extbase\Object\ObjectManager');
+		$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
 		foreach ($gettableProperties as $propertyName) {
 			if (FALSE === property_exists('Tx_Vhs_Asset', $propertyName)) {
 				continue;

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -80,7 +80,7 @@ abstract class Tx_Vhs_ViewHelpers_AbstractViewHelperTest extends Tx_Extbase_Test
 			$cObject = new tslib_cObj();
 			$cObject->start(array(), 'tt_content');
 			/** @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager */
-			$configurationManager = $this->objectManager->get('\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
+			$configurationManager = $this->objectManager->get('TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
 			$configurationManager->setContentObject($cObject);
 			$instance->injectConfigurationManager($configurationManager);
 		}


### PR DESCRIPTION
As per `GeneralUtility` Line 4113 (6.1.7):

``` php
$fullyQualifiedClassName = '\\' . $finalClassName;
```
