### PR TITLE
[BUGFIX] Make default menu behavior use shortcut UID

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -83,7 +83,7 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 		$this->registerArgument('classHasSubpages', 'string', 'Optional class name to add to links which have subpages', FALSE, 'sub');
 		$this->registerArgument('useShortcutTarget', 'boolean', 'Optional param for using shortcut target instead of shortcut itself for current link', FALSE, FALSE);
 		$this->registerArgument('useShortcutData', 'boolean', 'If TRUE, fetches ALL data from the shortcut target before any additional processing takes place. Note that this overrides everything, including the UID, effectively substituting the shortcut for the target', FALSE, FALSE);
-		$this->registerArgument('useShortcutUid', 'boolean', 'If TRUE, substitutes the link UID of a shortcut with the target page UID (and thus avoiding redirects) but does not change other data - which is done by using useShortcutData.', FALSE, FALSE);
+		$this->registerArgument('useShortcutUid', 'boolean', 'If TRUE, substitutes the link UID of a shortcut with the target page UID (and thus avoiding redirects) but does not change other data - which is done by using useShortcutData.', FALSE, TRUE);
 		$this->registerArgument('classFirst', 'string', 'Optional class name for the first menu elment', FALSE, '');
 		$this->registerArgument('classLast', 'string', 'Optional class name for the last menu elment', FALSE, '');
 		$this->registerArgument('substElementUid', 'boolean', 'Optional parameter for wrapping the link with the uid of the page', FALSE, '');
@@ -371,6 +371,9 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 				case 3:
 					// mode: parent page of current page (using PID of current page)
 					$targetPage = $this->pageSelect->getPage($page['pid']);
+					if ($page['pid'] == $GLOBALS['TSFE']->id) {
+						array_push($rootLine, $page);
+					}
 					break;
 				case 2:
 					// mode: random subpage of selected or current page


### PR DESCRIPTION
This changes two things:
1. The default value of `useShortcutUid` is set to TRUE since this will be the desired rendering in almost all cases.
2. The shortcut itself is added to the root line if the current page UID is the target of the shortcut and the shortcut is to "parent of current page".

The result of this is that all shortcuts' active and sub states become properly set when shortcut-to-parent is in used.
