### PR TITLE
[FEATURE] Added Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "fluidtypo3-vhs",
+  "homepage": "http://fluidtypo3.org/",
+  "description": "The vhs package from FluidTYPO3",
+  "keywords": [
+    "TYPO3",
+    "CMS",
+    "extension",
+    "templating",
+    "Utility",
+    "ViewHelper",
+    "fedext",
+    "fluid"
+  ],
+  "authors": [
+    "FluidTYPO3 Team"
+  ],
+  "license": "GPL-2.0+"
+}


### PR DESCRIPTION
<img src="http://yeoman.io/assets/img/yeoman-logo.a053.png" align="right"/>

I'm currently working on a [custom Yeoman generator](https://github.com/tollwerk/generator-tollwerk) that will make it a breeze to scaffold a TYPO3 project the way we usually do it at [tollwerk](http://tollwerk.de). The generator will be able to pre-install TYPO3 extensions. I would love to let the generator install the FT3 extensions as well (flux, fluidpages, fluidcontent, vhs).

For this to work, the repositories need to include appropriate `bower.json` configurations (I did this as well with [some of my own extensions](https://github.com/jkphl/TYPO3-ext-squeezr) and it works like a charm). Once the configuration files have been merged into the repos, I'll go and publish the extensions to the Bower registry (they'll be available with the prefix "fluidtypo3-*").

> This is the revised version with the `version`, `main` and `ignore` properties removed.

Cheers, Joschi
