### PR TITLE
[BUGFIX] Complete array returned for fileReference

### DIFF
--- a/Classes/Utility/ResourceUtility.php
+++ b/Classes/Utility/ResourceUtility.php
@@ -1,0 +1,58 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * ViewHelper Utility
+ *
+ * Contains helper methods used in resources ViewHelpers
+ *
+ * @author Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
+ * @package Vhs
+ * @subpackage Utility
+ */
+class Tx_Vhs_Utility_ResourceUtility {
+
+	/**
+	 * Fixes a bug in TYPO3 6.2.0 that the properties metadata is not overlayed on localization.
+	 *
+	 * @param \TYPO3\CMS\Core\Resource\File $file
+	 * @return array
+	 */
+	public static function getFileArray(\TYPO3\CMS\Core\Resource\File $file) {
+		$properties = $file->getProperties();
+		$stat = $file->getStorage()->getFileInfo($file);
+		$array = $file->toArray();
+
+		foreach ($properties as $key => $value) {
+			$array[$key] = $value;
+		}
+		foreach ($stat as $key => $value) {
+			$array[$key] = $value;
+		}
+
+		return $array;
+	}
+
+}

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -119,7 +119,7 @@ abstract class Tx_Vhs_ViewHelpers_Resource_AbstractImageViewHelper extends Tx_Vh
 			$imageSource = $GLOBALS['TSFE']->absRefPrefix . \TYPO3\CMS\Core\Utility\GeneralUtility::rawUrlEncodeFP($imageInfo[3]);
 
 			if (TRUE === $onlyProperties) {
-				$file = $this->getFileArray($file);
+				$file = Tx_Vhs_Utility_ResourceUtility::getFileArray($file);
 			}
 
 			$images[] = array(

--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -85,7 +85,7 @@ abstract class Tx_Vhs_ViewHelpers_Resource_AbstractResourceViewHelper extends \T
 						$file = $resourceFactory->getFileObject($fileUid);
 
 						if (TRUE === $onlyProperties) {
-							$file = $this->getFileArray($file);
+							$file = Tx_Vhs_Utility_ResourceUtility::getFileArray($file);
 						}
 
 						$files[] = $file;
@@ -114,7 +114,7 @@ abstract class Tx_Vhs_ViewHelpers_Resource_AbstractResourceViewHelper extends \T
 				}
 
 				if (TRUE === $onlyProperties) {
-					$file = $this->getFileArray($file);
+					$file = Tx_Vhs_Utility_ResourceUtility::getFileArray($file);
 				}
 
 				$files[] = $file;
@@ -147,27 +147,6 @@ abstract class Tx_Vhs_ViewHelpers_Resource_AbstractResourceViewHelper extends \T
 		}
 
 		return $argument;
-	}
-
-	/**
-	 * Fixes a bug in TYPO3 6.2.0 that the properties metadata is not overlayed on localization.
-	 *
-	 * @param \TYPO3\CMS\Core\Resource\File $file
-	 * @return array
-	 */
-	protected function getFileArray(\TYPO3\CMS\Core\Resource\File $file) {
-		$properties = $file->getProperties();
-		$stat = $file->getStorage()->getFileInfo($file);
-		$array = $file->toArray();
-
-		foreach ($properties as $key => $value) {
-			$array[$key] = $value;
-		}
-		foreach ($stat as $key => $value) {
-			$array[$key] = $value;
-		}
-
-		return $array;
 	}
 
 }

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -48,8 +48,11 @@ class Tx_Vhs_ViewHelpers_Resource_Record_FalViewHelper extends Tx_Vhs_ViewHelper
 	 */
 	public function getResource($identity) {
 		$fileReference = $this->resourceFactory->getFileReferenceObject(intval($identity));
+		$file = $fileReference->getOriginalFile();
+		$fileReferenceProperties = $fileReference->getProperties();
+		$fileProperties = Tx_Vhs_Utility_ResourceUtility::getFileArray($file);
 
-		return $fileReference->getProperties();
+		return array_merge($fileProperties, $fileReferenceProperties);
 	}
 
 	/**


### PR DESCRIPTION
When we replaced toArray with getProperties to get file reference the properties of the File itself were no longer available because toArray performed a array_merge internally.

For that we created a own method getFileArray but didn't use this in content.resources.fal yet.

This bugfix moves that method to a utility and replaces all usages of that method to use it on the utility.

Fixes: #532
