### PR TITLE
[BUGFIX] Allow sysfolder as subpages in vhs menu helpers

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -131,13 +131,17 @@ class Tx_Vhs_Service_PageSelectService implements \TYPO3\CMS\Core\SingletonInter
 	 * @param string $where
 	 * @param boolean $showHiddenInMenu
 	 * @param boolean $checkShortcuts
+	 * @param array $excludeSubpageTypes
 	 * @return array
 	 */
-	public function getMenu($pageUid = NULL, $excludePages = array(), $where = '', $showHiddenInMenu = FALSE, $checkShortcuts = FALSE) {
+	public function getMenu($pageUid = NULL, $excludePages = array(), $where = '', $showHiddenInMenu = FALSE, $checkShortcuts = FALSE, $excludeSubpageTypes = array(\TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SYSFOLDER)) {
 		if (NULL === $pageUid) {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
-		$addWhere = 'AND doktype!=254';
+		$addWhere = '';
+		if (0 < count($excludeSubpageTypes)) {
+			$addWhere .= ' AND doktype NOT IN (' . implode(',', $excludeSubpageTypes) . ')';
+		}
 		if (0 < count($excludePages)) {
 			$addWhere .= ' AND uid NOT IN (' . implode(',', $excludePages) . ')';
 		}

--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -270,7 +270,9 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 	 * @return array
 	 */
 	protected function parseDoktypeList($doktypes) {
-		if (TRUE === is_array($doktypes)) {
+		if (TRUE === empty($doktypes)) {
+			return array();
+		} elseif (TRUE === is_array($doktypes)) {
 			$types = $doktypes;
 		} else {
 			$types = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $doktypes);
@@ -678,7 +680,8 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 		$excludePages = $this->processPagesArgument($this->arguments['excludePages']);
 		$showHidden = (boolean) $this->arguments['showHidden'];
 		$showHiddenInMenu = (boolean) $this->arguments['showHiddenInMenu'];
-		$menuData = $this->pageSelect->getMenu($pageUid, $excludePages, $where, $showHiddenInMenu, FALSE);
+		$excludeSubpageTypes = $this->parseDoktypeList($this->arguments['excludeSubpageTypes']);
+		$menuData = $this->pageSelect->getMenu($pageUid, $excludePages, $where, $showHiddenInMenu, FALSE, $excludeSubpageTypes);
 		return $menuData;
 	}
 


### PR DESCRIPTION
In https://github.com/FluidTYPO3/vhs/commit/8d989b05b2bcdfe4ffa54d4855133887aec200fe the behavior was introduced to ignore sysfolders in general. This PR doesnt change this default behavior. The user can however modify `excludeSubpageTypes` to not include sysfolder and that way, with this PR, sysfolders will be included as subpages
