### PR TITLE
[BUGFIX] Use page uid for overlay

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -415,7 +415,7 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 		}
 
 		if (0 < $getLL) {
-			$pageOverlay = $this->pageSelect->getPageOverlay($pageUid, $getLL);
+			$pageOverlay = $this->pageSelect->getPageOverlay($page['uid'], $getLL);
 			foreach ($pageOverlay as $name => $value) {
 				if (FALSE === empty($value)) {
 					$page[$name] = $value;


### PR DESCRIPTION
When `shouldUseShortcutUid` is `TRUE` the page overlay comes from the target page, which is wrong. That should only happen on `shouldUseShortcutTarget`
