### PR TITLE
[BUGFIX] No early return on empty menu in deferred rendering mode

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -610,12 +610,13 @@ abstract class Tx_Vhs_ViewHelpers_Page_Menu_AbstractMenuViewHelper extends \TYPO
 	 * @return string
 	 */
 	public function renderContent($menu) {
-		if (0 === count($menu)) {
+		$deferredRendering = (boolean) $this->arguments['deferred'];
+		if (0 === count($menu) && FALSE === $deferredRendering) {
 			return NULL;
 		}
 		$this->tag->setTagName($this->getWrappingTagName());
 		$this->tag->forceClosingTag(TRUE);
-		if (TRUE === (boolean) $this->arguments['deferred']) {
+		if (TRUE === $deferredRendering) {
 			$tagContent = $this->autoRender($menu);
 			$this->tag->setContent($tagContent);
 			$deferredContent = $this->tag->render();


### PR DESCRIPTION
As reported on IRC. Child content of parent menu tag is not rendered in deferred mode when there are no menu entries.
