### PR TITLE
[BUGFIX] Serialize value to allow NULL

### DIFF
--- a/Classes/ViewHelpers/CaseViewHelper.php
+++ b/Classes/ViewHelpers/CaseViewHelper.php
@@ -61,7 +61,8 @@ class Tx_Vhs_ViewHelpers_CaseViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper
 	 * @return array
 	 */
 	public function render() {
-		$matchesCase = (boolean) ($this->viewHelperVariableContainer->get('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchCaseValue') == $this->arguments['case']);
+		$value = unserialize($this->viewHelperVariableContainer->get('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchCaseValue'));
+		$matchesCase = (boolean) ($value == $this->arguments['case']);
 		$mustContinue = $this->viewHelperVariableContainer->get('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchContinueUntilBreak');
 		$isDefault = (boolean) ('default' === $this->arguments['case']);
 		if (TRUE === $matchesCase || TRUE == $mustContinue || TRUE === $isDefault) {

--- a/Classes/ViewHelpers/SwitchViewHelper.php
+++ b/Classes/ViewHelpers/SwitchViewHelper.php
@@ -86,7 +86,8 @@ class Tx_Vhs_ViewHelpers_SwitchViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelp
 		if (TRUE === $context->getViewHelperVariableContainer()->exists('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchCaseValue')) {
 			$this->storeBackup($context);
 		}
-		$context->getViewHelperVariableContainer()->addOrUpdate('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchCaseValue', $this->arguments['value']);
+		$value = serialize($this->arguments['value']);
+		$context->getViewHelperVariableContainer()->addOrUpdate('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchCaseValue', $value);
 		$context->getViewHelperVariableContainer()->addOrUpdate('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchBreakRequested', FALSE);
 		$context->getViewHelperVariableContainer()->addOrUpdate('Tx_Vhs_ViewHelpers_SwitchViewHelper', 'switchContinueUntilBreak', FALSE);
 		foreach ($this->childNodes as $childNode) {


### PR DESCRIPTION
A `NULL` value is not stored into the viewhelper variable container thus `default` is not evaluated in this case.
