### PR TITLE
[BUGFIX] Test loginUser before frontendUserRepository

### DIFF
--- a/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
+++ b/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
@@ -238,6 +238,9 @@ abstract class Tx_Vhs_ViewHelpers_Security_AbstractSecurityViewHelper extends \T
 	 * @api
 	 */
 	public function getCurrentFrontendUser() {
+		if (FALSE === $GLOBALS['TSFE']->loginUser) {
+			return NULL;
+		}
 		return $this->frontendUserRepository->findByUid($GLOBALS['TSFE']->fe_user->user['uid']);
 	}
 


### PR DESCRIPTION
Prevents a PHP warning if $GLOBALS['TSFE']->fe_user->user is not set
