### PR TITLE
[FEATURE] Add unsupported browser message #584

### DIFF
--- a/Classes/ViewHelpers/Media/VideoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VideoViewHelper.php
@@ -72,6 +72,7 @@ class Tx_Vhs_ViewHelpers_Media_VideoViewHelper extends Tx_Vhs_ViewHelpers_Media_
 		$this->registerArgument('muted', 'boolean', 'Specifies that the audio output of the video should be muted.', FALSE, FALSE);
 		$this->registerArgument('poster', 'string', 'Specifies an image to be shown while the video is downloading, or until the user hits the play button.', FALSE, NULL);
 		$this->registerArgument('preload', 'string', 'Specifies if and how the author thinks the video should be loaded when the page loads. Can be "auto", "metadata" or "none".', FALSE, 'auto');
+		$this->registerArgument('unsupported', 'string', 'Add a message for old browsers like Internet Explorer 9 without video support.', FALSE);
 	}
 
 	/**
@@ -138,6 +139,9 @@ class Tx_Vhs_ViewHelpers_Media_VideoViewHelper extends Tx_Vhs_ViewHelpers_Media_
 			$tagAttributes['poster'] = $this->arguments['poster'];
 		}
 		$this->tag->addAttributes($tagAttributes);
+		if (NULL !== $this->arguments['unsupported']) {
+			$this->tag->setContent($this->tag->getContent() . LF . $this->arguments['unsupported']);
+		}
 		return $this->tag->render();
 	}
 


### PR DESCRIPTION
Add message for old browsers like IE9 or (old) safari. This message is shown instant of the player.
resolve #584

I don't know whats a good and short Argument. I choose unsupported, because this takes effect on unsupported browsers. noVideoMessage or unsupportedBrowserMessage sounds even stupider and not remember able. 
To setContent without getContent i would need to add it in front of everything. I set the content after all attributes.
