### PR TITLE
[Bugfix] Remote URL condition was always false

### DIFF
--- a/Classes/ViewHelpers/Media/VideoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VideoViewHelper.php
@@ -87,7 +87,7 @@ class Tx_Vhs_ViewHelpers_Media_VideoViewHelper extends Tx_Vhs_ViewHelpers_Media_
 		}
 		foreach ($sources as $source) {
 			if (TRUE === is_string($source)) {
-				if (TRUE === strpos($source, '//')) {
+				if (FALSE !== strpos($source, '//')) {
 					$src = $source;
 					$type = substr($source, strrpos($source, '.') + 1);
 				} else {


### PR DESCRIPTION
Condition never matched before because position (e.g. 60) === false because its not 1.
