### PR TITLE
[FEATURE] Add Media/AudioViewhelper

### DIFF
--- a/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
@@ -45,7 +45,7 @@ abstract class Tx_Vhs_ViewHelpers_Media_AbstractMediaViewHelper extends \TYPO3\C
 	 * @api
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('src', 'mixed', 'Path to the media resource(s). Can contain single or multiple paths for videos (either CSV, array or implementing Traversable).', TRUE);
+		$this->registerArgument('src', 'mixed', 'Path to the media resource(s). Can contain single or multiple paths for videos/audio (either CSV, array or implementing Traversable).', TRUE);
 		$this->registerArgument('relative', 'boolean', 'If FALSE media URIs are rendered absolute. URIs in backend mode are always absolute.', FALSE, TRUE);
 	}
 

--- a/Classes/ViewHelpers/Media/AudioViewHelper.php
+++ b/Classes/ViewHelpers/Media/AudioViewHelper.php
@@ -1,0 +1,154 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014  Xaver Maierhofer <xaver.maierhofer@xwissen.info>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * Renders HTML code to embed a HTML5 audio player. NOTICE: This is
+ * all HTML5 and won't work on browsers like IE8 and below. Include
+ * some helper library like kolber.github.io/audiojs/ if you need to suport those.
+ * Source can be a single file, a CSV of files or an array of arrays
+ * with multiple sources for different audio formats. In the latter
+ * case provide array keys 'src' and 'type'. Providing an array of
+ * sources (even for a single source) is preferred as you can set
+ * the correct mime type of the audio which is otherwise guessed
+ * from the filename's extension.
+ *
+ * @author Xaver Maierhofer <xaver.maierhofer@xwissen.info>
+ * @package Vhs
+ * @subpackage ViewHelpers\Media
+ */
+class Tx_Vhs_ViewHelpers_Media_AudioViewHelper extends Tx_Vhs_ViewHelpers_Media_AbstractMediaTagViewHelper {
+
+	/**
+	 * @var string
+	 */
+	protected $tagName = 'audio';
+
+	/**
+	 * @var array
+	 */
+	protected $validTypes = array('mp3', 'ogg', 'oga', 'wav');
+
+	/**
+	 * @var array
+	 */
+	protected $mimeTypesMap = array('mp3' => 'audio/mpeg', 'ogg' => 'audio/ogg', 'oga' => 'audio/ogg', 'wav' => 'audio/wav');
+
+	/**
+	 * @var array
+	 */
+	protected $validPreloadModes = array('auto', 'metadata', 'none');
+
+	/**
+	 * Initialize arguments.
+	 *
+	 * @return void
+	 * @api
+	 */
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerUniversalTagAttributes();
+		$this->registerArgument('width', 'integer', 'Sets the width of the audio player in pixels.', TRUE);
+		$this->registerArgument('height', 'integer', 'Sets the height of the audio player in pixels.', TRUE);
+		$this->registerArgument('autoplay', 'boolean', 'Specifies that the audio will start playing as soon as it is ready.', FALSE, FALSE);
+		$this->registerArgument('controls', 'boolean', 'Specifies that audio controls should be displayed (such as a play/pause button etc).', FALSE, FALSE);
+		$this->registerArgument('loop', 'boolean', 'Specifies that the audio will start over again, every time it is finished.', FALSE, FALSE);
+		$this->registerArgument('muted', 'boolean', 'Specifies that the audio output of the audio should be muted.', FALSE, FALSE);
+		$this->registerArgument('poster', 'string', 'Specifies an image to be shown while the audio is downloading, or until the user hits the play button.', FALSE, NULL);
+		$this->registerArgument('preload', 'string', 'Specifies if and how the author thinks the audio should be loaded when the page loads. Can be "auto", "metadata" or "none".', FALSE, 'auto');
+		$this->registerArgument('unsupported', 'string', 'Add a message for old browsers like Internet Explorer 9 without audio support.', FALSE);
+	}
+
+	/**
+	 * Render method
+	 *
+	 * @throws Tx_Fluid_Core_ViewHelper_Exception
+	 * @return string
+	 */
+	public function render() {
+		$sources = $this->getSourcesFromArgument();
+		if (0 === count($sources)) {
+			throw new Tx_Fluid_Core_ViewHelper_Exception('No audio sources provided.', 1359382189);
+		}
+
+		foreach ($sources as $source) {
+			if (TRUE === is_string($source)) {
+				if (FALSE !== strpos($source, '//')) {
+					$src = $source;
+					$type = substr($source, strrpos($source, '.') + 1);
+				} else {
+					$src = substr(\TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName($source), strlen(PATH_site));
+					$type = pathinfo($src, PATHINFO_EXTENSION);
+				}
+			} elseif (TRUE === is_array($source)) {
+				if (FALSE === isset($source['src'])) {
+					throw new Tx_Fluid_Core_ViewHelper_Exception('Missing value for "src" in sources array.', 1359381250);
+				}
+				$src = $source['src'];
+				if (FALSE === isset($source['type'])) {
+					throw new Tx_Fluid_Core_ViewHelper_Exception('Missing value for "type" in sources array.', 1359381255);
+				}
+				$type = $source['type'];
+			} else {
+				// skip invalid source
+				continue;
+			}
+			if (FALSE === in_array(strtolower($type), $this->validTypes)) {
+					throw new Tx_Fluid_Core_ViewHelper_Exception('Invalid audio type "' . $type . '".', 1359381260);
+			}
+			$type = $this->mimeTypesMap[$type];
+			$src = $this->preprocessSourceUri($src);
+			$this->renderChildTag('source', array('src' => $src, 'type' => $type), FALSE, 'append');
+		}
+		$tagAttributes = array(
+			'width'   => $this->arguments['width'],
+			'height'  => $this->arguments['height'],
+			'preload' => 'auto',
+		);
+		if (TRUE === (boolean) $this->arguments['autoplay']) {
+			$tagAttributes['autoplay'] = 'autoplay';
+		}
+		if (TRUE === (boolean) $this->arguments['controls']) {
+			$tagAttributes['controls'] = 'controls';
+		}
+		if (TRUE === (boolean) $this->arguments['loop']) {
+			$tagAttributes['loop'] = 'loop';
+		}
+		if (TRUE === (boolean) $this->arguments['muted']) {
+			$tagAttributes['muted'] = 'muted';
+		}
+		if (TRUE === in_array($this->validPreloadModes, $this->arguments['preload'])) {
+			$tagAttributes['preload'] = 'preload';
+		}
+		if (NULL !== $this->arguments['poster']) {
+			$tagAttributes['poster'] = $this->arguments['poster'];
+		}
+		$this->tag->addAttributes($tagAttributes);
+		if (NULL !== $this->arguments['unsupported']) {
+			$this->tag->setContent($this->tag->getContent() . LF . $this->arguments['unsupported']);
+		}
+		return $this->tag->render();
+	}
+
+}

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -114,6 +114,7 @@ return array(
 	'FluidTYPO3\Vhs\ViewHelpers\Media\Image\HeightViewHelper' => 'Tx_Vhs_ViewHelpers_Media_Image_HeightViewHelper',
 	'FluidTYPO3\Vhs\ViewHelpers\Media\Image\MimetypeViewHelper' => 'Tx_Vhs_ViewHelpers_Media_Image_MimetypeViewHelper',
 	'FluidTYPO3\Vhs\ViewHelpers\Media\Image\WidthViewHelper' => 'Tx_Vhs_ViewHelpers_Media_Image_WidthViewHelper',
+	'FluidTYPO3\Vhs\ViewHelpers\Media\AudioViewHelper' => 'Tx_Vhs_ViewHelpers_Media_AudioViewHelper',
 	'FluidTYPO3\Vhs\ViewHelpers\Media\ExistsViewHelper' => 'Tx_Vhs_ViewHelpers_Media_ExistsViewHelper',
 	'FluidTYPO3\Vhs\ViewHelpers\Media\ExtensionViewHelper' => 'Tx_Vhs_ViewHelpers_Media_ExtensionViewHelper',
 	'FluidTYPO3\Vhs\ViewHelpers\Media\FilesViewHelper' => 'Tx_Vhs_ViewHelpers_Media_FilesViewHelper',

--- a/Tests/Unit/ViewHelpers/Media/AudioViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/AudioViewHelperTest.php
@@ -1,0 +1,33 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @protection off
+ * @author Claus Due <claus@namelesscoder.net>
+ * @package Vhs
+ */
+class Tx_Vhs_ViewHelpers_Media_AudioViewHelperTest extends Tx_Vhs_ViewHelpers_AbstractViewHelperTest {
+
+}


### PR DESCRIPTION
Audio is really similar to Video, but it has no playback screen and different file types and mime types.

Should i add björn in (c) because its based on the video Viewhelper? I though a new viewhelper is always based on something.

resolves  #585
