### PR TITLE
[BUGFIX] Don't show hidden (inactive) pages in menus

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -138,10 +138,11 @@ class Tx_Vhs_Service_PageSelectService implements \TYPO3\CMS\Core\SingletonInter
 		if (NULL === $pageUid) {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
+		$addWhere = self::$pageSelect->enableFields('pages');
 		if (0 < count($allowedDoktypeList)) {
-			$addWhere = ' AND doktype IN (' . implode(',', $allowedDoktypeList) . ')';
+			$addWhere .= ' AND doktype IN (' . implode(',', $allowedDoktypeList) . ')';
 		} else {
-			$addWhere = ' AND doktype != ' . \TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SYSFOLDER;
+			$addWhere .= ' AND doktype != ' . \TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SYSFOLDER;
 		}
 		if (0 < count($excludePages)) {
 			$addWhere .= ' AND uid NOT IN (' . implode(',', $excludePages) . ')';


### PR DESCRIPTION
This might not be the final solution as intended in ce1513ef2 but it fixes an issue with hidden pages appearing  in menus. After updating `vhs` we had to manually set all deactivated/hidden pages to `hide in menu`.
