### PR TITLE
[TASK] Test for PHP 5.6 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ env:
   - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master
   - DB=mysql TYPO3=TYPO3_6-0 INTEGRATION=master
 
+matrix:
+   fast_finish: true
+   include:
+     - php: 5.6
+       env: DB=mysql TYPO3=master INTEGRATION=master
+
 before_script:
   - cd ..
   - git clone --single-branch --branch $INTEGRATION --depth 1 git://github.com/typo3-ci/TYPO3-Travis-Integration.git build-environment


### PR DESCRIPTION
PHP RC will be released on 19 June.
Right now all tests with PHP 5.6 passes in vhs

http://docs.php.net/manual/en/migration56.incompatible.php
http://docs.php.net/manual/en/migration56.deprecated.php
