### PR TITLE
[TASK] Namespaces should not contain a prefix backslash

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -35,13 +35,13 @@ namespace FluidTYPO3\Vhs\Service;
  * @package Vhs
  * @subpackage Service
  */
-use \TYPO3\CMS\Core\SingletonInterface;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use \TYPO3\CMS\Core\Utility\ArrayUtility;
-use \TYPO3\CMS\Extbase\Utility\DebuggerUtility;
-use \FluidTYPO3\Vhs\Asset;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use FluidTYPO3\Vhs\Asset;
 
 class AssetService implements SingletonInterface {
 

--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -37,8 +37,8 @@ namespace FluidTYPO3\Vhs\Service;
  * @package Vhs
  * @subpackage Service
  */
-use \TYPO3\CMS\Core\SingletonInterface;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class PageSelectService implements SingletonInterface {
 

--- a/Classes/View/UncacheTemplateView.php
+++ b/Classes/View/UncacheTemplateView.php
@@ -24,10 +24,10 @@ namespace FluidTYPO3\Vhs\View;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use \TYPO3\CMS\Fluid\View\TemplateView;
-use \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
-use \TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
-use \TYPO3\CMS\Fluid\Compatibility\TemplateParserBuilder;
+use TYPO3\CMS\Fluid\View\TemplateView;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Fluid\Compatibility\TemplateParserBuilder;
 
 /**
  * Uncache Template View

--- a/Classes/ViewHelpers/CallViewHelper.php
+++ b/Classes/ViewHelpers/CallViewHelper.php
@@ -44,7 +44,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class CallViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/CaseViewHelper.php
+++ b/Classes/ViewHelpers/CaseViewHelper.php
@@ -45,7 +45,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class CaseViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -36,9 +36,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * @package Vhs
  * @subpackage ViewHelpers\Content
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \FluidTYPO3\Vhs\Service\PageSelectService;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use FluidTYPO3\Vhs\Service\PageSelectService;
 
 abstract class AbstractContentViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Content/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Content/InfoViewHelper.php
@@ -32,9 +32,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * @package Vhs
  * @subpackage ViewHelpers\Content
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 class InfoViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Content/Random/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/Random/GetViewHelper.php
@@ -32,7 +32,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content\Random;
  * @package Vhs
  * @subpackage ViewHelpers\Content\Random
  */
-use \FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
 
 class GetViewHelper extends AbstractContentViewHelper {
 

--- a/Classes/ViewHelpers/Content/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Content/RenderViewHelper.php
@@ -35,7 +35,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * @package Vhs
  * @subpackage ViewHelpers\Content
  */
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 class RenderViewHelper extends AbstractContentViewHelper {
 

--- a/Classes/ViewHelpers/Content/ResourcesViewHelper.php
+++ b/Classes/ViewHelpers/Content/ResourcesViewHelper.php
@@ -30,7 +30,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * @package Vhs
  * @subpackage ViewHelpers\Content
  */
-use \FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
 
 class ResourcesViewHelper extends RecordViewHelper {
 

--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -31,10 +31,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
-use \TYPO3\CMS\Extbase\Reflection\ObjectAccess;
-use \TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInterface {
 

--- a/Classes/ViewHelpers/IfViewHelper.php
+++ b/Classes/ViewHelpers/IfViewHelper.php
@@ -30,8 +30,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
-use \TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 
 class IfViewHelper extends AbstractConditionViewHelper {
 

--- a/Classes/ViewHelpers/LViewHelper.php
+++ b/Classes/ViewHelpers/LViewHelper.php
@@ -44,8 +44,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelper;
-use \TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Fluid\ViewHelpers\TranslateViewHelper;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class LViewHelper extends TranslateViewHelper {
 

--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -24,7 +24,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Base class: Math ViewHelpers operating on one number or an

--- a/Classes/ViewHelpers/OrViewHelper.php
+++ b/Classes/ViewHelpers/OrViewHelper.php
@@ -32,8 +32,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class OrViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
+++ b/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
@@ -35,10 +35,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 
 abstract class AbstractRenderViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Render/AsciiViewHelper.php
+++ b/Classes/ViewHelpers/Render/AsciiViewHelper.php
@@ -52,7 +52,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class AsciiViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Render/RecordViewHelper.php
+++ b/Classes/ViewHelpers/Render/RecordViewHelper.php
@@ -33,7 +33,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
 
 class RecordViewHelper extends AbstractContentViewHelper {
 

--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -39,8 +39,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \TYPO3\CMS\Extbase\Mvc\Dispatcher;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Mvc\Dispatcher;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 class RequestViewHelper extends AbstractRenderViewHelper {
 

--- a/Classes/ViewHelpers/Render/TemplateViewHelper.php
+++ b/Classes/ViewHelpers/Render/TemplateViewHelper.php
@@ -72,7 +72,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TemplateViewHelper extends AbstractRenderViewHelper {
 

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -35,8 +35,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * @package Vhs
  * @subpackage ViewHelpers\Render
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class UncacheViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -33,9 +33,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * @package Vhs
  * @subpackage ViewHelpers\Resource
  */
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use FluidTYPO3\Vhs\Utility\ResourceUtility;
 
 abstract class AbstractImageViewHelper extends AbstractResourceViewHelper {

--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -32,9 +32,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * @package Vhs
  * @subpackage ViewHelpers\Resource
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use \FluidTYPO3\Vhs\Utility\ResourceUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use FluidTYPO3\Vhs\Utility\ResourceUtility;
 
 abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper {
 

--- a/Classes/ViewHelpers/Resource/FileViewHelper.php
+++ b/Classes/ViewHelpers/Resource/FileViewHelper.php
@@ -32,7 +32,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * @package Vhs
  * @subpackage ViewHelpers\Resource
  */
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 class FileViewHelper extends AbstractResourceViewHelper {
 

--- a/Classes/ViewHelpers/Resource/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/ImageViewHelper.php
@@ -32,7 +32,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * @package Vhs
  * @subpackage ViewHelpers\Resource
  */
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 class ImageViewHelper extends AbstractImageViewHelper {
 

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -30,11 +30,11 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
  * @package Vhs
  * @subpackage ViewHelpers\Resource\Record
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper implements RecordResourceViewHelperInterface {
 

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -30,8 +30,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
  * @package Vhs
  * @subpackage ViewHelpers\Resource\Record
  */
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
-use \FluidTYPO3\Vhs\Utility\ResourceUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use FluidTYPO3\Vhs\Utility\ResourceUtility;
 
 class FalViewHelper extends AbstractRecordResourceViewHelper {
 

--- a/Classes/ViewHelpers/Resource/Record/RecordResourceViewHelperInterface.php
+++ b/Classes/ViewHelpers/Resource/Record/RecordResourceViewHelperInterface.php
@@ -30,7 +30,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
  * @package Vhs
  * @subpackage ViewHelpers\Resource\Record
  */
-use \FluidTYPO3\Vhs\ViewHelpers\Resource\ResourceViewHelperInterface;
+use FluidTYPO3\Vhs\ViewHelpers\Resource\ResourceViewHelperInterface;
 
 interface RecordResourceViewHelperInterface extends ResourceViewHelperInterface {
 

--- a/Classes/ViewHelpers/Resource/RecordViewHelper.php
+++ b/Classes/ViewHelpers/Resource/RecordViewHelper.php
@@ -30,7 +30,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * @package Vhs
  * @subpackage ViewHelpers\Resource
  */
-use \FluidTYPO3\Vhs\ViewHelpers\Resource\Record\AbstractRecordResourceViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\Resource\Record\AbstractRecordResourceViewHelper;
 
 class RecordViewHelper extends AbstractRecordResourceViewHelper {
 

--- a/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
+++ b/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
@@ -32,9 +32,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Security;
  * @package Vhs
  * @subpackage ViewHelpers\Security
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
-use \TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
-use \TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Extbase\Domain\Repository\FrontendUserRepository;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
 
 abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper {
 

--- a/Classes/ViewHelpers/Security/AllowViewHelper.php
+++ b/Classes/ViewHelpers/Security/AllowViewHelper.php
@@ -46,7 +46,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Security;
  * @package Vhs
  * @subpackage ViewHelpers\Security
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
 
 class AllowViewHelper extends AbstractSecurityViewHelper implements ChildNodeAccessInterface {
 

--- a/Classes/ViewHelpers/Security/DenyViewHelper.php
+++ b/Classes/ViewHelpers/Security/DenyViewHelper.php
@@ -38,7 +38,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Security;
  * @package Vhs
  * @subpackage ViewHelpers\Security
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
 
 class DenyViewHelper extends AbstractSecurityViewHelper implements ChildNodeAccessInterface {
 

--- a/Classes/ViewHelpers/SwitchViewHelper.php
+++ b/Classes/ViewHelpers/SwitchViewHelper.php
@@ -45,8 +45,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
 
 class SwitchViewHelper extends AbstractViewHelper implements ChildNodeAccessInterface {
 

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -34,7 +34,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * @package Vhs
  * @subpackage ViewHelpers\System
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class DateTimeViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -38,7 +38,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * @package Vhs
  * @subpackage ViewHelpers\System
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class TimestampViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/System/UniqIdViewHelper.php
+++ b/Classes/ViewHelpers/System/UniqIdViewHelper.php
@@ -37,7 +37,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * @package Vhs
  * @subpackage ViewHelpers\System
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class UniqIdViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/TryViewHelper.php
+++ b/Classes/ViewHelpers/TryViewHelper.php
@@ -99,8 +99,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
-use \FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
 class TryViewHelper extends AbstractConditionViewHelper {
 

--- a/Classes/ViewHelpers/Uri/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Uri/RequestViewHelper.php
@@ -35,8 +35,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * @package Vhs
  * @subpackage ViewHelpers\Uri
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RequestViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
@@ -51,7 +51,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class TypolinkViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Variable/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ConvertViewHelper.php
@@ -37,8 +37,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * @package Vhs
  * @subpackage ViewHelpers\Var
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ConvertViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Variable/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/GetViewHelper.php
@@ -46,8 +46,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * @package Vhs
  * @subpackage ViewHelpers\Var
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 class GetViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Variable/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/SetViewHelper.php
@@ -72,8 +72,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * @subpackage ViewHelpers\Var
  */
 
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 class SetViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
+++ b/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
@@ -59,9 +59,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * @package Vhs
  * @subpackage ViewHelpers\Var
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use \TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TyposcriptViewHelper extends AbstractViewHelper {
 

--- a/Classes/ViewHelpers/Variable/UnsetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/UnsetViewHelper.php
@@ -51,7 +51,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * @package Vhs
  * @subpackage ViewHelpers\Var
  */
-use \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class UnsetViewHelper extends AbstractViewHelper {
 


### PR DESCRIPTION
PHP Docs
Note that for namespaced names (fully qualified namespace names containing namespace separator, such as Foo\Bar as opposed to global names that do not, such as FooBar),
the leading backslash is unnecessary and not recommended, as import names must be fully qualified, and are not processed relative to the current namespace.
