### PR TITLE
[BUGFIX] Ensure unique ids of nested menus

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -539,11 +539,18 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 				$subMenuData = $this->getMenu($pageUid);
 				$subMenu = $this->parseMenu($subMenuData, $rootLineData);
 				$renderedSubMenu = $this->autoRender($subMenu, $level + 1);
+				$parentTagId = $this->tag->getAttribute('id');
+				if (FALSE === empty($parentTagId)) {
+					$this->tag->addAttribute('id', $parentTagId . '-lvl-' . strval($level));
+				}
 				$this->tag->setTagName($this->getWrappingTagName());
 				$this->tag->setContent($renderedSubMenu);
 				$this->tag->addAttribute('class', ($this->arguments['class'] ? $this->arguments['class'] . ' lvl-' : 'lvl-') . strval($level));
 				$html[] = $this->tag->render();
 				$this->tag->addAttribute('class', $this->arguments['class']);
+				if (FALSE === empty($parentTagId)) {
+					$this->tag->addAttribute('id', $parentTagId);
+				}
 				array_push($includedPages, $page);
 			}
 			if (FALSE === $this->isNonWrappingMode()) {


### PR DESCRIPTION
Fixes #624 by appending `lvl-x` to the parent tag's id if set.
