### PR TITLE
[BUGFIX] Content-sliding ignored for positive values

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -131,7 +131,13 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 
 		$slide = intval($this->arguments['slide']);
 		$slideCollect = intval($this->arguments['slideCollect']);
-		$slide = min($slide, $slideCollect);
+
+		if (-1 === $slideCollect || -1 === $slide) {
+			$slide = -1;
+		} else {
+			$slide = max($slide, $slideCollect);
+		}
+
 		$slideCollectReverse = (boolean) $this->arguments['slideCollectReverse'];
 
 		$rootLine = NULL;


### PR DESCRIPTION
This should fix #233.

If `$slideCollect` or `$slide` were `0` the given positive value of the other was ignored and sliding was disabled.
The fix excplictly checks for infinite sliding.
