### PR TITLE
[FEATURE] ViewHelpers to set/get TSFE-registers

### DIFF
--- a/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
@@ -1,0 +1,68 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Stefan Neufeind <info (at) speedpartner.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * ### Variable\Register: Get
+ *
+ * ViewHelper used to read the value of a TSFE-register
+ * Can be used to read names of variables which contain dynamic parts:
+ *
+ *     <!-- if {variableName} is "Name", outputs value of {dynamicName} -->
+ *     {v:variable.register.get(name: 'dynamic{variableName}')}
+ *
+ * @author Stefan Neufeind <info (at) speedpartner.de>
+ * @package Vhs
+ * @subpackage ViewHelpers\Var
+ */
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
+class GetViewHelper extends AbstractViewHelper {
+
+	/**
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerArgument('name', 'string', 'Name of register', TRUE);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function render() {
+		if (FALSE === $GLOBALS['TSFE'] instanceof \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController) {
+			return NULL;
+		}
+		$name = $this->arguments['name'];
+		$value = NULL;
+		if (TRUE === isset($GLOBALS['TSFE']->register[$name])) {
+			$value = $GLOBALS['TSFE']->register[$name];
+		}
+		return $value;
+	}
+
+}

--- a/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
@@ -1,0 +1,74 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Stefan Neufeind <info (at) speedpartner.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * ### Variable\Register: Set
+ *
+ * Sets a single register in the TSFE-register.
+ *
+ * Using as `{value -> v:variable.register.set(name: 'myVar')}` makes $GLOBALS["TSFE"]->register['myVar']
+ * contain `{value}`.
+ *
+ * @author Stefan Neufeind <info (at) speedpartner.de>
+ * @package Vhs
+ * @subpackage ViewHelpers\Var
+ */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
+class SetViewHelper extends AbstractViewHelper {
+
+	/**
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerArgument('value', 'mixed', 'Value to set', FALSE, NULL);
+		$this->registerArgument('name', 'string', 'Name of register', TRUE);
+	}
+
+	/**
+	 * Set (override) the value in register $name.
+	 *
+	 * @param string $name
+	 * @param mixed $value
+	 * @return void
+	 */
+	public function render() {
+		if (FALSE === $GLOBALS['TSFE'] instanceof \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController) {
+			return NULL;
+		}
+		$name = $this->arguments['name'];
+		$value = $this->arguments['value'];
+		if (NULL === $value) {
+			$value = $this->renderChildren();
+		}
+		$GLOBALS['TSFE']->register[$name] = $value;
+		return NULL;
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Variable/Register/GetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/Register/GetViewHelperTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Stefan Neufeind <info (at) speedpartner.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author Stefan Neufeind <info (at) speedpartner.de>
+ * @package Vhs
+ */
+class GetViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * Set up this testcase
+	 */
+	public function setUp() {
+		$GLOBALS['TSFE'] = $this->getMock('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController', array(), array(array(), 1, 1));
+	}
+
+	/**
+	 * @test
+	 */
+	public function returnsNullIfRegisterDoesNotExist() {
+		$name = uniqid();
+		$this->assertEquals(NULL, $this->executeViewHelper(array('name' => $name)));
+	}
+
+	/**
+	 * @test
+	 */
+	public function returnsValueIfRegisterExists() {
+		$name = uniqid();
+		$value = uniqid();
+		$GLOBALS['TSFE']->register[$name] = $value;
+		$this->assertEquals($value, $this->executeViewHelper(array('name' => $name)));
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Variable/Register/SetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/Register/SetViewHelperTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Stefan Neufeind <info (at) speedpartner.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author Stefan Neufeind <info (at) speedpartner.de>
+ * @package Vhs
+ */
+class SetViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * Set up this testcase
+	 */
+	public function setUp() {
+		$GLOBALS['TSFE'] = $this->getMock('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController', array(), array(array(), 1, 1));
+	}
+
+	/**
+	 * @test
+	 */
+	public function canSetRegister() {
+		$name = uniqid();
+		$value = uniqid();
+		$this->executeViewHelper(array('name' => $name, 'value' => $value));
+		$this->assertEquals($value, $GLOBALS['TSFE']->register[$name]);
+	}
+
+	/**
+	 * @test
+	 */
+	public function canSetVariableWithValueFromTagContent() {
+		$name = uniqid();
+		$value = uniqid();
+		$this->executeViewHelperUsingTagContent('Text', $value, array('name' => $name));
+		$this->assertEquals($value, $GLOBALS['TSFE']->register[$name]);
+	}
+
+}


### PR DESCRIPTION
Allows accessing values previously set in TypoScript
via LOAD_REGISTER, or to set values to access elsewhere
from the registers.
