### PR TITLE
[BUGFIX] Avoid path conflicts on CSS assets

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -575,7 +575,7 @@ class AssetService implements SingletonInterface {
 		foreach ($matches[2] as $matchCount => $match) {
 			$match = trim($match, '\'" ');
 			if (FALSE === strpos($match, ':') && !preg_match('/url\\s*\\(/i', $match)) {
-				$checksum = md5($match);
+				$checksum = md5($originalDirectory . $match);
 				if (0 < preg_match('/([^\?#]+)(.+)?/', $match, $items)) {
 					list(, $path, $suffix) = $items;
 				} else {


### PR DESCRIPTION
When copying files referenced inside CSS files (the "rewrite" process),
only the filename of the examined CSS file is taken into account for
obtaining a temporary name. That leads to name conflicts if two CSS
files both reference to a – different – file that is reachable via the
same relative path from within each of the two CSS files.
