### PR TITLE
[FEATURE] Add "srcset" attribute for images

### DIFF
--- a/Classes/ViewHelpers/Media/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/ImageViewHelper.php
@@ -56,6 +56,7 @@ class ImageViewHelper extends AbstractImageViewHelper {
 		$this->registerTagAttribute('usemap', 'string', 'A hash-name reference to a map element with which to associate the image.', FALSE);
 		$this->registerTagAttribute('ismap', 'string', 'Specifies that its img element provides access to a server-side image map.', FALSE, '');
 		$this->registerTagAttribute('alt', 'string', 'Equivalent content for those who cannot process images or who have image loading disabled.', TRUE);
+		$this->registerTagAttribute('srcset', 'string', 'Attribute to provide multiple images that only vary in their size', FALSE, NULL);
 	}
 
 	/**
@@ -72,6 +73,7 @@ class ImageViewHelper extends AbstractImageViewHelper {
 		if ('' === $this->arguments['title']) {
 			$this->tag->addAttribute('title', $this->arguments['alt']);
 		}
+		$this->tag->addAttribute('srcset', $this->arguments['srcset']);
 		return $this->tag->render();
 	}
 

--- a/Classes/ViewHelpers/Resource/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/ImageViewHelper.php
@@ -56,6 +56,7 @@ class ImageViewHelper extends AbstractImageViewHelper {
 		$this->registerTagAttribute('usemap', 'string', 'A hash-name reference to a map element with which to associate the image.', FALSE, NULL);
 		$this->registerTagAttribute('ismap', 'string', 'Specifies that its img element provides access to a server-side image map.', FALSE, NULL);
 		$this->registerTagAttribute('alt', 'string', 'Equivalent content for those who cannot process images or who have image loading disabled.', FALSE, NULL);
+		$this->registerTagAttribute('srcset', 'string', 'Attribute to provide multiple images that only vary in their size', FALSE, NULL);
 		$this->registerArgument('as', 'string', 'If specified, a template variable with this name containing the requested data will be inserted instead of returning it.', FALSE, NULL);
 	}
 
@@ -88,6 +89,7 @@ class ImageViewHelper extends AbstractImageViewHelper {
 			$this->tag->addAttribute('width', $width);
 			$this->tag->addAttribute('height', $height);
 			$this->tag->addAttribute('alt', $alt);
+			$this->tag->addAttribute('srcset', $this->arguments['srcset']);
 
 			$tag = $this->tag->render();
 			$image['tag'] = $tag;


### PR DESCRIPTION
The "srcset" attribute of the `<img>` tag is part of the [W3C Editor's Draft of HTML5](http://www.w3.org/html/wg/drafts/html/master/embedded-content.html#attr-img-srcset) and is already supported by Chrome 34+ and will be supported by Safari 8. Therefore I think this attribute should be supported by the Flux' image ViewHelpers.
