### PR TITLE
[BUGFIX] Only write temp asset files when content changes

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -317,7 +317,9 @@ class AssetService implements SingletonInterface {
 				// Put a return carriage between assets preventing broken content.
 				$source .= "\n";
 			}
-			file_put_contents($fileAbsolutePathAndFilename, $source);
+			if (md5_file($fileAbsolutePathAndFilename) != md5($source)) {
+				file_put_contents($fileAbsolutePathAndFilename, $source);
+			}
 		}
 		if (FALSE === empty($GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'])) {
 			$timestampMode = $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'];


### PR DESCRIPTION
Instead of always overwriting asset files in typo3temp/, this
is now only done when the content of the file changed.

This keeps the modification timestamp stable, so that browsers can
keep using the cached version of the file even when
versionNumberInFilename is activated in TYPO3.
