### PR TITLE
[TASK] Add allowMoveToFooter setter to Asset

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -537,6 +537,15 @@ class Asset implements AssetInterface {
 	}
 
 	/**
+	 * @param boolean $allowMoveToFooter
+	 * @return $this
+	 */
+	public function setAllowMoveToFooter($allowMoveToFooter) {
+		$this->movable = $allowMoveToFooter;
+		return $this;
+	}
+
+	/**
 	 * @return boolean
 	 */
 	public function getRemoved() {


### PR DESCRIPTION
This allows our users to use the same parameter on typoscript as they are used to when using the assetViewHelper.

The allowMoveToFooter setter will set the movable property.
