### PR TITLE
[BUGFIX] File Argument has to be optional to allow use of tag children

### DIFF
--- a/Classes/ViewHelpers/Media/ExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExtensionViewHelper.php
@@ -42,7 +42,7 @@ class ExtensionViewHelper extends AbstractViewHelper {
 	 * @api
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('file', 'string', 'Path to the file to determine extension for.', TRUE);
+		$this->registerArgument('file', 'string', 'Path to the file to determine extension for.', FALSE);
 	}
 
 	/**
@@ -52,7 +52,7 @@ class ExtensionViewHelper extends AbstractViewHelper {
 
 		$filePath = $this->arguments['file'];
 
-		if (NULL === $filePath) {
+		if (TRUE === empty($filePath)) {
 			$filePath = $this->renderChildren();
 
 			if (NULL === $filePath) {


### PR DESCRIPTION
The file argument has to be optional. As long as it is required we will never reach the point where renderChildren is called. Also chaining isnt possible yet but after this fix.
