### PR TITLE
[BUGFIX] Consider $settings[variables] when parsing assets as fluid

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -508,7 +508,15 @@ class AssetService implements SingletonInterface {
 	private function renderAssetAsFluidTemplate($asset) {
 		$settings = $this->extractAssetSettings($asset);
 		$templateReference = $settings['path'];
-		$variables = (TRUE === (isset($settings['arguments']) && is_array($settings['arguments'])) ? $settings['arguments'] : array());
+
+		if(TRUE === isset($settings['arguments']) && TRUE === is_array($settings['arguments'])) {
+			$variables = $settings['arguments'];
+		} elseif(TRUE === isset($settings['variables']) && TRUE === is_array($settings['variables'])) {
+			$variables = $settings['variables'];
+		} else {
+			$variables = array();
+		}
+
 		$isExternal = (TRUE === (isset($settings['external']) && $settings['external'] > 0));
 		if (TRUE === $isExternal) {
 			$fileContents = file_get_contents($templateReference);


### PR DESCRIPTION
Right now we assign the fluid variables from $settings['arguments'] only, but when creating an Asset from PHP and use setVariables then $settings['arguments'] is empty because $settings['variables'] is set.

This patch makes the AssetService fallback to the variables key.
