### PR TITLE
Allow record sliding in page.resources.fal

### DIFF
--- a/Classes/ViewHelpers/AbstractSlideViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSlideViewHelper.php
@@ -1,0 +1,137 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Philipp Kerling <pkerling@casix.org>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @author Philipp Kerling <pkerling@casix.org>
+ * @package Vhs
+ * @subpackage ViewHelpers
+ */
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\PageRelatedRecordsViewHelperInterface;
+use FluidTYPO3\Vhs\Service\PageSelectService;
+
+/**
+ * Abstract ViewHelper class for view helpers that want to support
+ * sliding along the page rootline in order to find records. To use this
+ * class, be sure to call initializeSlideArguments in your initializeArguments
+ * function and have a class ready that implements PageRelatedRecordsViewHelperInterface.
+ * It is used for actually finding any kind of records (e.g. content records)
+ * on a given page. Everything related to sliding is then automatically
+ * handled by getSlideRecords.
+ */
+abstract class AbstractSlideViewHelper extends AbstractViewHelper {
+
+	/**
+	 * @var \FluidTYPO3\Vhs\Service\PageSelectService
+	 */
+	protected $pageSelect;
+
+	/**
+	 * @param \FluidTYPO3\Vhs\Service\PageSelectService $pageSelect
+	 * @return void
+	 */
+	public function injectPageSelectService(PageSelectService $pageSelect) {
+		$this->pageSelect = $pageSelect;
+	}
+
+	/**
+	 * Initialize arguments related to record sliding
+	 * Please take note that the order argument is not automatically added
+	 * as not all implementations can easily support it.
+	 */
+	public function initializeSlideArguments() {
+		$this->registerArgument('limit', 'integer', 'Optional limit to the total number of records to render');
+		$this->registerArgument('slide', 'integer', 'Enables Record Sliding - amount of levels which shall get walked up the rootline, including the current page. For infinite sliding (till the rootpage) set to -1. Only the first PID which has at minimum one record is used', FALSE, 0);
+		$this->registerArgument('slideCollect', 'integer', 'Amount of levels which shall get walked up the rootline and have their records collected. For infinite sliding (till the rootpage) set to -1. If set, this value overrides $slide', FALSE, 0);
+		$this->registerArgument('slideCollectReverse', 'boolean', 'Normally when collecting records the elements from the actual page get shown on the top and those from the parent pages below those. You can invert this behaviour (actual page elements at bottom) by setting this flag))', FALSE, 0);
+	}
+	
+	/**
+	 * Get records, optionally sliding up the page rootline
+	 *
+	 * @param integer $pageUid
+	 * @param \FluidTYPO3\Vhs\ViewHelpers\PageRelatedRecordsViewHelperInterface $recordProvider
+	 * @param integer $limit
+	 * @param string $order
+	 * @return array
+	 */
+	protected function getSlideRecords($pageUid, PageRelatedRecordsViewHelperInterface $recordProvider, $limit = NULL, $order = NULL) {
+		if (NULL === $limit && FALSE === empty($this->arguments['limit'])) {
+			$limit = (integer) $this->arguments['limit'];
+		}
+		
+		$slide = (integer) $this->arguments['slide'];
+		$slideCollectReverse = (boolean) $this->arguments['slideCollectReverse'];
+		$slideCollect = (integer) $this->arguments['slideCollect'];
+		if (FALSE === empty($this->arguments['slideCollect'])) {
+			// $slideCollect overrides $slide to automatically start sliding if
+			// collection is enabled.
+			$slide = $slideCollect;
+		}
+
+		// find out which storage page UIDs to read from, respecting slide depth
+		$storagePageUids = array();
+		if (0 === $slide) {
+			$storagePageUids[] = $pageUid;
+		} else {
+			$rootLine = $this->pageSelect->getRootLine($pageUid, NULL, $slideCollectReverse);
+			if (-1 !== $slide) {
+				if (TRUE === $slideCollectReverse) {
+					$rootLine = array_slice($rootLine, - $slide);
+				} else {
+					$rootLine = array_slice($rootLine, 0, $slide);
+				}
+			}
+			foreach ($rootLine as $page) {
+				$storagePageUids[] = (integer) $page['uid'];
+			}
+		}
+		// select records, respecting slide and slideCollect.
+		$records = array();
+		do {
+			$storagePageUid = array_shift($storagePageUids);
+			$limitRemaining = NULL;
+			if (NULL !== $limit) {
+				$limitRemaining = $limit - count($records);
+				if (0 >= $limitRemaining) {
+					break;
+				}
+			}
+			$recordsFromPageUid = $recordProvider->getRecordsFromPage($storagePageUid, $limitRemaining, $order);
+			if (0 < count($recordsFromPageUid)) {
+				$records = array_merge($records, $recordsFromPageUid);
+				if (0 === $slideCollect) {
+					// stop collecting because argument said so and we've gotten at least one record now.
+					break;
+				}
+			}
+		} while (0 < count($storagePageUids));
+		
+		return $records;
+	}
+
+}

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -36,11 +36,12 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * @package Vhs
  * @subpackage ViewHelpers\Content
  */
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\AbstractSlideViewHelper;
+use FluidTYPO3\Vhs\ViewHelpers\PageRelatedRecordsViewHelperInterface;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use FluidTYPO3\Vhs\Service\PageSelectService;
 
-abstract class AbstractContentViewHelper extends AbstractViewHelper {
+abstract class AbstractContentViewHelper extends AbstractSlideViewHelper implements PageRelatedRecordsViewHelperInterface {
 
 	/**
 	 * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
@@ -53,11 +54,6 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 	protected $configurationManager;
 
 	/**
-	 * @var \FluidTYPO3\Vhs\Service\PageSelectService
-	 */
-	protected $pageSelect;
-
-	/**
 	 * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager
 	 * @return void
 	 */
@@ -67,27 +63,16 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @param \FluidTYPO3\Vhs\Service\PageSelectService $pageSelect
-	 * @return void
-	 */
-	public function injectPageSelectService(PageSelectService $pageSelect) {
-		$this->pageSelect = $pageSelect;
-	}
-
-	/**
 	 * Initialize
 	 */
 	public function initializeArguments() {
+		$this->initializeSlideArguments();
 		$this->registerArgument('column', 'integer', 'Name of the column to render', FALSE, 0);
-		$this->registerArgument('limit', 'integer', 'Optional limit to the number of content elements to render');
 		$this->registerArgument('order', 'string', 'Optional sort field of content elements - RAND() supported', FALSE, 'sorting');
 		$this->registerArgument('sortDirection', 'string', 'Optional sort direction of content elements', FALSE, 'ASC');
 		$this->registerArgument('pageUid', 'integer', 'If set, selects only content from this page UID', FALSE, 0);
 		$this->registerArgument('contentUids', 'array', 'If used, replaces all conditions with an "uid IN (1,2,3)" style condition using the UID values from this array');
 		$this->registerArgument('sectionIndexOnly', 'boolean', 'If TRUE, only renders/gets content that is marked as "include in section index"', FALSE, FALSE);
-		$this->registerArgument('slide', 'integer', 'Enables Content Sliding - amount of levels which shall get walked up the rootline. For infinite sliding (till the rootpage) set to -1)', FALSE, 0);
-		$this->registerArgument('slideCollect', 'integer', 'If TRUE, content is collected up the root line. If FALSE, only the first PID which has content is used. If greater than zero, this value overrides $slide', FALSE, 0);
-		$this->registerArgument('slideCollectReverse', 'boolean', 'Normally when collecting content elements the elements from the actual page get shown on the top and those from the parent pages below those. You can invert this behaviour (actual page elements at bottom) by setting this flag))', FALSE, 0);
 		$this->registerArgument('loadRegister', 'array', 'List of LOAD_REGISTER variable');
 		$this->registerArgument('render', 'boolean', 'Optional returning variable as original table rows', FALSE, TRUE);
 		$this->registerArgument('hideUntranslated', 'boolean', 'If FALSE, will NOT include elements which have NOT been translated, if current language is NOT the default language. Default is to show untranslated elements but never display the original if there is a translated version', FALSE, FALSE);
@@ -98,47 +83,17 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 	 *
 	 * @param integer $limit
 	 * @param string $order
+	 * @param boolean $render
 	 * @return array
 	 */
-	protected function getContentRecords($limit = NULL, $order = NULL) {
+	protected function getContentRecords($limit = NULL, $order = NULL, $render = NULL) {
 		$pageUid = $this->getPageUid();
-		$slide = (integer) $this->arguments['slide'];
-		$slideCollectReverse = (boolean) $this->arguments['slideCollectReverse'];
-		$slideCollect = (integer) $this->arguments['slideCollect'];
-		if (0 < $slideCollect) {
-			// $slideCollect overrides $slide to automatically start sliding if
-			// collection is enabled.
-			$slide = $slideCollect;
-		}
+		$contentRecords = $this->getSlideRecords($pageUid, $this, $limit, $order);
 
-		// find out which storage page UIDs to read from, respecting slide depth
-		$storagePageUids = array();
-		if (0 === $slide) {
-			$storagePageUids[] = $pageUid;
-		} else {
-			$rootLine = $this->pageSelect->getRootLine($pageUid, NULL, $slideCollectReverse);
-			if (-1 !== $slide) {
-				$rootLine = array_slice($rootLine, 0, $slide);
-			}
-			foreach ($rootLine as $page) {
-				$storagePageUids[] = (integer) $page['uid'];
-			}
+		if (NULL === $render && FALSE === empty($this->arguments['render'])) {
+			$render = $this->arguments['render'];
 		}
-		// select content elements, respecting slide and slideCollect.
-		$contentRecords = array();
-		do {
-			$storagePageUid = array_shift($storagePageUids);
-			$contentFromPageUid = $this->getContentRecordsFromPage($storagePageUid, $limit, $order);
-			if (0 < count($contentFromPageUid)) {
-				$contentRecords = array_merge($contentRecords, $contentFromPageUid);
-				if (0 === $slideCollect) {
-					// stop collecting because argument said so and we've gotten at least one record now.
-					break;
-				}
-			}
-		} while (0 < count($storagePageUids));
-
-		if (TRUE === (boolean) $this->arguments['render']) {
+		if (TRUE === (boolean) $render) {
 			$contentRecords = $this->getRenderedRecords($contentRecords);
 		} else {
 			$contentRecords = $contentRecords;
@@ -153,7 +108,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 	 * @param string $order
 	 * @return array[]
 	 */
-	protected function getContentRecordsFromPage($pageUid, $limit, $order) {
+	public function getRecordsFromPage($pageUid, $limit = NULL, $order = NULL) {
 		$column = (integer) $this->arguments['column'];
 		if (NULL === $limit && FALSE === empty($this->arguments['limit'])) {
 			$limit = (integer) $this->arguments['limit'];

--- a/Classes/ViewHelpers/PageRelatedRecordsViewHelperInterface.php
+++ b/Classes/ViewHelpers/PageRelatedRecordsViewHelperInterface.php
@@ -1,0 +1,43 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Philipp Kerling <pkerling@casix.org>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+/**
+ * @author Philipp Kerling <pkerling@casix.org>
+ * @package Vhs
+ * @subpackage ViewHelpers\Resource
+ */
+interface PageRelatedRecordsViewHelperInterface {
+
+	/**
+	 * @param integer $pageUid
+	 * @param integer $limit
+	 * @param string $order
+	 * @return array
+	 */
+	public function getRecordsFromPage($pageUid, $limit = NULL, $order = NULL);
+
+}

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -30,13 +30,13 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
  * @package Vhs
  * @subpackage ViewHelpers\Resource\Record
  */
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+use FluidTYPO3\Vhs\ViewHelpers\AbstractSlideViewHelper;
 use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 
-abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper implements RecordResourceViewHelperInterface {
+abstract class AbstractRecordResourceViewHelper extends AbstractSlideViewHelper implements RecordResourceViewHelperInterface {
 
 	/**
 	 * @var string
@@ -158,7 +158,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
 	public function getActiveRecord() {
 		return $this->configurationManager->getContentObject()->data;
 	}
-
+	
 	/**
 	 * @return mixed
 	 */

--- a/Tests/Unit/ViewHelpers/Page/Resources/FalViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/Resources/FalViewHelperTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Page\Resources;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Philipp Kerling <pkerling@casix.org>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author Philipp Kerling <pkerling@casix.org>
+ * @package Vhs
+ */
+class FalViewHelperTest extends AbstractViewHelperTest {
+
+}


### PR DESCRIPTION
Page\Resources\FalViewHelper was until now missing the feature to use record sliding for page-related media. That is however commonly required for dynamic page background images and such and I wanted to avoid falling back to TypoScript.

It made quite a challenge to separate the already existing sliding code from AbstractContentViewHelper into a separate class and I'm not sure whether the result is quite right. If you have suggestions concerning the implementation of this feature, I'd be happy to rework it.