### PR TITLE
[BUGFIX] Argument "limit" is ignored in Random/GetViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Content/Random/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/Random/GetViewHelper.php
@@ -45,7 +45,8 @@ class GetViewHelper extends AbstractContentViewHelper {
 		if ('BE' === TYPO3_MODE) {
 			return '';
 		}
-		$contentRecords = $this->getContentRecords(1, 'RAND()');
+		$limit = $this->arguments['limit'] ? (integer)$this->arguments['limit'] : 1;
+		$contentRecords = $this->getContentRecords($limit, 'RAND()');
 		return $contentRecords;
 	}
 


### PR DESCRIPTION
As GetViewHelper inherited from AbstractContentViewHelper limit argument is inherited too, but ignored for Random/GetViewHelper.
