### PR TITLE
[BUGFIX] negative entryLevel is one page off

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -678,7 +678,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 		$rootLineData = $this->pageSelect->getRootLine();
 		$entryLevel = (integer) $this->arguments['entryLevel'];
 		if (0 > $entryLevel) {
-			$entryLevel = count($rootLineData) + $entryLevel - 1;
+			$entryLevel = count($rootLineData) + $entryLevel;
 		}
 		if (TRUE === empty($pageUid)) {
 			if (NULL !== $rootLineData[$entryLevel]['uid']) {


### PR DESCRIPTION
entryLevel = -1 should correspond to current page, i.e. the last item in rootline. If we remove 1 here, then entryLevel = -1 corresponds to parent page, and there is no way to select menu relative to current page.
