### PR TITLE
[BUGFIX] hideIfEmpty was not working

### DIFF
--- a/Classes/ViewHelpers/TagViewHelper.php
+++ b/Classes/ViewHelpers/TagViewHelper.php
@@ -58,7 +58,7 @@ class TagViewHelper extends AbstractTagBasedViewHelper {
 		if (TRUE === empty($trimmedContent) && FALSE === empty($this->arguments['hideIfEmpty'])) {
 			return '';
 		}
-		if ('none' === $this->arguments['name'] || TRUE === empty($this->arguments['name'])) {
+		if ('none' === $this->arguments['name'] || TRUE === (boolean) empty($this->arguments['name'])) {
 			// skip building a tag if special keyword "none" is used, or tag name is empty
 			return $content;
 		}


### PR DESCRIPTION
hideIfEmpty was not used for anything, so v:tag without content was not rendered. Now it works as expected.
