### PR TITLE
[BUGFIX] Fixed hideIfEmpty argument. It was not used in code.

### DIFF
--- a/Classes/ViewHelpers/TagViewHelper.php
+++ b/Classes/ViewHelpers/TagViewHelper.php
@@ -55,7 +55,7 @@ class TagViewHelper extends AbstractTagBasedViewHelper {
 		$this->arguments['class'] = trim($this->arguments['class']);
 		$content = $this->renderChildren();
 		$trimmedContent = trim($content);
-		if (TRUE === empty($trimmedContent)) {
+		if (TRUE === empty($trimmedContent) && TRUE === (boolean) $this->arguments['hideIfEmpty']) {
 			return '';
 		}
 		if ('none' === $this->arguments['name'] || TRUE === empty($this->arguments['name'])) {


### PR DESCRIPTION
The arguement hideIfEmpty was not working so <v:tag> with no content was not rendered.
