### PR TITLE
[FEATURE] Context view helpers

### DIFF
--- a/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
@@ -1,0 +1,64 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * ### Context: IsDevelopment
+ *
+ * Returns true if current root application context is development otherwise false.
+ * If no application context has been set, then the default context is production.
+ *
+ * #### Note about how to set the application context
+ *
+ * The context TYPO3 CMS runs in is specified through the environment variable TYPO3_CONTEXT.
+ * It can be set by .htaccess or in the server configuration
+ *
+ * See: http://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Bootstrapping/Index.html#bootstrapping-context
+ *
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ * @subpackage ViewHelpers\Condition\Context
+ */
+class IsDevelopmentViewHelper extends AbstractConditionViewHelper {
+
+	/**
+	 * Render method
+	 *
+	 * @return string
+	 */
+	public function render () {
+		if (TRUE === $this->isDevelopmentContext()) {
+			return $this->renderThenChild();
+		}
+
+		return $this->renderElseChild();
+	}
+
+
+	/**
+	 * @return boolean
+	 */
+	protected function isDevelopmentContext () {
+		return GeneralUtility::getApplicationContext()->isDevelopment();
+	}
+}

--- a/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
@@ -1,0 +1,65 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * ### Context: IsProduction
+ *
+ * Returns true if current root application context is production otherwise false.
+ * If no application context has been set, then this is the default context.
+ *
+ * #### Note about how to set the application context
+ *
+ * The context TYPO3 CMS runs in is specified through the environment variable TYPO3_CONTEXT.
+ * It can be set by .htaccess or in the server configuration
+ *
+ * See: http://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Bootstrapping/Index.html#bootstrapping-context
+ *
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ * @subpackage ViewHelpers\Condition\Context
+ */
+class IsProductionViewHelper extends AbstractConditionViewHelper {
+
+	/**
+	 * Render method
+	 *
+	 * @return string
+	 */
+	public function render () {
+		if (TRUE === $this->isProductionContext()) {
+			return $this->renderThenChild();
+		}
+
+		return $this->renderElseChild();
+	}
+
+
+	/**
+	 * @return boolean
+	 */
+	protected function isProductionContext () {
+		return GeneralUtility::getApplicationContext()->isProduction();
+	}
+
+}

--- a/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
@@ -1,0 +1,65 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * ### Context: IsProduction
+ *
+ * Returns true if current root application context is testing otherwise false.
+ * If no application context has been set, then the default context is production.
+ *
+ * #### Note about how to set the application context
+ *
+ * The context TYPO3 CMS runs in is specified through the environment variable TYPO3_CONTEXT.
+ * It can be set by .htaccess or in the server configuration
+ *
+ * See: http://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Bootstrapping/Index.html#bootstrapping-context
+ *
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ * @subpackage ViewHelpers\Condition\Context
+ */
+class IsTestingViewHelper extends AbstractConditionViewHelper {
+
+	/**
+	 * Render method
+	 *
+	 * @return string
+	 */
+	public function render () {
+		if (TRUE === $this->isTestingContext()) {
+			return $this->renderThenChild();
+		}
+
+		return $this->renderElseChild();
+	}
+
+
+	/**
+	 * @return boolean
+	 */
+	protected function isTestingContext () {
+		return GeneralUtility::getApplicationContext()->isTesting();
+	}
+
+}

--- a/Classes/ViewHelpers/Context/GetViewHelper.php
+++ b/Classes/ViewHelpers/Context/GetViewHelper.php
@@ -1,0 +1,53 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * ### Context: Get
+ *
+ * Returns the current application context which may include possible sub-contexts.
+ * The application context can be 'Production', 'Development' or 'Testing'.
+ * Additionally each context can be extended with custom sub-contexts like: 'Production/Staging' or ' Production/Staging/Server1'.
+ * If no application context has been set by the configuration, then the default context is 'Production'.
+ *
+ * #### Note about how to set the application context
+ *
+ * The context TYPO3 CMS runs in is specified through the environment variable TYPO3_CONTEXT.
+ * It can be set by .htaccess or in the server configuration
+ *
+ * See: http://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Bootstrapping/Index.html#bootstrapping-context
+ *
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ * @subpackage ViewHelpers\Context
+ */
+class GetViewHelper extends AbstractViewHelper {
+
+	/**
+	 * @return string
+	 */
+	public function render () {
+		return (string) GeneralUtility::getApplicationContext();
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsDevelopmentViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsDevelopmentViewHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ */
+class IsDevelopmentViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * @test
+	 */
+	public function testIsDevelopmentContext() {
+		$instance = $this->createInstance();
+		$result = $this->callInaccessibleMethod($instance, 'isDevelopmentContext');
+		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
+	}
+
+	/**
+	 * @test
+	 * @dataProvider getRenderTestValues
+	 * @param boolean $verdict
+	 * @param boolean $expected
+	 */
+	public function testRender($verdict, $expected) {
+		$instance = $this->getMock(substr(get_class($this), 0, -4), array('isDevelopmentContext'));
+		$instance->expects($this->once())->method('isDevelopmentContext')->will($this->returnValue($verdict));
+		$arguments = array('then' => TRUE, 'else' => FALSE);
+		$instance->setArguments($arguments);
+		$result = $instance->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getRenderTestValues() {
+		return array(
+			array(FALSE, FALSE),
+			array(TRUE, TRUE),
+		);
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsProductionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsProductionViewHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ */
+class IsProductionViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * @test
+	 */
+	public function testIsProductionContext() {
+		$instance = $this->createInstance();
+		$result = $this->callInaccessibleMethod($instance, 'isProductionContext');
+		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
+	}
+
+	/**
+	 * @test
+	 * @dataProvider getRenderTestValues
+	 * @param boolean $verdict
+	 * @param boolean $expected
+	 */
+	public function testRender($verdict, $expected) {
+		$instance = $this->getMock(substr(get_class($this), 0, -4), array('isProductionContext'));
+		$instance->expects($this->once())->method('isProductionContext')->will($this->returnValue($verdict));
+		$arguments = array('then' => TRUE, 'else' => FALSE);
+		$instance->setArguments($arguments);
+		$result = $instance->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getRenderTestValues() {
+		return array(
+			array(FALSE, FALSE),
+			array(TRUE, TRUE),
+		);
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsTestingViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsTestingViewHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection off
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ */
+class IsTestingViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * @test
+	 */
+	public function testIsTestingContext() {
+		$instance = $this->createInstance();
+		$result = $this->callInaccessibleMethod($instance, 'isTestingContext');
+		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
+	}
+
+	/**
+	 * @test
+	 * @dataProvider getRenderTestValues
+	 * @param boolean $verdict
+	 * @param boolean $expected
+	 */
+	public function testRender($verdict, $expected) {
+		$instance = $this->getMock(substr(get_class($this), 0, -4), array('isTestingContext'));
+		$instance->expects($this->once())->method('isTestingContext')->will($this->returnValue($verdict));
+		$arguments = array('then' => TRUE, 'else' => FALSE);
+		$instance->setArguments($arguments);
+		$result = $instance->render();
+		$this->assertEquals($expected, $result);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getRenderTestValues() {
+		return array(
+			array(FALSE, FALSE),
+			array(TRUE, TRUE),
+		);
+	}
+
+}

--- a/Tests/Unit/ViewHelpers/Context/GetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Context/GetViewHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Context;
+
+/***************************************************************
+ *  Copyright notice
+ *  (c) 2014 Benjamin Beck <beck@beckdigitalemedien.de>
+ *  All rights reserved
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Vhs\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @author     Benjamin Beck <beck@beckdigitalemedien.de>
+ * @package    Vhs
+ */
+class GetViewHelperTest extends AbstractViewHelperTest {
+
+	/**
+	 * @test
+	 */
+	public function renderCompleteContext() {
+		$result = $this->executeViewHelper();
+		$expectedResult = getenv('TYPO3_CONTEXT') ?: (getenv('REDIRECT_TYPO3_CONTEXT') ?: 'Production');
+		$this->assertSame($result, $expectedResult);
+	}
+
+}


### PR DESCRIPTION
With this view-helpers you can use the [`TYPO3_CONTEXT`](http://docs.typo3.org/typo3cms/CoreApiReference/ApiOverview/Bootstrapping/Index.html#bootstrapping-context) to output different content for your development,testing or production environment.

Please don´t merge until the following questions are solved:
1. `TYPO3_CONTEXT` [got added in 6.2](http://docs.typo3.org/typo3cms/CoreApiReference/singlehtml/#what-s-new) but vhs emconf says 6.0 is supported - how do we deal with that old versions? Can we have view-helpers that only work with 6.2?
2. I created this view-helpers in the namespace `ViewHelpers/Context/*`. I used the wording "Context" because the core uses it, although "Environment" would feel more intuitive to me. There are also already some view-helpers in a similar namespace: `ViewHelpers/Condition/Context/*`. I am open for suggestions to improve this situation.
