### PR TITLE
[TASK] Get rid of deprecation log in TYPO3 7.1

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -239,7 +239,8 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 		if (FALSE === empty($parent)) {
 			++$GLOBALS['TSFE']->recordRegister[$parent];
 		}
-		$html = $GLOBALS['TSFE']->cObj->RECORDS($conf);
+		$html = $GLOBALS['TSFE']->cObj->cObjGetSingle('RECORDS', $conf);
+
 		$GLOBALS['TSFE']->currentRecord = $parent;
 		if (FALSE === empty($parent)) {
 			--$GLOBALS['TSFE']->recordRegister[$parent];

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media\Image;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Media\AbstractMediaViewHelper;
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
@@ -121,7 +122,11 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper {
 		if (FALSE === is_array($this->imageInfo)) {
 			throw new Exception('Could not get image resource for "' . htmlspecialchars($src) . '".', 1253191060);
 		}
-		$this->imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($this->imageInfo[3]);
+		if ((float) substr(TYPO3_version, 0, 3) < 7.1) {
+			$this->imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($this->imageInfo[3]);
+		} else {
+			$this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);
+		}
 		$GLOBALS['TSFE']->imagesOnPage[] = $this->imageInfo[3];
 		$publicUrl = rawurldecode($this->imageInfo[3]);
 		$this->mediaSource = $GLOBALS['TSFE']->absRefPrefix . GeneralUtility::rawUrlEncodeFP($publicUrl);

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  */
 
 use FluidTYPO3\Vhs\Utility\ResourceUtility;
+use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
@@ -104,6 +105,11 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper {
 				throw new Exception('Could not get image resource for "' . htmlspecialchars($file->getCombinedIdentifier()) . '".', 1253191060);
 			}
 
+			if ((float) substr(TYPO3_version, 0, 3) < 7.1) {
+				$imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($imageInfo[3]);
+			} else {
+				$imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($imageInfo[3]);
+			}
 			$imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($imageInfo[3]);
 			$GLOBALS['TSFE']->imagesOnPage[] = $imageInfo[3];
 			$imageSource = $GLOBALS['TSFE']->absRefPrefix . GeneralUtility::rawUrlEncodeFP($imageInfo[3]);


### PR DESCRIPTION

using of `cObjGetSingle('RECORDS', $conf)` instead of `RECORDS($conf)` which will be deprecated in TYPO3 8.0.

Also checking TYPO3 Version in `\ViewHelpers\Media\Image\AbstractImageViewHelper`and in `ViewHelpers\Resource\AbstractImageViewHelper` to switch between 
* TYPO3 Version < 7.1  using `GeneralUtility::png_to_gif_by_imagemagick`
* TYPO3 Version >= 7.1 using `GraphicalFunctions::pngToGifByImagemagick`