### PR TITLE
[FEATURE] Add attribute "property" to Page\Header\MetaViewHelper

### DIFF
--- a/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
@@ -37,6 +37,7 @@ class MetaViewHelper extends AbstractTagBasedViewHelper {
 	 */
 	public function initializeArguments() {
 		$this->registerTagAttribute('name', 'string', 'Name property of meta tag');
+		$this->registerTagAttribute('property', 'string', 'Property of meta tag');
 		$this->registerTagAttribute('content', 'string', 'Content of meta tag');
 		$this->registerTagAttribute('http-equiv', 'string', 'Property: http-equiv');
 		$this->registerTagAttribute('scheme', 'string', 'Property: scheme');


### PR DESCRIPTION
missing attribute "property" for e.g. to set open graph metadata in page header.