### PR TITLE
[BUGFIX] Fixed DirectoryViewHelper.Menu attribute "pages".

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -717,6 +717,8 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 			$pages = iterator_to_array($pages);
 		} elseif (TRUE === is_string($pages)) {
 			$pages = GeneralUtility::trimExplode(',', $pages, TRUE);
+		} elseif (TRUE === is_integer($pages)) {
+			$pages = (array) $pages;
 		}
 		if (FALSE === is_array($pages)) {
 			return array();


### PR DESCRIPTION
If attribute was given an integer value, for example the key value of an
ForViewHelper, processPagesArgument in AbstractMenuViewHelper returns an
empty array instead of an array with the given attribute value, which
results in an empty return in render method of DirectoryViewHelper.

Added a test is_integer