### PR TITLE
[FEATURE] New viewhelper /Resource/Folder

### DIFF
--- a/Classes/Traits/ArrayConsumingViewHelperTrait.php
+++ b/Classes/Traits/ArrayConsumingViewHelperTrait.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
  * - retrieving an argument either from arguments or from
  *   tag contents while also converting it to array.
  * - merge arrays with a switch to respect TYPO3 version.
+ * - Converts the value into an array. If the value is NULL,
+ *   then the value of the given argument name is used.
  */
 trait ArrayConsumingViewHelperTrait {
 
@@ -78,5 +80,31 @@ trait ArrayConsumingViewHelperTrait {
 			return GeneralUtility::array_merge_recursive_overrule($array1, $array2);
 		}
 	}
+
+	/**
+	 * Mixed argument with CSV, array, Traversable
+	 *
+	 * @param mixed $value
+	 * @param string $argumentName
+	 * @param bool $useKeys
+	 *
+	 * @return array
+	 * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
+	 */
+	public function convertValueOrGetArgumentAsArray($value, $argumentName, $useKeys = TRUE) {
+		if (NULL === $value) {
+			$value = $this->arguments[$argumentName];
+			if (NULL === $value) {
+				return array();
+			}
+			if (is_int($value)) {
+				return (array) $value;
+			}
+		}
+
+		return $this->arrayFromArrayOrTraversableOrCSV($value, $useKeys);
+	}
+
+
 
 }

--- a/Classes/Traits/ResourceViewHelperTrait.php
+++ b/Classes/Traits/ResourceViewHelperTrait.php
@@ -1,0 +1,198 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Resource\Filter\FileExtensionFilter;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+use FluidTYPO3\Vhs\Utility\ResourceUtility;
+
+
+/**
+ * Class ResourceViewHelperTrait
+ *
+ * Trait implemented by ViewHelpers that operate with
+ * File and Folder Resources
+ *
+ * Contains the following main responsibilities:
+ *
+ * - get files of given identifiers or categories
+ * - fetch files of folders, given by FAL identifier.
+ *   With the ability to filter the files on given file extensions.
+ */
+trait ResourceViewHelperTrait {
+
+	use ArrayConsumingViewHelperTrait;
+
+	/**
+	 *
+	 * @var FileExtensionFilter
+	 */
+	protected $filter = NULL;
+
+	/**
+	 * Returns the files
+	 *
+	 * @param boolean $onlyProperties
+	 * @param mixed $identifier
+	 * @param mixed $categories
+	 * @return array|NULL
+	 */
+	public function getFiles($onlyProperties = FALSE, $identifier = NULL, $categories = NULL) {
+		$identifier = $this->convertValueOrGetArgumentAsArray($identifier, 'identifier');
+		$categories = $this->convertValueOrGetArgumentAsArray($categories, 'categories');
+		$treatIdAsUid = (boolean) $this->arguments['treatIdAsUid'];
+		$treatIdAsReference = (boolean) $this->arguments['treatIdAsReference'];
+
+		if (TRUE === $treatIdAsUid && TRUE === $treatIdAsReference) {
+			throw new \RuntimeException('The arguments "treatIdAsUid" and "treatIdAsReference" may not both be TRUE.', 1384604695);
+		}
+
+		if (TRUE === empty($identifier) && TRUE === empty($categories)) {
+			return NULL;
+		}
+
+		$files = array();
+		$resourceFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\ResourceFactory');
+
+		if (FALSE === empty($categories)) {
+			$sqlCategories = implode(',', $GLOBALS['TYPO3_DB']->fullQuoteArray($categories, 'sys_category_record_mm'));
+			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid_foreign', 'sys_category_record_mm', 'tablenames = \'sys_file\' AND uid_local IN (' . $sqlCategories . ')');
+
+			$fileUids = array();
+			while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+				$fileUids[] = intval($row['uid_foreign']);
+			}
+			$fileUids = array_unique($fileUids);
+
+			if (TRUE === empty($identifier)) {
+				foreach ($fileUids as $fileUid) {
+					try {
+						$file = $resourceFactory->getFileObject($fileUid);
+
+						if (TRUE === $onlyProperties) {
+							$file = ResourceUtility::getFileArray($file);
+						}
+
+						$files[] = $file;
+					} catch (\Exception $e) {
+						continue;
+					}
+				}
+
+				return $files;
+			}
+		}
+
+		foreach ($identifier as $i) {
+			try {
+				if (TRUE === $treatIdAsUid) {
+					$file = $resourceFactory->getFileObject(intval($i));
+				} elseif (TRUE === $treatIdAsReference) {
+					$fileReference = $resourceFactory->getFileReferenceObject(intval($i));
+					$file = $fileReference->getOriginalFile();
+				} else {
+					$file = $resourceFactory->getFileObjectFromCombinedIdentifier($i);
+				}
+
+				if (TRUE === isset($fileUids) && FALSE === in_array($file->getUid(), $fileUids)) {
+					continue;
+				}
+
+				if (TRUE === $onlyProperties) {
+					$file = ResourceUtility::getFileArray($file);
+				}
+
+				$files[] = $file;
+			} catch (\Exception $e) {
+				continue;
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Returns the files of the folders
+	 *
+	 * @param boolean $onlyProperties
+	 * @param mixed   $identifier
+	 * @param mixed   $recursive
+	 *
+	 * @return array|NULL
+	 */
+	public function getFilesOfFolders($onlyProperties = FALSE, $identifier = NULL, $recursive = NULL) {
+		$identifier = $this->convertValueOrGetArgumentAsArray($identifier, 'identifier');
+		$recursive = NULL === $recursive ? $this->arguments['recursive'] : $recursive;
+		$filterExtensions = trim((string) $this->arguments['filterExtensions']);
+		$start = (integer) $this->arguments['start'];
+		$numberOfItems = (integer) $this->arguments['numberOfItems'];
+
+		if (TRUE === empty($identifier)) {
+			return NULL;
+		}
+
+		$files = array();
+		$resourceFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\ResourceFactory');
+
+		if (FALSE === empty($filterExtensions)) {
+			$this->filter = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\Filter\\FileExtensionFilter');
+			$this->filter->setAllowedFileExtensions($filterExtensions);
+			$filter = array(
+				array(
+					$this->filter,
+					'filterFileList',
+				)
+			);
+		}
+
+		foreach ($identifier as $i) {
+			try {
+				/** @var Folder $folder */
+				$folder = $resourceFactory->retrieveFileOrFolderObject($i);
+				if (NULL !== $this->filter) {
+					$folder->setFileAndFolderNameFilters($filter);
+				}
+
+				if (TRUE === $onlyProperties) {
+					$files = array_merge($files, self::getFilesOfFolderAsArray($folder, $start, $numberOfItems, $recursive));
+				} else {
+					$files = array_merge($files, $folder->getFiles($start, $numberOfItems, Folder::FILTER_MODE_USE_OWN_AND_STORAGE_FILTERS, $recursive));
+				}
+			} catch (\Exception $e) {
+				continue;
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * Get all Files from the $folder and convert each file object to an array.
+	 *
+	 * @param Folder $folder
+	 * @param int    $start
+	 * @param int    $numberOfItems
+	 * @param bool   $recursive
+	 *
+	 * @return array
+	 */
+	public static function getFilesOfFolderAsArray(Folder $folder, $start = 0, $numberOfItems = 0, $recursive = FALSE) {
+		$array = array();
+		$files = $folder->getFiles($start, $numberOfItems, Folder::FILTER_MODE_USE_OWN_AND_STORAGE_FILTERS, $recursive);
+		foreach ($files as $file) {
+			$array[] = ResourceUtility::getFileArray($file);
+		}
+
+		return $array;
+	}
+}

--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Vhs\Utility\ResourceUtility;
+use FluidTYPO3\Vhs\Traits\ResourceViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
@@ -21,6 +21,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper {
 
+	use ResourceViewHelperTrait;
+
 	/**
 	 * Initialize arguments.
 	 *
@@ -32,111 +34,6 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper {
 		$this->registerArgument('categories', 'mixed', 'The sys_category records to select the resources from (either CSV, array or implementing Traversable).', FALSE, NULL);
 		$this->registerArgument('treatIdAsUid', 'boolean', 'If TRUE, the identifier argument is treated as resource uids.', FALSE, FALSE);
 		$this->registerArgument('treatIdAsReference', 'boolean', 'If TRUE, the identifier argument is treated as reference uids and will be resolved to resources via sys_file_reference.', FALSE, FALSE);
-	}
-
-	/**
-	 * Returns the files
-	 *
-	 * @param boolean $onlyProperties
-	 * @param mixed $identifier
-	 * @param mixed $categories
-	 * @return array|NULL
-	 */
-	public function getFiles($onlyProperties = FALSE, $identifier = NULL, $categories = NULL) {
-		$identifier = $this->arrayForMixedArgument($identifier, 'identifier');
-		$categories = $this->arrayForMixedArgument($categories, 'categories');
-		$treatIdAsUid = (boolean) $this->arguments['treatIdAsUid'];
-		$treatIdAsReference = (boolean) $this->arguments['treatIdAsReference'];
-
-		if (TRUE === $treatIdAsUid && TRUE === $treatIdAsReference) {
-			throw new \RuntimeException('The arguments "treatIdAsUid" and "treatIdAsReference" may not both be TRUE.', 1384604695);
-		}
-
-		if (TRUE === empty($identifier) && TRUE === empty($categories)) {
-			 return NULL;
-		}
-
-		$files = array();
-		$resourceFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\ResourceFactory');
-
-		if (FALSE === empty($categories)) {
-			$sqlCategories = implode(',', $GLOBALS['TYPO3_DB']->fullQuoteArray($categories, 'sys_category_record_mm'));
-			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid_foreign', 'sys_category_record_mm', 'tablenames = \'sys_file\' AND uid_local IN (' . $sqlCategories . ')');
-
-			$fileUids = array();
-			while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
-				$fileUids[] = intval($row['uid_foreign']);
-			}
-			$fileUids = array_unique($fileUids);
-
-			if (TRUE === empty($identifier)) {
-				foreach ($fileUids as $fileUid) {
-					try {
-						$file = $resourceFactory->getFileObject($fileUid);
-
-						if (TRUE === $onlyProperties) {
-							$file = ResourceUtility::getFileArray($file);
-						}
-
-						$files[] = $file;
-					} catch (\Exception $e) {
-						continue;
-					}
-				}
-
-				return $files;
-			}
-		}
-
-		foreach ($identifier as $i) {
-			try {
-				if (TRUE === $treatIdAsUid) {
-					$file = $resourceFactory->getFileObject(intval($i));
-				} elseif (TRUE === $treatIdAsReference) {
-					$fileReference = $resourceFactory->getFileReferenceObject(intval($i));
-					$file = $fileReference->getOriginalFile();
-				} else {
-					$file = $resourceFactory->getFileObjectFromCombinedIdentifier($i);
-				}
-
-				if (TRUE === isset($fileUids) && FALSE === in_array($file->getUid(), $fileUids)) {
-					continue;
-				}
-
-				if (TRUE === $onlyProperties) {
-					$file = ResourceUtility::getFileArray($file);
-				}
-
-				$files[] = $file;
-			} catch (\Exception $e) {
-				continue;
-			}
-		}
-
-		return $files;
-	}
-
-	/**
-	 * Mixed argument with CSV, array, Traversable
-	 *
-	 * @param mixed $argument
-	 * @param string $name
-	 * @return array
-	 */
-	public function arrayForMixedArgument($argument, $name) {
-		if (NULL === $argument) {
-			$argument = $this->arguments[$name];
-		}
-
-		if (TRUE === $argument instanceof \Traversable) {
-			$argument = iterator_to_array($argument);
-		} elseif (TRUE === is_string($argument)) {
-			$argument = GeneralUtility::trimExplode(',', $argument, TRUE);
-		} else {
-			$argument = (array) $argument;
-		}
-
-		return $argument;
 	}
 
 }

--- a/Classes/ViewHelpers/Resource/FolderViewHelper.php
+++ b/Classes/ViewHelpers/Resource/FolderViewHelper.php
@@ -1,0 +1,62 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Vhs\Traits\ResourceViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
+use TYPO3\CMS\Core\Resource\Filter\FileExtensionFilter;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+/**
+ * ViewHelper to handle FAL folders, fetch all files of the given folders
+ * The identifier must be in the format '[fileStorageId]:/folder/subfolder/'
+ * Example identifier: 'file:1:/myFolder/' or '1:/myFolder/'
+ *
+ * @author Frank Rakow <frank.rakow@gestalten.de>, Gestaltende GmbH
+ * @package Vhs
+ * @subpackage ViewHelpers\Resource
+ */
+class FolderViewHelper extends AbstractTagBasedViewHelper {
+
+	use TemplateVariableViewHelperTrait;
+	use ResourceViewHelperTrait;
+
+	/**
+	 * Initialize arguments.
+	 *
+	 * @return void
+	 * @api
+	 */
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('identifier', 'mixed', 'The FAL combined identifiers (either CSV, array or implementing Traversable).', FALSE, NULL);
+		$this->registerArgument('recursive', 'boolean', 'If TRUE,then all files are fetched recursivly.', FALSE, FALSE);
+		$this->registerArgument('start', 'int', 'The item to start at.', FALSE, 0);
+		$this->registerArgument('numberOfItems', 'int', 'The number of items to return', FALSE, 0);
+		$this->registerArgument('filterExtensions', 'string', 'if not NULL, CSV of allowed file extensions.', FALSE, NULL);
+
+		$this->registerAsArgument();
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function render() {
+		$files = $this->getFilesOfFolders(TRUE);
+		if (1 === count($files)) {
+			$files = array_shift($files);
+		}
+		return $this->renderChildrenWithVariableOrReturnInput($files);
+	}
+
+
+
+}

--- a/Tests/Unit/ViewHelpers/Resource/FolderViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Resource/FolderViewHelperTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Resource;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * @protection on
+ * @author Claus Due <claus@namelesscoder.net>
+ * @author Frank Rakow <frank.rakow@gestalten.de>
+ * @package Vhs
+ */
+class FolderViewHelperTest extends AbstractViewHelperTest {
+
+	public function testRender() {
+		$this->assertEmpty($this->executeViewHelper());
+	}
+
+}


### PR DESCRIPTION
ViewHelper to handle FAL folders, fetch all files of the given folders.
An additional filter on file extensions can be used.
The identifier must be in the format '[fileStorageId]:/folder/subfolder/'
Example identifier: 'file:1:/myFolder/' or '1:/myFolder/'

Reorganize ```Classes/Resource/AbstractResourceViewHelper.php```. Move resource based code to Trait ```Classes/Traits/ResourceViewHelperTrait.php```

Added the method ```convertValueOrGetArgumentAsArray```to ```Classes/Traits/Trait ArrayConsumingViewHelperTrait```, formerly it was the method ```arrayForMixedArgument```from  ```Classes/Resource/AbstractResourceViewHelper.php```