### PR TITLE
[BUGFIX] Do not group by uid

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -172,7 +172,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 			$conditions .= ' AND sectionIndex = 1';
 		}
 
-		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', $conditions, 'uid', $order, $limit);
+		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', $conditions, '', $order, $limit);
 		return $rows;
 	}
 


### PR DESCRIPTION
Since uid is a unique field, it's not required to group it.
The query fails on other DBMS than MySQL due to the grouping.