### PR TITLE
[FEATURE] Add "whitespaceBetweenHtmlTags" option to EliminateViewhelper

### DIFF
--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -32,6 +32,7 @@ class EliminateViewHelper extends AbstractViewHelper {
 		$this->registerArgument('characters', 'mixed', "Characters to remove. Array or string, i.e. {0: 'a', 1: 'b', 2: 'c'} or 'abc' to remove all occurrences of a, b and c");
 		$this->registerArgument('strings', 'mixed', "Strings to remove. Array or CSV, i.e. {0: 'foo', 1: 'bar'} or 'foo,bar' to remove all occorrences of foo and bar. If your strings overlap then place the longest match first");
 		$this->registerArgument('whitespace', 'boolean', 'Eliminate ALL whitespace characters', FALSE, FALSE);
+		$this->registerArgument('whitespaceBetweenHtmlTags', 'boolean', 'Eliminate ALL whitespace characters between HTML tags', FALSE, FALSE);
 		$this->registerArgument('tabs', 'boolean', 'Eliminate only tab whitespaces', FALSE, FALSE);
 		$this->registerArgument('unixBreaks', 'boolean', 'Eliminate only UNIX line breaks', FALSE, FALSE);
 		$this->registerArgument('windowsBreaks', 'boolean', 'Eliminates only Windows carriage returns', FALSE, FALSE);
@@ -56,6 +57,9 @@ class EliminateViewHelper extends AbstractViewHelper {
 		}
 		if (TRUE === $this->arguments['whitespace']) {
 			$content = $this->eliminateWhitespace($content);
+		}
+		if (TRUE === $this->arguments['whitespaceBetweenHtmlTags']) {
+			$content = $this->eliminateWhitespaceBetweenHtmlTags($content);
 		}
 		if (TRUE === $this->arguments['tabs']) {
 			$content = $this->eliminateTabs($content);
@@ -128,6 +132,15 @@ class EliminateViewHelper extends AbstractViewHelper {
 	 */
 	protected function eliminateWhitespace($content) {
 		$content = preg_replace('/\s+/', '', $content);
+		return $content;
+	}
+
+	/**
+	 * @param string $content
+	 * @return string
+	 */
+	protected function eliminateWhitespaceBetweenHtmlTags($content) {
+		$content = trim(preg_replace('/>\s+</', '><', $content));
 		return $content;
 	}
 

--- a/Tests/Unit/ViewHelpers/Format/EliminateViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/EliminateViewHelperTest.php
@@ -114,6 +114,16 @@ class EliminateViewHelperTest extends AbstractViewHelperTest {
 	/**
 	 * @test
 	 */
+	public function removesWhitespaceBetweenHtmlTags() {
+		$arguments = $this->arguments;
+		$arguments['whitespaceBetweenHtmlTags'] = TRUE;
+		$test = $this->executeViewHelperUsingTagContent('Text', ' <p> Foo </p> <p> Bar </p> ', $arguments);
+		$this->assertSame('<p> Foo </p><p> Bar </p>', $test);
+	}
+
+	/**
+	 * @test
+	 */
 	public function removesCharactersRespectsCaseSensitive() {
 		$arguments = $this->arguments;
 		$arguments['characters'] = 'abc';


### PR DESCRIPTION
Removes whitespaces between HTML tags and is inspired by Twig's "spaceless Tag":
http://twig.sensiolabs.org/doc/tags/spaceless.html