### PR TITLE
[BUGFIX] AlternateViewHelper should include a link to current language

### DIFF
--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -91,9 +91,6 @@ class AlternateViewHelper extends AbstractViewHelper {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
 
-		$currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
-		unset($languages[$currentLanguageUid]);
-
 		/** @var UriBuilder $uriBuilder */
 		$uriBuilder = $this->controllerContext->getUriBuilder();
 		$uriBuilder = $uriBuilder->reset()


### PR DESCRIPTION
The hreflang link Tag should also include the current language. Right now it's deleted, but this is wrong behaviour.

From the [google docs](https://support.google.com/webmasters/answer/189077?hl=en): If you have multiple language versions of a URL, each language page must identify all language versions, **including itself**.