### PR TITLE
[BUGFIX] Do not hardcode menu backup variables

### DIFF
--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -21,11 +21,6 @@ use FluidTYPO3\Vhs\ViewHelpers\Page\Menu\AbstractMenuViewHelper;
 class BreadCrumbViewHelper extends AbstractMenuViewHelper {
 
 	/**
-	 * @var array
-	 */
-	protected $backups = array('rootLine');
-
-	/**
 	 * @return void
 	 */
 	public function initializeArguments() {
@@ -39,7 +34,6 @@ class BreadCrumbViewHelper extends AbstractMenuViewHelper {
 	 * @return string
 	 */
 	public function render() {
-		$this->backups = array($this->arguments['as']);
 		$pageUid = $this->arguments['pageUid'] > 0 ? $this->arguments['pageUid'] : $GLOBALS['TSFE']->id;
 		$entryLevel = $this->arguments['entryLevel'];
 		$endLevel = $this->arguments['endLevel'];

--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -34,11 +34,6 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 	/**
 	 * @var array
 	 */
-	protected $backups = array('menu', 'rootLine');
-
-	/**
-	 * @var array
-	 */
 	private $backupValues = array();
 
 	/**
@@ -596,7 +591,8 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 	 * @return void
 	 */
 	public function backupVariables() {
-		foreach ($this->backups as $var) {
+		$backups = array($this->arguments['as'], $this->arguments['rootLineAs']);
+		foreach ($backups as $var) {
 			if (TRUE === $this->templateVariableContainer->exists($var)) {
 				$this->backupValues[$var] = $this->templateVariableContainer->get($var);
 				$this->templateVariableContainer->remove($var);


### PR DESCRIPTION
The names of those variables can be set via view helper arguments so they should not be hardcoded.

Fix for #845.