### PR TITLE
[BUGFIX] Use the correct flag icon path depended on the current core version

### DIFF
--- a/Classes/Utility/CoreUtility.php
+++ b/Classes/Utility/CoreUtility.php
@@ -27,7 +27,7 @@ class CoreUtility {
 	 * @return string
 	 */
 	public static function getLanguageFlagIconPath() {
-		if (7.1 > (double)CoreUtility::getCurrentCoreVersion()) {
+		if (7.1 > (double)self::getCurrentCoreVersion()) {
 			return ExtensionManagementUtility::extPath('t3skin') . 'images/flags/';
 		} else {
 			return ExtensionManagementUtility::extPath('core') . 'Resources/Public/Icons/flags/';

--- a/Classes/Utility/CoreUtility.php
+++ b/Classes/Utility/CoreUtility.php
@@ -1,0 +1,47 @@
+<?php
+namespace FluidTYPO3\Vhs\Utility;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * Core Utility
+ *
+ * Utility to get core informations.
+ *
+ * @author Daniel Dorndorf <dorndorf@dreipunktnull.com>
+ * @package Vhs
+ * @subpackage Utility
+ */
+class CoreUtility {
+
+	/**
+	 * Returns the flag icons path depending on the current core version
+	 *
+	 * @return string
+	 */
+	public static function getLanguageFlagIconPath() {
+		if (7.1 > (double)CoreUtility::getCurrentCoreVersion()) {
+			return ExtensionManagementUtility::extPath('t3skin') . 'images/flags/';
+		} else {
+			return ExtensionManagementUtility::extPath('core') . 'Resources/Public/Icons/flags/';
+		}
+	}
+
+	/**
+	 * Returns the current core minor version
+	 *
+	 * @return string
+	 * @throws \TYPO3\CMS\Core\Package\Exception
+	 */
+	public static function getCurrentCoreVersion() {
+		return substr(ExtensionManagementUtility::getExtensionVersion('core'), 0, 3);
+	}
+
+}

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\CoreUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
@@ -59,7 +60,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper {
 		$this->registerArgument('hideNotTranslated', 'boolean', 'Hides languageIDs which are not translated', FALSE, FALSE);
 		$this->registerArgument('layout', 'string', 'How to render links when using autorendering. Possible selections: name,flag - use fx "name" or "flag,name" or "name,flag"', FALSE, 'flag,name');
 		$this->registerArgument('useCHash', 'boolean', 'Use cHash for typolink', FALSE, TRUE);
-		$this->registerArgument('flagPath', 'string', 'Overwrites the path to the flag folder', FALSE, 'typo3/sysext/t3skin/images/flags/');
+		$this->registerArgument('flagPath', 'string', 'Overwrites the path to the flag folder', FALSE, '');
 		$this->registerArgument('flagImageType', 'string', 'Sets type of flag image: png, gif, jpeg', FALSE, 'png');
 		$this->registerArgument('linkCurrent', 'boolean', 'Sets flag to link current language or not', FALSE, TRUE);
 		$this->registerArgument('classCurrent', 'string', 'Sets the class, by which the current language will be marked', FALSE, 'current');
@@ -151,7 +152,12 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper {
 	 * @return string
 	 */
 	protected function getLanguageFlagSrc($iso) {
-		$path = trim($this->arguments['flagPath']);
+		if ('' !== $this->arguments['flagPath']) {
+			$path = trim($this->arguments['flagPath']);
+		} else {
+			$path = CoreUtility::getLanguageFlagIconPath();
+		}
+
 		$imgType = trim($this->arguments['flagImageType']);
 		$img = $path . $iso . '.' . $imgType;
 		return $img;

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -112,7 +112,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper {
 			}
 			$imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($imageInfo[3]);
 			$GLOBALS['TSFE']->imagesOnPage[] = $imageInfo[3];
-			
+
 			if (TRUE === GeneralUtility::isValidUrl($imageInfo[3])) {
 				$imageSource = $imageInfo[3];
 			} else {


### PR DESCRIPTION
In TYPO3 7.1 the flag icons were moved, see: [TYPO3 7.1 Changes](http://wiki.typo3.org/TYPO3.CMS/Releases/7.1/Breaking#Breaking:_.2364143_-_Language_.2F_Country_Flag_files_moved)

Solves #854