### PR TITLE
[BUGFIX] Force overriding with overlay values

### DIFF
--- a/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/Menu/AbstractMenuViewHelper.php
@@ -428,9 +428,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper {
 		if (0 < $getLL) {
 			$pageOverlay = $this->pageSelect->getPageOverlay($overlayPageUid, $getLL);
 			foreach ($pageOverlay as $name => $value) {
-				if (FALSE === empty($value)) {
-					$page[$name] = $value;
-				}
+				$page[$name] = $value;
 			}
 		}
 


### PR DESCRIPTION
Currently overlay values are only used if not empty which leads to unexpected behavior regarding link title generation in menus. A page may provide values for nav_title *and* title in ``L=0`` but only for title in ``L=1`` resulting in a not translated menu item. I'm not aware of unwanted side effects but YMMV.