### PR TITLE
[TASK] Make Condition ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/Context/IsBackendViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsBackendViewHelper.php
@@ -39,21 +39,12 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsBackendViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		if (TRUE === $this->isBackendContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
-
-	/**
-	 * @return boolean
-	 */
-	protected function isBackendContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return ('BE' === TYPO3_MODE);
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
@@ -39,21 +39,12 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsCliViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		if (TRUE === $this->isCliContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
-
-	/**
-	 * @return boolean
-	 */
-	protected function isCliContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return defined('TYPO3_climode');
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
@@ -31,19 +31,13 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsDevelopmentViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isDevelopmentContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isDevelopmentContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isDevelopment();
 	}
+
 }

--- a/Classes/ViewHelpers/Condition/Context/IsFrontendViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsFrontendViewHelper.php
@@ -39,21 +39,12 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsFrontendViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		if ($this->isFrontendContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
-
-	/**
-	 * @return boolean
-	 */
-	protected function isFrontendContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return ('FE' === TYPO3_MODE);
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
@@ -31,19 +31,12 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsProductionViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isProductionContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isProductionContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isProduction();
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
@@ -31,19 +31,12 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsTestingViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isTestingContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isTestingContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isTesting();
 	}
 

--- a/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
@@ -8,9 +8,12 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Form;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Reflection\ReflectionService;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 
 /**
  * ### Form: Field Has Validator?
@@ -31,21 +34,9 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 	const ALTERNATE_FORM_VIEWHELPER_CLASSNAME = 'TYPO3\\CMS\\Fluid\\ViewHelpers\\FormViewHelper';
 
 	/**
-	 * Note: property name is "ownReflectionService" because "reflectionService"
-	 * is used by the parent class - but is, quite unfriendly and needlessly, set
-	 * with "private" access.
-	 *
 	 * @var ReflectionService
 	 */
-	protected $ownReflectionService;
-
-	/**
-	 * @param ReflectionService $reflectionService
-	 * @return void
-	 */
-	public function injectOwnReflectionService(ReflectionService $reflectionService) {
-		$this->ownReflectionService = $reflectionService;
-	}
+	static protected $staticReflectionService;
 
 	/**
 	 * Render
@@ -60,8 +51,40 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 	 * @return string
 	 */
 	public function render($property, $validatorName = NULL, DomainObjectInterface $object = NULL) {
+		return static::renderStatic(
+			array(
+				'property' => $property,
+				'validatorName' => $validatorName,
+				'object' => $object
+			),
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+
+		if (self::$staticReflectionService === NULL) {
+			$objectManager = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+			self::$staticReflectionService = $objectManager->get('TYPO3\CMS\Extbase\Reflection\ReflectionService');
+		}
+
+		$property = $arguments['property'];
+		$validatorName = isset($arguments['validatorName']) ? $arguments['validatorName'] : NULL;
+		$object = isset($arguments['object']) ? $arguments['object'] : NULL;
+
 		if (NULL === $object) {
-			$object = $this->getFormObject();
+			$object = self::getFormObject($renderingContext->getViewHelperVariableContainer());
 		}
 		$className = get_class($object);
 		if (FALSE !== strpos($property, '.')) {
@@ -70,7 +93,7 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 				if (TRUE === ctype_digit($property)) {
 					continue;
 				}
-				$annotations = $this->ownReflectionService->getPropertyTagValues($className, $property, 'var');
+				$annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, 'var');
 				$possibleClassName = array_pop($annotations);
 				if (FALSE !== strpos($possibleClassName, '<')) {
 					$className = array_pop(explode('<', trim($possibleClassName, '>')));
@@ -79,25 +102,27 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 				}
 			}
 		}
-		$annotations = $this->ownReflectionService->getPropertyTagValues($className, $property, 'validate');
+
+		$annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, 'validate');
+		$hasEvaluated = TRUE;
 		if (0 < count($annotations) && (NULL === $validatorName || TRUE === in_array($validatorName, $annotations))) {
-			return $this->renderThenChild();
+			return static::renderStaticThenChild($arguments, $hasEvaluated);
 		}
-		return $this->renderElseChild();
+		return static::renderStaticElseChild($arguments, $hasEvaluated);
 	}
 
 	/**
+	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
 	 * @param string $formClassName
 	 * @return DomainObjectInterface|NULL
 	 */
-	protected function getFormObject($formClassName = 'Tx_Fluid_ViewHelpers_FormViewHelper') {
-		if (TRUE === $this->viewHelperVariableContainer->exists($formClassName, 'formObject')) {
-			return $this->viewHelperVariableContainer->get($formClassName, 'formObject');
+	static protected function getFormObject($viewHelperVariableContainer, $formClassName = 'Tx_Fluid_ViewHelpers_FormViewHelper') {
+		if (TRUE === $viewHelperVariableContainer->exists($formClassName, 'formObject')) {
+			return $viewHelperVariableContainer->get($formClassName, 'formObject');
 		}
 		if (self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME !== $formClassName) {
-			return $this->getFormObject(self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME);
+			return self::getFormObject($viewHelperVariableContainer, self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME);
 		}
 		return NULL;
 	}
-
 }

--- a/Classes/ViewHelpers/Condition/Form/IsRequiredViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Form/IsRequiredViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Form;
  */
 
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * ### Is Field Required ViewHelper (condition)
@@ -24,19 +25,28 @@ use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 class IsRequiredViewHelper extends HasValidatorViewHelper {
 
 	/**
-	 * Render
-	 *
-	 * Renders the then-child if the property at $property of the
-	 * object at $object (or the associated form object if $object
-	 * is not specified)
-	 *
-	 * @param string $property The property name, dotted path supported, to determine required
-	 * @param DomainObjectInterface $object Optional object - if not specified, grabs the associated form object
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($property, DomainObjectInterface $object = NULL) {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('property', 'string', 'The property name, dotted path supported, to determine required', TRUE);
+		$this->registerArgument('object', 'DomainObjectInterface', 'Optional object - if not specified, grabs the associated form object', FALSE, NULL);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		$validatorName = 'NotEmpty';
-		return parent::render($property, $validatorName, $object);
+		$arguments['validatorName'] = 'NotEmpty';
+		return parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Iterator/ContainsViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Iterator/ContainsViewHelper.php
@@ -19,6 +19,10 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  * Condition ViewHelper. Renders the then-child if Iterator/array
  * haystack contains needle value.
  *
+ * ### Example:
+ *
+ *     {v:condition.iterator.contains(needle: 'foo', haystack: {0: 'foo'}, then: 'yes', else: 'no')}
+ *
  * @author Claus Due <claus@namelesscoder.net>
  * @package Vhs
  * @subpackage ViewHelpers\Condition\Iterator
@@ -40,32 +44,26 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	}
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		$haystack = $this->arguments['haystack'];
-		$needle = $this->arguments['needle'];
-
-		$this->evaluation = $this->assertHaystackHasNeedle($haystack, $needle);
-
-		if (FALSE !== $this->evaluation) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	static protected function evaluateCondition($arguments = NULL) {
+		$haystack = $arguments['haystack'];
+		$needle = $arguments['needle'];
+		return FALSE !== self::assertHaystackHasNeedle($haystack, $needle, $arguments);
 	}
 
 	/**
 	 * @param integer $index
 	 * @return mixed
 	 */
-	protected function getNeedleAtIndex($index) {
+	static protected function getNeedleAtIndex($index) {
 		if (0 > $index) {
 			return NULL;
 		}
-		$haystack = $this->arguments['haystack'];
+		$haystack = self::$arguments['haystack'];
 		$asArray = array();
 		if (TRUE === is_array($haystack)) {
 			$asArray = $haystack;
@@ -87,17 +85,18 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	/**
 	 * @param mixed $haystack
 	 * @param mixed $needle
+	 * @param array $arguments
 	 * @return boolean|integer
 	 */
-	protected function assertHaystackHasNeedle($haystack, $needle) {
+	static protected function assertHaystackHasNeedle($haystack, $needle, $arguments) {
 		if (TRUE === is_array($haystack)) {
-			return $this->assertHaystackIsArrayAndHasNeedle($haystack, $needle);
+			return self::assertHaystackIsArrayAndHasNeedle($haystack, $needle, $arguments);
 		} elseif ($haystack instanceof LazyObjectStorage) {
-			return $this->assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
+			return self::assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
 		} elseif ($haystack instanceof ObjectStorage) {
-			return $this->assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
+			return self::assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
 		} elseif ($haystack instanceof QueryResult) {
-			return $this->assertHaystackIsQueryResultAndHasNeedle($haystack, $needle);
+			return self::assertHaystackIsQueryResultAndHasNeedle($haystack, $needle);
 		} elseif (TRUE === is_string($haystack)) {
 			return strpos($haystack, $needle);
 		}
@@ -109,7 +108,7 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	 * @param mixed $needle
 	 * @return boolean|integer
 	 */
-	protected function assertHaystackIsQueryResultAndHasNeedle($haystack, $needle) {
+	static protected function assertHaystackIsQueryResultAndHasNeedle($haystack, $needle) {
 		if (TRUE === $needle instanceof DomainObjectInterface) {
 			/** @var $needle DomainObjectInterface */
 			$needle = $needle->getUid();
@@ -128,7 +127,7 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	 * @param mixed $needle
 	 * @return boolean|integer
 	 */
-	protected function assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle) {
+	static protected function assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle) {
 		$index = 0;
 		/** @var $candidate DomainObjectInterface */
 		if (TRUE === $needle instanceof AbstractDomainObject) {
@@ -146,11 +145,12 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	/**
 	 * @param mixed $haystack
 	 * @param mixed $needle
+	 * @param array $arguments
 	 * @return boolean|integer
 	 */
-	protected function assertHaystackIsArrayAndHasNeedle($haystack, $needle) {
+	static protected function assertHaystackIsArrayAndHasNeedle($haystack, $needle, $arguments) {
 		if (FALSE === $needle instanceof DomainObjectInterface) {
-			if (TRUE === (boolean) $this->arguments['considerKeys']) {
+			if (TRUE === (boolean) $arguments['considerKeys']) {
 				$result = (boolean) (FALSE !== array_search($needle, $haystack) || TRUE === isset($haystack[$needle]));
 			} else {
 				$result = array_search($needle, $haystack);
@@ -173,7 +173,7 @@ class ContainsViewHelper extends AbstractConditionViewHelper {
 	 * @param mixed $needle
 	 * @return boolean|integer
 	 */
-	protected function assertHaystackIsStringAndHasNeedle($haystack, $needle) {
+	static protected function assertHaystackIsStringAndHasNeedle($haystack, $needle) {
 		return strpos($haystack, $needle);
 	}
 

--- a/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
@@ -26,26 +26,34 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
 class IsChildPageViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param integer $pageUid
-	 * @param boolean $respectSiteRoot
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($pageUid = NULL, $respectSiteRoot = FALSE) {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('pageUid', 'integer', 'value to check', FALSE, NULL);
+		$this->registerArgument('respectSiteRoot', 'boolean', 'value to check', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		$pageUid = $arguments['pageUid'];
+		$respectSiteRoot = $arguments['respectSiteRoot'];
+
 		if (NULL === $pageUid || TRUE === empty($pageUid) || 0 === intval($pageUid)) {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
 		$pageSelect = new PageRepository();
 		$page = $pageSelect->getPage($pageUid);
+
 		if (TRUE === (boolean) $respectSiteRoot && TRUE === isset($page['is_siteroot']) && TRUE === (boolean) $page['is_siteroot']) {
-			return $this->renderElseChild();
+			return FALSE;
 		}
-		if (TRUE === isset($page['pid']) && 0 < $page['pid']) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === isset($page['pid']) && 0 < $page['pid'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
@@ -26,13 +26,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsLanguageViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $language
-	 * @param string $defaultTitle
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($language, $defaultTitle = 'en') {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('language', 'string', 'language to check', TRUE);
+		$this->registerArgument('defaultTitle', 'string', 'title of the default language', FALSE, 'en');
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		$language = $arguments['language'];
+		$defaultTitle = $arguments['defaultTitle'];
+
 		$currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
 		if (TRUE === is_numeric($language)) {
 			$languageUid = intval($language);
@@ -48,7 +59,7 @@ class IsLanguageViewHelper extends AbstractConditionViewHelper {
 				}
 			}
 		}
-		return ($languageUid === $currentLanguageUid ? $this->renderThenChild() : $this->renderElseChild());
+		return $languageUid === $currentLanguageUid;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
@@ -23,18 +23,22 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class ContainsViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param string $haystack
-	 * @param mixed $needle
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($haystack, $needle) {
-		if (FALSE !== strpos($haystack, $needle)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('haystack', 'string', 'haystack', TRUE);
+		$this->registerArgument('needle', 'string', 'need', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return FALSE !== strpos($arguments['haystack'], $arguments['needle']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
@@ -24,23 +24,27 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsLowercaseViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param string $string
-	 * @param boolean $fullString
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($string, $fullString = FALSE) {
-		if (TRUE === $fullString) {
-			$result = ctype_lower($string);
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('string', 'string', 'string to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		if (TRUE === $arguments['fullString']) {
+			$result = ctype_lower($arguments['string']);
 		} else {
-			$result = ctype_lower(substr($string, 0, 1));
+			$result = ctype_lower(substr($arguments['string'], 0, 1));
 		}
-		if (TRUE === $result) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $result;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsNumericViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === ctype_digit($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === ctype_digit($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
@@ -24,23 +24,27 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsUppercaseViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param string $string
-	 * @param boolean $fullString
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($string, $fullString = FALSE) {
-		if (TRUE === $fullString) {
-			$result = ctype_upper($string);
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('string', 'string', 'string to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		if (TRUE === $arguments['fullString']) {
+			$result = ctype_upper($arguments['string']);
 		} else {
-			$result = ctype_upper(substr($string, 0, 1));
+			$result = ctype_upper(substr($arguments['string'], 0, 1));
 		}
-		if (TRUE === $result) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $result;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
@@ -21,19 +21,22 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  * @subpackage ViewHelpers\Condition\Type
  */
 class IsArrayViewHelper extends AbstractConditionViewHelper {
+	/**
+	 * Initialize arguments
+	 */
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'string', 'value to check', TRUE);
+	}
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @param mixed $value
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render($value) {
-		if (TRUE === is_array($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	static protected function evaluateCondition($arguments = NULL) {
+		return (isset($arguments['value']) && (TRUE === is_array($arguments['value'])));
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
@@ -20,19 +20,22 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  * @subpackage ViewHelpers\Condition\Type
  */
 class IsBooleanViewHelper extends AbstractConditionViewHelper {
+	/**
+	 * Initialize arguments
+	 */
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @param mixed $value
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render($value) {
-		if (TRUE === is_bool($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_bool($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsDomainObjectViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsDomainObjectViewHelper.php
@@ -25,17 +25,22 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsDomainObjectViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof AbstractDomainObject) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof AbstractDomainObject;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsFloatViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_float($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_float($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsInstanceOfViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsInstanceOfViewHelper.php
@@ -23,18 +23,22 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsInstanceOfViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @param string $class
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value, $class) {
-		if (TRUE === $value instanceof $class) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+		$this->registerArgument('class', 'mixed', 'className to check against', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof $arguments['class'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsIntegerViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_integer($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_integer($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsObjectViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_object($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_object($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsQueryResultViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsQueryResultViewHelper.php
@@ -24,17 +24,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsQueryResultViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof QueryResultInterface) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof QueryResultInterface;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsStringViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_string($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_string($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsTraversableViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsTraversableViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsTraversableViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof \Traversable) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof \Traversable;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Variable/IsNullViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IsNullViewHelper.php
@@ -23,17 +23,21 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IsNullViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (NULL === $value) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'string', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return NULL === $arguments['value'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -34,16 +35,40 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IssetViewHelper extends AbstractConditionViewHelper {
 
 	/**
-	 * Renders else-child or else-argument if variable $name exists
-	 *
-	 * @param string $name
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($name) {
-		if (TRUE === $this->templateVariableContainer->exists($name)) {
-			return $this->renderThenChild();
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('name', 'string', 'name of the variable', TRUE);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$hasEvaluated = TRUE;
+		if (TRUE === $renderingContext->getTemplateVariableContainer()->exists($arguments['name'])) {
+			$result = static::renderStaticThenChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
+
+			return $renderChildrenClosure();
+		} else {
+			$result = static::renderStaticElseChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
 		}
-		return $this->renderElseChild();
+
+		return '';
 	}
 
 }

--- a/Classes/ViewHelpers/Extension/LoadedViewHelper.php
+++ b/Classes/ViewHelpers/Extension/LoadedViewHelper.php
@@ -17,6 +17,14 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  *
  * Condition to check if an extension is loaded.
  *
+ * ### Example:
+ *
+ *     {v:extension.loaded(extensionName: 'news', then: 'yes', else: 'no')}
+ *
+ *     <v:extension.loaded extensionName="news">
+ *         ...
+ *     </v:extension.loaded>
+ *
  * @author Claus Due <claus@namelesscoder.net>
  * @package Vhs
  * @subpackage ViewHelpers\Extension
@@ -32,19 +40,16 @@ class LoadedViewHelper extends AbstractConditionViewHelper {
 	}
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		$extensionName = $this->arguments['extensionName'];
+	static protected function evaluateCondition($arguments = NULL) {
+		$extensionName = $arguments['extensionName'];
 		$extensionKey = GeneralUtility::camelCaseToLowerCaseUnderscored($extensionName);
 		$isLoaded = ExtensionManagementUtility::isLoaded($extensionKey);
-		if (TRUE === $isLoaded) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $isLoaded;
 	}
 
 }

--- a/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Searches $haystack for index of $needle, returns -1 if $needle
@@ -21,15 +22,21 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class IndexOfViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
 	 *
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
 	 */
-	public function render() {
-		parent::render();
-		if (FALSE !== $this->evaluation) {
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$hasEvaluated = TRUE;
+		if (static::evaluateCondition($arguments)) {
 			return intval($this->evaluation);
 		}
+
 		return -1;
 	}
 

--- a/Classes/ViewHelpers/Iterator/NextViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/NextViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Returns next element in array $haystack from position of $needle
@@ -20,13 +21,22 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class NextViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
 	 *
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
 	 */
-	public function render() {
-		parent::render();
-		return $this->getNeedleAtIndex($this->evaluation !== FALSE ? $this->evaluation + 1 : -1);
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+
+		$haystack = $arguments['haystack'];
+		$needle = $arguments['needle'];
+		$evaluation = self::assertHaystackHasNeedle($haystack, $needle, $arguments);
+
+		return self::getNeedleAtIndex($evaluation !== FALSE ? $evaluation + 1 : -1);
 	}
 
 }

--- a/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Returns previous element in array $haystack from position of $needle
@@ -20,13 +21,22 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class PreviousViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
 	 *
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
 	 */
-	public function render() {
-		parent::render();
-		return $this->getNeedleAtIndex($this->evaluation !== FALSE ? $this->evaluation - 1 : -1);
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+
+		$haystack = $arguments['haystack'];
+		$needle = $arguments['needle'];
+		$evaluation = self::assertHaystackHasNeedle($haystack, $needle, $arguments);
+
+		return self::getNeedleAtIndex($evaluation !== FALSE ? $evaluation - 1 : -1);
 	}
 
 }

--- a/Classes/ViewHelpers/Media/ExistsViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExistsViewHelper.php
@@ -10,10 +10,19 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * File/Directory Exists Condition ViewHelper
+ *
+ * ### Example:
+ *
+ *     {v:media.exists(directory: 'fileadmin', then: 'yes', else: 'no')}
+ *
+ *     {v:media.exists(file: 'fileadmin/foo.png', then: 'yes', else: 'no')}
+ *
+ *     <v:media.exists file="fileadmin/foo.png">
+ *         show image, etc...
+ *     </v:media.exists>
  *
  * @author Claus Due <claus@namelesscoder.net>
  * @package Vhs
@@ -33,21 +42,6 @@ class ExistsViewHelper extends AbstractConditionViewHelper {
 	}
 
 	/**
-	 * Render method
-	 *
-	 * @return string
-	 */
-	public function render() {
-
-		$evaluation = static::evaluateCondition($this->arguments);
-
-		if (FALSE !== $evaluation) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
-
-	/**
 	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
 	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
@@ -56,13 +50,15 @@ class ExistsViewHelper extends AbstractConditionViewHelper {
 	static protected function evaluateCondition($arguments = NULL) {
 		$file = GeneralUtility::getFileAbsFileName($arguments['file']);
 		$directory = $arguments['directory'];
+
 		$evaluation = FALSE;
 		if (TRUE === isset($arguments['file'])) {
 			$evaluation = (boolean) ((TRUE === file_exists($file) || TRUE === file_exists(constant('PATH_site') . $file)) && TRUE === is_file($file));
 		} elseif (TRUE === isset($arguments['directory'])) {
 			$evaluation = (boolean) (TRUE === is_dir($directory) || TRUE === is_dir(constant('PATH_site') . $directory));
 		}
-		return $evaluation;
+
+		return FALSE !== $evaluation;
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsBackendViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsBackendViewHelperTest.php
@@ -36,8 +36,7 @@ class IsBackendViewHelperTest extends AbstractViewHelperTest {
 		$instance = $this->getMock($this->getViewHelperClassName(), array('isBackendContext'));
 		$instance->expects($this->once())->method('isBackendContext')->will($this->returnValue($verdict));
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsCliViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsCliViewHelperTest.php
@@ -36,8 +36,7 @@ class IsCliViewHelperTest extends AbstractViewHelperTest {
 		$instance = $this->getMock($this->getViewHelperClassName(), array('isCliContext'));
 		$instance->expects($this->once())->method('isCliContext')->will($this->returnValue($verdict));
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsFrontendViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsFrontendViewHelperTest.php
@@ -36,8 +36,7 @@ class IsFrontendViewHelperTest extends AbstractViewHelperTest {
 		$instance = $this->getMock($this->getViewHelperClassName(), array('isFrontendContext'));
 		$instance->expects($this->once())->method('isFrontendContext')->will($this->returnValue($verdict));
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper
stopped working since 7.3 because the AbstractConditionViewHelper
is now compiled statically by default which the extending classes
now need to do too in order for the conditions to properly work
in cached instances.

There are 2 still missing/broken, because they are using the TemplateVariableViewHelperTrait
which is used quite heavily thruought vhs and thus not that easy to fix:

- IfViewHelper
- Condition\String\PregViewHelper

fixes: https://github.com/FluidTYPO3/vhs/issues/893