### PR TITLE
[TASK] Make Condition/Context ViewHelpers static compilable

### DIFF
--- a/Classes/Traits/ConditionViewHelperTrait.php
+++ b/Classes/Traits/ConditionViewHelperTrait.php
@@ -1,0 +1,134 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * This trait can be used by viewhelpers that generate image tags
+ * to add srcsets based to the imagetag for better responsiveness
+ */
+trait ConditionViewHelperTrait {
+	/**
+	 * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+	 *
+	 * @return string the rendered string
+	 * @api
+	 */
+	public function render() {
+		if (static::evaluateCondition($this->arguments)) {
+			return $this->renderThenChild();
+		} else {
+			return $this->renderElseChild();
+		}
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * TODO: remove at some point, because this is only here for legacy reasons.
+	 * the AbstractConditionViewHelper in 6.2.* doesn't have a default render
+	 * method. 7.2+ on the other hand provides basically exactly this method here
+	 * luckily it's backwards compatible out of the box.
+	 * tl;dr -> remove after expiration of support for anything below 7.2
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext) {
+		$hasEvaluated = TRUE;
+		if (static::evaluateCondition($arguments)) {
+			$result = static::renderStaticThenChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
+
+			return $renderChildrenClosure();
+		} else {
+			$result = static::renderStaticElseChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Statically evalute "then" children.
+	 * The "$hasEvaluated" argument is there to distinguish the case that "then" returned NULL or was not evaluated.
+	 *
+	 * TODO: remove at some point, because this is only here for legacy reasons.
+	 * the AbstractConditionViewHelper in 6.2.* doesn't have a default render
+	 * method. 7.2+ on the other hand provides basically exactly this method here
+	 * luckily it's backwards compatible out of the box.
+	 * tl;dr -> remove after expiration of support for anything below 7.2
+	 *
+	 * @param array $arguments ViewHelper arguments
+	 * @param bool $hasEvaluated Can be used to check if the "then" child was actually evaluated by this method.
+	 * @return string
+	 */
+	static protected function renderStaticThenChild($arguments, &$hasEvaluated) {
+		if (isset($arguments['then'])) {
+			return $arguments['then'];
+		}
+		if (isset($arguments['__thenClosure'])) {
+			$thenClosure = $arguments['__thenClosure'];
+			return $thenClosure();
+		} elseif (isset($arguments['__elseClosure'])) {
+			return '';
+		}
+
+		$hasEvaluated = FALSE;
+	}
+
+	/**
+	 * Statically evalute "else" children.
+	 * The "$hasEvaluated" argument is there to distinguish the case that "else" returned NULL or was not evaluated.
+	 *
+	 * TODO: remove at some point, because this is only here for legacy reasons.
+	 * the AbstractConditionViewHelper in 6.2.* doesn't have a default render
+	 * method. 7.2+ on the other hand provides basically exactly this method here
+	 * luckily it's backwards compatible out of the box.
+	 * tl;dr -> remove after expiration of support for anything below 7.2
+	 *
+	 * @param array $arguments ViewHelper arguments
+	 * @param bool $hasEvaluated Can be used to check if the "else" child was actually evaluated by this method.
+	 * @return string
+	 */
+	static protected function renderStaticElseChild($arguments, &$hasEvaluated) {
+		if (isset($arguments['else'])) {
+			return $arguments['else'];
+		}
+		if (isset($arguments['__elseClosure'])) {
+			$elseClosure = $arguments['__elseClosure'];
+			return $elseClosure();
+		}
+
+		$hasEvaluated = FALSE;
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * TODO: remove at some point, because this is only here for legacy reasons.
+	 * the AbstractConditionViewHelper in 6.2.* doesn't have a default render
+	 * method. 7.2+ on the other hand provides basically exactly this method here
+	 * luckily it's backwards compatible out of the box.
+	 * tl;dr -> remove after expiration of support for anything below 7.2
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return (isset($arguments['condition']) && $arguments['condition']);
+	}
+}

--- a/Classes/ViewHelpers/Condition/Context/IsBackendViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsBackendViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Is context Backend?
@@ -38,22 +39,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsBackendViewHelper extends AbstractConditionViewHelper {
 
-	/**
-	 * Render method
-	 *
-	 * @return string
-	 */
-	public function render() {
-		if (TRUE === $this->isBackendContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
+	use ConditionViewHelperTrait;
 
 	/**
-	 * @return boolean
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	protected function isBackendContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return ('BE' === TYPO3_MODE);
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Is context CLI?
@@ -38,22 +39,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsCliViewHelper extends AbstractConditionViewHelper {
 
-	/**
-	 * Render method
-	 *
-	 * @return string
-	 */
-	public function render() {
-		if (TRUE === $this->isCliContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
+	use ConditionViewHelperTrait;
 
 	/**
-	 * @return boolean
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	protected function isCliContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return defined('TYPO3_climode');
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsDevelopmentViewHelper.php
@@ -11,6 +11,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
+
 /**
  * ### Context: IsDevelopment
  *
@@ -30,20 +32,16 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsDevelopmentViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isDevelopmentContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isDevelopmentContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isDevelopment();
 	}
+
 }

--- a/Classes/ViewHelpers/Condition/Context/IsFrontendViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsFrontendViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Is context Frontend?
@@ -38,22 +39,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsFrontendViewHelper extends AbstractConditionViewHelper {
 
-	/**
-	 * Render method
-	 *
-	 * @return string
-	 */
-	public function render() {
-		if ($this->isFrontendContext()) {
-			return $this->renderThenChild();
-		}
-		return $this->renderElseChild();
-	}
+	use ConditionViewHelperTrait;
 
 	/**
-	 * @return boolean
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	protected function isFrontendContext() {
+	static protected function evaluateCondition($arguments = NULL) {
 		return ('FE' === TYPO3_MODE);
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsProductionViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Context: IsProduction
@@ -30,20 +31,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsProductionViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isProductionContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isProductionContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isProduction();
 	}
 

--- a/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsTestingViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Context;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Context: IsProduction
@@ -30,20 +31,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsTestingViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render () {
-		return (TRUE === $this->isTestingContext() ? $this->renderThenChild() : $this->renderElseChild());
-	}
-
-
-	/**
-	 * @return boolean
-	 */
-	protected function isTestingContext () {
+	static protected function evaluateCondition($arguments = NULL) {
 		return GeneralUtility::getApplicationContext()->isTesting();
 	}
 

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -109,14 +109,14 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 	protected function buildViewHelperInstance($arguments = array(), $variables = array(), $childNode = NULL, $extensionName = NULL, $pluginName = NULL) {
 		$instance = $this->createInstance();
 		$node = new ViewHelperNode($instance, $arguments);
-		/** @var RenderingContext $renderingContext */
-		$renderingContext = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\Rendering\\RenderingContext');
+		/** @var RenderingContext $this->renderingContext */
+		$this->renderingContext = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\Rendering\\RenderingContext');
 		/** @var TemplateVariableContainer $container */
 		$container = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\ViewHelper\\TemplateVariableContainer');
 		if (0 < count($variables)) {
 			ObjectAccess::setProperty($container, 'variables', $variables, TRUE);
 		}
-		ObjectAccess::setProperty($renderingContext, 'templateVariableContainer', $container, TRUE);
+		ObjectAccess::setProperty($this->renderingContext, 'templateVariableContainer', $container, TRUE);
 		if (NULL !== $extensionName || NULL !== $pluginName) {
 			/** @var ViewHelperVariableContainer $viewHelperContainer */
 			$viewHelperContainer = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\ViewHelper\\ViewHelperVariableContainer');
@@ -137,8 +137,8 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 			$controllerContext->setRequest($request);
 			$controllerContext->setResponse($response);
 			$controllerContext->setUriBuilder($uriBuilder);
-			ObjectAccess::setProperty($renderingContext, 'viewHelperVariableContainer', $viewHelperContainer, TRUE);
-			$renderingContext->setControllerContext($controllerContext);
+			ObjectAccess::setProperty($this->renderingContext, 'viewHelperVariableContainer', $viewHelperContainer, TRUE);
+			$this->renderingContext->setControllerContext($controllerContext);
 		}
 		if (TRUE === $instance instanceof \Tx_Fluidwidget_Core_Widget_AbstractWidgetViewHelper) {
 			/** @var WidgetContext $widgetContext */
@@ -152,7 +152,7 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 			}
 		}
 		$instance->setArguments($arguments);
-		$instance->setRenderingContext($renderingContext);
+		$instance->setRenderingContext($this->renderingContext);
 		$instance->setViewHelperNode($node);
 		return $instance;
 	}
@@ -169,6 +169,21 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 		$instance = $this->buildViewHelperInstance($arguments, $variables, $childNode, $extensionName, $pluginName);
 		$output = $instance->initializeArgumentsAndRender();
 		return $output;
+	}
+
+	/**
+	 * @param array $arguments
+	 * @param array $variables
+	 * @param NodeInterface $childNode
+	 * @param string $extensionName
+	 * @param string $pluginName
+	 * @return mixed
+	 */
+	protected function executeViewHelperStatic($arguments = array(), $variables = array(), $childNode = NULL, $extensionName = NULL, $pluginName = NULL) {
+		$instance = $this->buildViewHelperInstance($arguments, $variables, $childNode, $extensionName, $pluginName);
+
+		$viewHelperClassName = $this->getViewHelperClassName();
+		return $viewHelperClassName::renderStatic($arguments, function(){}, $this->renderingContext);
 	}
 
 	/**

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsBackendViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsBackendViewHelperTest.php
@@ -22,33 +22,20 @@ class IsBackendViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function testIsBackendContext() {
 		$instance = $this->createInstance();
-		$result = $this->callInaccessibleMethod($instance, 'isBackendContext');
+		$result = $this->callInaccessibleMethod($instance, 'evaluateCondition');
 		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
 	}
 
 	/**
 	 * @test
-	 * @dataProvider getRenderTestValues
-	 * @param boolean $verdict
-	 * @param boolean $expected
 	 */
-	public function testRender($verdict, $expected) {
-		$instance = $this->getMock($this->getViewHelperClassName(), array('isBackendContext'));
-		$instance->expects($this->once())->method('isBackendContext')->will($this->returnValue($verdict));
+	public function testRender() {
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals(TRUE, $result);
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(FALSE, FALSE),
-			array(TRUE, TRUE),
-		);
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsCliViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsCliViewHelperTest.php
@@ -22,33 +22,20 @@ class IsCliViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function testIsCliContext() {
 		$instance = $this->createInstance();
-		$result = $this->callInaccessibleMethod($instance, 'isCliContext');
+		$result = $this->callInaccessibleMethod($instance, 'evaluateCondition');
 		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
 	}
 
 	/**
 	 * @test
-	 * @dataProvider getRenderTestValues
-	 * @param boolean $verdict
-	 * @param boolean $expected
 	 */
-	public function testRender($verdict, $expected) {
-		$instance = $this->getMock($this->getViewHelperClassName(), array('isCliContext'));
-		$instance->expects($this->once())->method('isCliContext')->will($this->returnValue($verdict));
+	public function testRender() {
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals(FALSE, $result);
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(FALSE, FALSE),
-			array(TRUE, TRUE),
-		);
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsDevelopmentViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsDevelopmentViewHelperTest.php
@@ -18,7 +18,12 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 class IsDevelopmentViewHelperTest extends AbstractViewHelperTest {
 
 	public function testRender() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else')));
+		$arguments = array('then' => 'then', 'else' => 'else');
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsFrontendViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsFrontendViewHelperTest.php
@@ -22,33 +22,20 @@ class IsFrontendViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function testIsFrontendContext() {
 		$instance = $this->createInstance();
-		$result = $this->callInaccessibleMethod($instance, 'isFrontendContext');
+		$result = $this->callInaccessibleMethod($instance, 'evaluateCondition');
 		$this->assertThat($result, new \PHPUnit_Framework_Constraint_IsType(\PHPUnit_Framework_Constraint_IsType::TYPE_BOOL));
 	}
 
 	/**
 	 * @test
-	 * @dataProvider getRenderTestValues
-	 * @param boolean $verdict
-	 * @param boolean $expected
 	 */
-	public function testRender($verdict, $expected) {
-		$instance = $this->getMock($this->getViewHelperClassName(), array('isFrontendContext'));
-		$instance->expects($this->once())->method('isFrontendContext')->will($this->returnValue($verdict));
+	public function testRender() {
 		$arguments = array('then' => TRUE, 'else' => FALSE);
-		$instance->setArguments($arguments);
-		$result = $instance->render();
-		$this->assertEquals($expected, $result);
-	}
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals(FALSE, $result);
 
-	/**
-	 * @return array
-	 */
-	public function getRenderTestValues() {
-		return array(
-			array(FALSE, FALSE),
-			array(TRUE, TRUE),
-		);
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsProductionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsProductionViewHelperTest.php
@@ -18,7 +18,12 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 class IsProductionViewHelperTest extends AbstractViewHelperTest {
 
 	public function testRender() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else')));
+		$arguments = array('then' => 'then', 'else' => 'else');
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Context/IsTestingViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Context/IsTestingViewHelperTest.php
@@ -18,7 +18,12 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 class IsTestingViewHelperTest extends AbstractViewHelperTest {
 
 	public function testRender() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else')));
+		$arguments = array('then' => 'then', 'else' => 'else');
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper stopped working since 7.3 because the AbstractConditionViewHelper is now compiled statically by default. Any ConditionViewHelper that implements it's own render method without taking compiling into account currently simple fail by showing their "false/else" result as soon as they are executed from cache. Non-cached execution still works, which makes this problem a bit weird to catch. Aside from fixing the ViewHelpers itself the testcases are updated to verify, that the effected viewHelpers render/work the same in cached and uncached
context.