### PR TITLE
[TASK] Make Condition/String ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\String;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: String contains substring
@@ -22,19 +23,25 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class ContainsViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param string $haystack
-	 * @param mixed $needle
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($haystack, $needle) {
-		if (FALSE !== strpos($haystack, $needle)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('haystack', 'string', 'haystack', TRUE);
+		$this->registerArgument('needle', 'string', 'need', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return FALSE !== strpos($arguments['haystack'], $arguments['needle']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\String;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: String is lowercase
@@ -23,24 +24,30 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsLowercaseViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param string $string
-	 * @param boolean $fullString
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($string, $fullString = FALSE) {
-		if (TRUE === $fullString) {
-			$result = ctype_lower($string);
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('string', 'string', 'string to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		if (TRUE === $arguments['fullString']) {
+			$result = ctype_lower($arguments['string']);
 		} else {
-			$result = ctype_lower(substr($string, 0, 1));
+			$result = ctype_lower(substr($arguments['string'], 0, 1));
 		}
-		if (TRUE === $result) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $result;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\String;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is numeric
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsNumericViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === ctype_digit($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === ctype_digit($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\String;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: String is lowercase
@@ -23,24 +24,30 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsUppercaseViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param string $string
-	 * @param boolean $fullString
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($string, $fullString = FALSE) {
-		if (TRUE === $fullString) {
-			$result = ctype_upper($string);
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('string', 'string', 'string to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		if (TRUE === $arguments['fullString']) {
+			$result = ctype_upper($arguments['string']);
 		} else {
-			$result = ctype_upper(substr($string, 0, 1));
+			$result = ctype_upper(substr($arguments['string'], 0, 1));
 		}
-		if (TRUE === $result) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $result;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/String/PregViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/PregViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\String;
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: String matches regular expression
@@ -26,28 +27,80 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class PregViewHelper extends AbstractConditionViewHelper {
 
 	use TemplateVariableViewHelperTrait;
+	use ConditionViewHelperTrait;
 
 	/**
-	 * Render method
-	 *
-	 * @param string $pattern
-	 * @param string $string
-	 * @param boolean $global
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($pattern, $string, $global = FALSE) {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('pattern', 'string', 'regex pattern to match string against', TRUE);
+		$this->registerArgument('string', 'string', 'string to match with the regex pattern', TRUE);
+		$this->registerArgument('global', 'boolean', 'match global', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
 		$matches = array();
-		if (TRUE === (boolean) $global) {
-			preg_match_all($pattern, $string, $matches, PREG_SET_ORDER);
+		if (TRUE === (boolean) $arguments['global']) {
+			preg_match_all($arguments['pattern'], $arguments['string'], $matches, PREG_SET_ORDER);
 		} else {
-			preg_match($pattern, $string, $matches);
+			preg_match($arguments['pattern'], $arguments['string'], $matches);
 		}
-		if (0 < count($matches)) {
+		return 0 < count($matches);
+	}
+
+	/**
+	 * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+	 *
+	 * @return string the rendered string
+	 * @api
+	 */
+	public function render() {
+		if (static::evaluateCondition($this->arguments)) {
 			$content = $this->renderThenChild();
 		} else {
 			$content = $this->renderElseChild();
 		}
 		return $this->renderChildrenWithVariableOrReturnInput($content);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * TODO: remove at some point, because this is only here for legacy reasons.
+	 * the AbstractConditionViewHelper in 6.2.* doesn't have a default render
+	 * method. 7.2+ on the other hand provides basically exactly this method here
+	 * luckily it's backwards compatible out of the box.
+	 * tl;dr -> remove after expiration of support for anything below 7.2
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext) {
+		$hasEvaluated = TRUE;
+		$content = '';
+		if (static::evaluateCondition($arguments)) {
+			$result = static::renderStaticThenChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				$content = $result;
+			}
+		} else {
+			$result = static::renderStaticElseChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				$content = $result;
+			}
+		}
+		return self::renderChildrenWithVariableOrReturnInputStatic($content, $arguments['as'], $renderingContext, $renderChildrenClosure);
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -182,8 +182,15 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 	protected function executeViewHelperStatic($arguments = array(), $variables = array(), $childNode = NULL, $extensionName = NULL, $pluginName = NULL) {
 		$instance = $this->buildViewHelperInstance($arguments, $variables, $childNode, $extensionName, $pluginName);
 
+		if ($childNode !== NULL) {
+			$childClosure = function() use ($childNode) {
+				return $childNode->evaluate($this->renderingContext);
+			};
+		} else {
+			$childClosure = function() {};
+		}
 		$viewHelperClassName = $this->getViewHelperClassName();
-		return $viewHelperClassName::renderStatic($arguments, function(){}, $this->renderingContext);
+		return $viewHelperClassName::renderStatic($arguments, $childClosure, $this->renderingContext);
 	}
 
 	/**
@@ -200,6 +207,26 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 		$instance = $this->buildViewHelperInstance($arguments, $variables, $childNode, $extensionName, $pluginName);
 		$output = $instance->initializeArgumentsAndRender();
 		return $output;
+	}
+
+	/**
+	 * @param string $nodeType
+	 * @param mixed $nodeValue
+	 * @param array $arguments
+	 * @param array $variables
+	 * @param string $extensionName
+	 * @param string $pluginName
+	 * @return mixed
+	 */
+	protected function executeViewHelperUsingTagContentStatic($nodeType, $nodeValue, $arguments = array(), $variables = array(), $extensionName = NULL, $pluginName = NULL) {
+		$childNode = $this->createNode($nodeType, $nodeValue);
+		$instance = $this->buildViewHelperInstance($arguments, $variables, $childNode, $extensionName, $pluginName);
+
+		$childClosure = function() use ($childNode) {
+			return $childNode->evaluate($this->renderingContext);
+		};
+		$viewHelperClassName = $this->getViewHelperClassName();
+		return $viewHelperClassName::renderStatic($arguments, $childClosure, $this->renderingContext);
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/String/ContainsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/String/ContainsViewHelperTest.php
@@ -21,14 +21,34 @@ class ContainsViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'haystack' => 'foobar', 'needle' => 'bar')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'haystack' => 'foobar',
+			'needle' => 'bar'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'haystack' => 'foobar', 'needle' => 'baz')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'haystack' => 'foobar',
+			'needle' => 'baz'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/String/IsLowercaseViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/String/IsLowercaseViewHelperTest.php
@@ -21,28 +21,68 @@ class IsLowercaseViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfFirstCharacterIsLowercase() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foobar', 'fullString' => FALSE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foobar',
+			'fullString' => FALSE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersThenChildIfAllCharactersAreLowercase() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foobar', 'fullString' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foobar',
+			'fullString' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfFirstCharacterIsNotLowercase() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'FooBar', 'fullString' => FALSE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'FooBar',
+			'fullString' => FALSE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfAllCharactersAreNotLowercase() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'fooBar', 'fullString' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'fooBar',
+			'fullString' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/String/IsNumericViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/String/IsNumericViewHelperTest.php
@@ -21,14 +21,32 @@ class IsNumericViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => '123')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+		 	'value' => '123'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 'z123')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 'z123'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/String/IsUppercaseViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/String/IsUppercaseViewHelperTest.php
@@ -21,28 +21,68 @@ class IsUppercaseViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfFirstCharacterIsUppercase() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'Foobar', 'fullString' => FALSE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'Foobar',
+			'fullString' => FALSE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersThenChildIfAllCharactersAreUppercase() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'FOOBAR', 'fullString' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'FOOBAR',
+			'fullString' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfFirstCharacterIsNotUppercase() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'fooBar', 'fullString' => FALSE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'fooBar',
+			'fullString' => FALSE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfAllCharactersAreNotUppercase() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'FooBar', 'fullString' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'FooBar',
+			'fullString' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/String/PregViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/String/PregViewHelperTest.php
@@ -21,35 +21,86 @@ class PregViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foo123bar', 'pattern' => '/([0-9]+)/i')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foo123bar',
+			'pattern' => '/([0-9]+)/i'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foobar', 'pattern' => '/[0-9]+/i')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foobar',
+			'pattern' => '/[0-9]+/i'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatchedAndGlobalEnabled() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foo123bar', 'pattern' => '/([0-9]+)/i')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foo123bar',
+			'pattern' => '/([0-9]+)/i'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatchedAndGlobalEnabled() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'string' => 'foobar', 'pattern' => '/[0-9]+/i', 'global' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'string' => 'foobar',
+			'pattern' => '/[0-9]+/i',
+			'global' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersTagContentWhenConditionMatchedAndAsArgumentUsed() {
-		$this->assertEquals('test', $this->executeViewHelperUsingTagContent('Text', 'test', array('string' => 'foo123bar', 'pattern' => '/[0-9]+/', 'global' => TRUE, 'as' => 'dummy'), array('dummy' => 'test')));
+		$arguments = array(
+			'string' => 'foo123bar',
+			'pattern' => '/[0-9]+/',
+			'global' => TRUE, 'as' => 'dummy'
+		);
+		$variables = array('dummy' => 'test');
+		$result = $this->executeViewHelperUsingTagContent('Text', 'test', $arguments, $variables);
+		$this->assertEquals('test', $result);
+
+		$staticResult = $this->executeViewHelperUsingTagContentStatic('Text', 'test', $arguments, $variables);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper
stopped working since 7.3 because the AbstractConditionViewHelper
is now compiled statically by default. Any ConditionViewHelper that implements
it's own render method without taking compiling into account currently
simple fail by showing their "false/else" result as soon as they are
executed from cache. Non-cached execution still works, which
makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify,
that the effected viewHelpers render/work the same in cached and uncached
context.

followup of: https://github.com/FluidTYPO3/vhs/pull/906