### PR TITLE
[TASK] Make Condition/Form ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
@@ -8,9 +8,13 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Form;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Reflection\ReflectionService;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Form: Field Has Validator?
@@ -25,27 +29,17 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class HasValidatorViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
 	 * @var string
 	 */
 	const ALTERNATE_FORM_VIEWHELPER_CLASSNAME = 'TYPO3\\CMS\\Fluid\\ViewHelpers\\FormViewHelper';
 
 	/**
-	 * Note: property name is "ownReflectionService" because "reflectionService"
-	 * is used by the parent class - but is, quite unfriendly and needlessly, set
-	 * with "private" access.
-	 *
 	 * @var ReflectionService
 	 */
-	protected $ownReflectionService;
-
-	/**
-	 * @param ReflectionService $reflectionService
-	 * @return void
-	 */
-	public function injectOwnReflectionService(ReflectionService $reflectionService) {
-		$this->ownReflectionService = $reflectionService;
-	}
+	static protected $staticReflectionService;
 
 	/**
 	 * Render
@@ -60,8 +54,36 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 	 * @return string
 	 */
 	public function render($property, $validatorName = NULL, DomainObjectInterface $object = NULL) {
+		return static::renderStatic(
+			$this->arguments,
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+
+		if (self::$staticReflectionService === NULL) {
+			$objectManager = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+			self::$staticReflectionService = $objectManager->get('TYPO3\CMS\Extbase\Reflection\ReflectionService');
+		}
+
+		$property = $arguments['property'];
+		$validatorName = isset($arguments['validatorName']) ? $arguments['validatorName'] : NULL;
+		$object = isset($arguments['object']) ? $arguments['object'] : NULL;
+
 		if (NULL === $object) {
-			$object = $this->getFormObject();
+			$object = self::getFormObject($renderingContext->getViewHelperVariableContainer());
 		}
 		$className = get_class($object);
 		if (FALSE !== strpos($property, '.')) {
@@ -70,7 +92,7 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 				if (TRUE === ctype_digit($property)) {
 					continue;
 				}
-				$annotations = $this->ownReflectionService->getPropertyTagValues($className, $property, 'var');
+				$annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, 'var');
 				$possibleClassName = array_pop($annotations);
 				if (FALSE !== strpos($possibleClassName, '<')) {
 					$className = array_pop(explode('<', trim($possibleClassName, '>')));
@@ -79,25 +101,27 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper {
 				}
 			}
 		}
-		$annotations = $this->ownReflectionService->getPropertyTagValues($className, $property, 'validate');
+
+		$annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, 'validate');
+		$hasEvaluated = TRUE;
 		if (0 < count($annotations) && (NULL === $validatorName || TRUE === in_array($validatorName, $annotations))) {
-			return $this->renderThenChild();
+			return static::renderStaticThenChild($arguments, $hasEvaluated);
 		}
-		return $this->renderElseChild();
+		return static::renderStaticElseChild($arguments, $hasEvaluated);
 	}
 
 	/**
+	 * @param ViewHelperVariableContainer $viewHelperVariableContainer
 	 * @param string $formClassName
 	 * @return DomainObjectInterface|NULL
 	 */
-	protected function getFormObject($formClassName = 'Tx_Fluid_ViewHelpers_FormViewHelper') {
-		if (TRUE === $this->viewHelperVariableContainer->exists($formClassName, 'formObject')) {
-			return $this->viewHelperVariableContainer->get($formClassName, 'formObject');
+	static protected function getFormObject($viewHelperVariableContainer, $formClassName = 'Tx_Fluid_ViewHelpers_FormViewHelper') {
+		if (TRUE === $viewHelperVariableContainer->exists($formClassName, 'formObject')) {
+			return $viewHelperVariableContainer->get($formClassName, 'formObject');
 		}
 		if (self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME !== $formClassName) {
-			return $this->getFormObject(self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME);
+			return self::getFormObject($viewHelperVariableContainer, self::ALTERNATE_FORM_VIEWHELPER_CLASSNAME);
 		}
 		return NULL;
 	}
-
 }

--- a/Classes/ViewHelpers/Condition/Form/IsRequiredViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Form/IsRequiredViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Form;
  */
 
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * ### Is Field Required ViewHelper (condition)
@@ -24,19 +25,18 @@ use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 class IsRequiredViewHelper extends HasValidatorViewHelper {
 
 	/**
-	 * Render
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
 	 *
-	 * Renders the then-child if the property at $property of the
-	 * object at $object (or the associated form object if $object
-	 * is not specified)
-	 *
-	 * @param string $property The property name, dotted path supported, to determine required
-	 * @param DomainObjectInterface $object Optional object - if not specified, grabs the associated form object
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
 	 */
-	public function render($property, DomainObjectInterface $object = NULL) {
-		$validatorName = 'NotEmpty';
-		return parent::render($property, $validatorName, $object);
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$arguments['validatorName'] = 'NotEmpty';
+		return parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Form/HasValidatorViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Form/HasValidatorViewHelperTest.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Condition\Form;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Tests\Fixtures\Domain\Model\Bar;
+use FluidTYPO3\Vhs\Tests\Fixtures\Domain\Model\Foo;
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 
 /**
@@ -17,4 +19,93 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
  */
 class HasValidatorViewHelperTest extends AbstractViewHelperTest {
 
+	public function testRenderThenWithSingleProperty() {
+		$domainObject = new Foo();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderElseWithSingleProperty() {
+		$domainObject = new Foo();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderThenWithNestedSingleProperty() {
+		$domainObject = new Bar();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'foo.bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderElseWithNestedSingleProperty() {
+		$domainObject = new Bar();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'foo.foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderThenWithNestedMultiProperty() {
+		$domainObject = new Bar();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'bars.bar.foo.bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderElseWithNestedMultiProperty() {
+		$domainObject = new Bar();
+		$arguments = array(
+			'validatorName' => 'NotEmpty',
+			'property' => 'bars.foo.foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
 }

--- a/Tests/Unit/ViewHelpers/Condition/Form/IsRequiredViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Form/IsRequiredViewHelperTest.php
@@ -21,38 +21,86 @@ class IsRequiredViewHelperTest extends AbstractViewHelperTest {
 
 	public function testRenderThenWithSingleProperty() {
 		$domainObject = new Foo();
-		$result = $this->executeViewHelper(array('property' => 'bar', 'object' => $domainObject, 'then' => 'then'));
+		$arguments = array(
+			'property' => 'bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	public function testRenderElseWithSingleProperty() {
 		$domainObject = new Foo();
-		$result = $this->executeViewHelper(array('property' => 'foo', 'object' => $domainObject, 'else' => 'else'));
+		$arguments = array(
+			'property' => 'foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	public function testRenderThenWithNestedSingleProperty() {
 		$domainObject = new Bar();
-		$result = $this->executeViewHelper(array('property' => 'foo.bar', 'object' => $domainObject, 'then' => 'then'));
+		$arguments = array(
+			'property' => 'foo.bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	public function testRenderElseWithNestedSingleProperty() {
 		$domainObject = new Bar();
-		$result = $this->executeViewHelper(array('property' => 'foo.foo', 'object' => $domainObject, 'else' => 'else'));
+		$arguments = array(
+			'property' => 'foo.foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	public function testRenderThenWithNestedMultiProperty() {
 		$domainObject = new Bar();
-		$result = $this->executeViewHelper(array('property' => 'bars.bar.foo.bar', 'object' => $domainObject, 'then' => 'then'));
+		$arguments = array(
+			'property' => 'bars.bar.foo.bar',
+			'object' => $domainObject,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	public function testRenderElseWithNestedMultiProperty() {
 		$domainObject = new Bar();
-		$result = $this->executeViewHelper(array('property' => 'bars.foo.foo', 'object' => $domainObject, 'else' => 'else'));
+		$arguments = array(
+			'property' => 'bars.foo.foo',
+			'object' => $domainObject,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper stopped working since 7.3 because the AbstractConditionViewHelper is now compiled statically by default. Any ConditionViewHelper that implements it's own render method without taking compiling into account currently
simple fail by showing their "false/else" result as soon as they are executed from cache. Non-cached execution still works, which makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify, that the effected viewHelpers render/work the same in cached and uncached context.

followup of: https://github.com/FluidTYPO3/vhs/pull/906