### PR TITLE
[TASK] Make Condition/Iterator ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Searches $haystack for index of $needle, returns -1 if $needle
@@ -21,14 +22,33 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class IndexOfViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Render
 	 *
 	 * @return string
 	 */
 	public function render() {
-		parent::render();
-		if (FALSE !== $this->evaluation) {
-			return intval($this->evaluation);
+		return static::renderStatic(
+			$this->arguments,
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$evaluation = self::assertHaystackHasNeedle($arguments['haystack'], $arguments['needle'], $arguments);
+
+		if (FALSE !== $evaluation) {
+			return intval($evaluation);
 		}
 		return -1;
 	}

--- a/Classes/ViewHelpers/Iterator/NextViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/NextViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Returns next element in array $haystack from position of $needle
@@ -20,13 +21,31 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class NextViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Render
 	 *
 	 * @return string
 	 */
 	public function render() {
-		parent::render();
-		return $this->getNeedleAtIndex($this->evaluation !== FALSE ? $this->evaluation + 1 : -1);
+		return static::renderStatic(
+			$this->arguments,
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$evaluation = self::assertHaystackHasNeedle($arguments['haystack'], $arguments['needle'], $arguments);
+		return self::getNeedleAtIndex($evaluation !== FALSE ? $evaluation + 1 : -1, $arguments);
 	}
 
 }

--- a/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Returns previous element in array $haystack from position of $needle
@@ -20,13 +21,31 @@ use FluidTYPO3\Vhs\ViewHelpers\Condition\Iterator\ContainsViewHelper;
 class PreviousViewHelper extends ContainsViewHelper {
 
 	/**
-	 * Render method
+	 * Render
 	 *
 	 * @return string
 	 */
 	public function render() {
-		parent::render();
-		return $this->getNeedleAtIndex($this->evaluation !== FALSE ? $this->evaluation - 1 : -1);
+		return static::renderStatic(
+			$this->arguments,
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$evaluation = self::assertHaystackHasNeedle($arguments['haystack'], $arguments['needle'], $arguments);
+		return self::getNeedleAtIndex($evaluation !== FALSE ? $evaluation - 1 : -1, $arguments);
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Iterator/ContainsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Iterator/ContainsViewHelperTest.php
@@ -29,8 +29,16 @@ class ContainsViewHelperTest extends AbstractViewHelperTest {
 	 * @param mixed $needle
 	 */
 	public function testRendersThen($haystack, $needle) {
-		$result = $this->executeViewHelper(array('haystack' => $haystack, 'needle' => $needle, 'then' => 'then'));
+		$arguments = array(
+			'haystack' => $haystack,
+			'needle' => $needle,
+			'then' => 'then'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -63,8 +71,16 @@ class ContainsViewHelperTest extends AbstractViewHelperTest {
 	 * @param mixed $needle
 	 */
 	public function testRendersElse($haystack, $needle) {
-		$result = $this->executeViewHelper(array('haystack' => $haystack, 'needle' => $needle, 'else' => 'else'));
+		$arguments = array(
+			'haystack' => $haystack,
+			'needle' => $needle,
+			'else' => 'else'
+		);
+		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**

--- a/Tests/Unit/ViewHelpers/Iterator/IndexOfViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/IndexOfViewHelperTest.php
@@ -26,8 +26,11 @@ class IndexOfViewHelperTest extends AbstractViewHelperTest {
 			'haystack' => $array,
 			'needle' => 'c',
 		);
-		$output = $this->executeViewHelper($arguments);
-		$this->assertEquals(2, $output);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals(2, $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -39,8 +42,11 @@ class IndexOfViewHelperTest extends AbstractViewHelperTest {
 			'haystack' => $array,
 			'needle' => 'd',
 		);
-		$output = $this->executeViewHelper($arguments);
-		$this->assertEquals(-1, $output);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals(-1, $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Iterator/NextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/NextViewHelperTest.php
@@ -27,8 +27,11 @@ class NextViewHelperTest extends AbstractViewHelperTest {
 			'haystack' => $array,
 			'needle' => 'b',
 		);
-		$output = $this->executeViewHelper($arguments);
-		$this->assertEquals('c', $output);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('c', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Iterator/PreviousViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/PreviousViewHelperTest.php
@@ -27,8 +27,11 @@ class PreviousViewHelperTest extends AbstractViewHelperTest {
 			'haystack' => $array,
 			'needle' => 'c',
 		);
-		$output = $this->executeViewHelper($arguments);
-		$this->assertEquals('b', $output);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('b', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper
stopped working since 7.3 because the AbstractConditionViewHelper
is now compiled statically by default. Any ConditionViewHelper that implements
it's own render method without taking compiling into account currently
simple fail by showing their "false/else" result as soon as they are
executed from cache. Non-cached execution still works, which
makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify,
that the effected viewHelpers render/work the same in cached and uncached
context.