### PR TITLE
[TASK] Make Condition/Page ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/Page/HasSubpagesViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/HasSubpagesViewHelper.php
@@ -9,7 +9,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Page;
  */
 
 use FluidTYPO3\Vhs\Service\PageSelectService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Page has subpages
@@ -26,38 +28,54 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class HasSubpagesViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
 	 * @var PageSelectService
 	 */
-	protected $pageSelect;
+	static protected $pageSelect;
 
 	/**
 	 * @param PageSelectService $pageSelect
 	 * @return void
 	 */
-	public function injectPageSelectService(PageSelectService $pageSelect) {
-		$this->pageSelect = $pageSelect;
+	static public function setPageSelectService(PageSelectService $pageSelect) {
+		self::$pageSelect = $pageSelect;
 	}
 
 	/**
-	 * Render method
-	 *
-	 * @param integer $pageUid
-	 * @param boolean $includeHidden
-	 * @param boolean $showHiddenInMenu
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($pageUid = NULL, $includeHidden = FALSE, $showHiddenInMenu = FALSE) {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('pageUid', 'integer', 'value to check', FALSE, NULL);
+		$this->registerArgument('includeHidden', 'boolean', 'include hidden pages', FALSE, FALSE);
+		$this->registerArgument('showHiddenInMenu', 'boolean', 'include pages hidden in menu', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		$pageUid = $arguments['pageUid'];
+		$includeHidden = $arguments['includeHidden'];
+		$showHiddenInMenu = $arguments['showHiddenInMenu'];
+
 		if (NULL === $pageUid || TRUE === empty($pageUid) || 0 === intval($pageUid)) {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
-		$menu = $this->pageSelect->getMenu($pageUid, array(), '', $showHiddenInMenu);
-		$pageHasSubPages = (0 < count($menu));
-		if (TRUE === $pageHasSubPages) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
+
+		if (self::$pageSelect === NULL) {
+			$objectManager = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+			self::$pageSelect = $objectManager->get('FluidTYPO3\Vhs\Service\PageSelectService');
 		}
+
+		$menu = self::$pageSelect->getMenu($pageUid, array(), '', $showHiddenInMenu);
+		$pageHasSubPages = (0 < count($menu));
+		return TRUE === $pageHasSubPages;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Page;
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use TYPO3\CMS\Frontend\Page\PageRepository;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Page is child page
@@ -25,27 +26,37 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
  */
 class IsChildPageViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param integer $pageUid
-	 * @param boolean $respectSiteRoot
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($pageUid = NULL, $respectSiteRoot = FALSE) {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('pageUid', 'integer', 'value to check', FALSE, NULL);
+		$this->registerArgument('respectSiteRoot', 'boolean', 'value to check', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		$pageUid = $arguments['pageUid'];
+		$respectSiteRoot = $arguments['respectSiteRoot'];
+
 		if (NULL === $pageUid || TRUE === empty($pageUid) || 0 === intval($pageUid)) {
 			$pageUid = $GLOBALS['TSFE']->id;
 		}
 		$pageSelect = new PageRepository();
 		$page = $pageSelect->getPage($pageUid);
+
 		if (TRUE === (boolean) $respectSiteRoot && TRUE === isset($page['is_siteroot']) && TRUE === (boolean) $page['is_siteroot']) {
-			return $this->renderElseChild();
+			return FALSE;
 		}
-		if (TRUE === isset($page['pid']) && 0 < $page['pid']) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === isset($page['pid']) && 0 < $page['pid'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Page;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Is current language
@@ -25,14 +26,27 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsLanguageViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $language
-	 * @param string $defaultTitle
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($language, $defaultTitle = 'en') {
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('language', 'string', 'language to check', TRUE);
+		$this->registerArgument('defaultTitle', 'string', 'title of the default language', FALSE, 'en');
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		$language = $arguments['language'];
+		$defaultTitle = $arguments['defaultTitle'];
+
 		$currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
 		if (TRUE === is_numeric($language)) {
 			$languageUid = intval($language);
@@ -48,7 +62,7 @@ class IsLanguageViewHelper extends AbstractConditionViewHelper {
 				}
 			}
 		}
-		return ($languageUid === $currentLanguageUid ? $this->renderThenChild() : $this->renderElseChild());
+		return $languageUid === $currentLanguageUid;
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Page/HasSubpagesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Page/HasSubpagesViewHelperTest.php
@@ -17,4 +17,40 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
  */
 class HasSubpagesViewHelperTest extends AbstractViewHelperTest {
 
+	public function testRenderWithAPageThatHasSubpages() {
+		$pageSelect = $this->getMock('FluidTYPO3\Vhs\Service\PageSelectService', array('getMenu'), array(), '', FALSE);
+		$pageSelect->expects($this->any())->method('getMenu')->will($this->returnValue(array('childpage')));
+
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'pageUid' => 1
+		);
+		$instance = $this->buildViewHelperInstance($arguments);
+		$instance::setPageSelectService($pageSelect);
+		$result = $instance->initializeArgumentsAndRender();
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
+	public function testRenderWithAPageWithoutSubpages() {
+		$pageSelect = $this->getMock('FluidTYPO3\Vhs\Service\PageSelectService', array('getMenu'), array(), '', FALSE);
+		$pageSelect->expects($this->any())->method('getMenu')->will($this->returnValue(array()));
+
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'pageUid' => 1
+		);
+		$instance = $this->buildViewHelperInstance($arguments);
+		$instance::setPageSelectService($pageSelect);
+		$result = $instance->initializeArgumentsAndRender();
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
+	}
+
 }

--- a/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
@@ -20,7 +20,16 @@ class IsChildPageViewHelperTest extends AbstractViewHelperTest {
 	public function testRender() {
 		$GLOBALS['TYPO3_DB'] = $this->getMock('TYPO3\\CMS\\Core\\Database\\DatabaseConnection', array('exec_SELECTquery'), array(), '', FALSE);
 		$GLOBALS['TYPO3_DB']->expects($this->any())->method('exec_SELECTquery')->will($this->returnValue(FALSE));
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'pageUid' => 0)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'pageUid' => 0
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Page/IsLanguageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Page/IsLanguageViewHelperTest.php
@@ -20,7 +20,17 @@ class IsLanguageViewHelperTest extends AbstractViewHelperTest {
 	public function testRender() {
 		$GLOBALS['TYPO3_DB'] = $this->getMock('TYPO3\\CMS\\Core\\Database\\DatabaseConnection', array('exec_SELECTgetSingleRow'), array(), '', FALSE);
 		$GLOBALS['TYPO3_DB']->expects($this->any())->method('exec_SELECTgetSingleRow')->will($this->returnValue(FALSE));
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'language' => 0)));
+
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'language' => 0
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper
stopped working since 7.3 because the AbstractConditionViewHelper
is now compiled statically by default. Any ConditionViewHelper that implements
it's own render method without taking compiling into account currently
simple fail by showing their "false/else" result as soon as they are
executed from cache. Non-cached execution still works, which
makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify,
that the effected viewHelpers render/work the same in cached and uncached
context.