### PR TITLE
[TASK] Make Condition/Type ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Type of value is array
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsArrayViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_array($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'string', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return (isset($arguments['value']) && (TRUE === is_array($arguments['value'])));
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Type of value is a boolean
@@ -21,18 +22,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsBooleanViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_bool($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_bool($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsDomainObjectViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsDomainObjectViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
 
 use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is a domain object
@@ -24,18 +25,25 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsDomainObjectViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof AbstractDomainObject) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+		$this->registerArgument('fullString', 'string', 'need', FALSE, FALSE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof AbstractDomainObject;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Type of value is float
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsFloatViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_float($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_float($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsInstanceOfViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsInstanceOfViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is an instance of a class
@@ -22,19 +23,25 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsInstanceOfViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @param string $class
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value, $class) {
-		if (TRUE === $value instanceof $class) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+		$this->registerArgument('class', 'mixed', 'className to check against', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof $arguments['class'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Type of value is integer
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsIntegerViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_integer($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_integer($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is an object
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsObjectViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_object($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_object($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsQueryResultViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsQueryResultViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
 
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is a query result
@@ -23,18 +24,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsQueryResultViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof QueryResultInterface) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof QueryResultInterface;
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Type of value is string
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsStringViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === is_string($value)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === is_string($arguments['value']);
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Type/IsTraversableViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsTraversableViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Type;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value implements interface Traversable
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsTraversableViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (TRUE === $value instanceof \Traversable) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'mixed', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === $arguments['value'] instanceof \Traversable;
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsArrayViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsArrayViewHelperTest.php
@@ -21,14 +21,32 @@ class IsArrayViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => array())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => array()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new \stdClass())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new \stdClass()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsBooleanViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsBooleanViewHelperTest.php
@@ -20,14 +20,32 @@ class IsBooleanViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => TRUE)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => TRUE
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new \stdClass())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new \stdClass()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsDomainObjectViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsDomainObjectViewHelperTest.php
@@ -22,14 +22,32 @@ class IsDomainObjectViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new FrontendUser())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new FrontendUser()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new \stdClass())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new \stdClass()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsFloatViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsFloatViewHelperTest.php
@@ -21,14 +21,32 @@ class IsFloatViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 0.5)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 0.5
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsInstanceOfViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsInstanceOfViewHelperTest.php
@@ -22,14 +22,34 @@ class IsInstanceOfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildIfConditionMatched() {
 		$dateTime = new \DateTime('now');
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => $dateTime, 'class' => 'DateTime')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => $dateTime,
+			'class' => 'DateTime'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1, 'class' => 'DateTime')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1,
+			'class' => 'DateTime'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsIntegerViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsIntegerViewHelperTest.php
@@ -21,14 +21,32 @@ class IsIntegerViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 0.5)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 0.5
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsObjectViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsObjectViewHelperTest.php
@@ -21,14 +21,32 @@ class IsObjectViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new \DateTime('now'))));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new \DateTime('now')
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsQueryResultViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsQueryResultViewHelperTest.php
@@ -23,14 +23,32 @@ class IsQueryResultViewHelperTest extends AbstractViewHelperTest {
 	public function rendersThenChildIfConditionMatched() {
 		$queryResult = $this->getMock('TYPO3\\CMS\\Extbase\\Persistence\\Generic\\QueryResult',
 			array('toArray', 'initialize', 'rewind', 'valid', 'count'), array(), '', FALSE);
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => $queryResult)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => $queryResult
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsStringViewHelperTest.php
@@ -21,14 +21,32 @@ class IsStringViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 'test')));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 'test'
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Type/IsTraversableViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Type/IsTraversableViewHelperTest.php
@@ -22,14 +22,32 @@ class IsTraversableViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfConditionMatched() {
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => new ObjectStorage())));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => new ObjectStorage()
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfConditionNotMatched() {
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'value' => 1)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'value' => 1
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper stopped working since 7.3 because the AbstractConditionViewHelper is now compiled statically by default. Any ConditionViewHelper that implements it's own render method without taking compiling into account currently simple fail by showing their "false/else" result as soon as they are executed from cache. Non-cached execution still works, which makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify,
that the effected viewHelpers render/work the same in cached and uncached context.