### PR TITLE
[TASK] Make Condition/Variable ViewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Condition/Variable/IsNullViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IsNullViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Variable;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Condition: Value is NULL
@@ -22,18 +23,24 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IsNullViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Render method
-	 *
-	 * @param mixed $value
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($value) {
-		if (NULL === $value) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('value', 'string', 'value to check', TRUE);
+	}
+
+	/**
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
+	 */
+	static protected function evaluateCondition($arguments = NULL) {
+		return NULL === $arguments['value'];
 	}
 
 }

--- a/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Variable: Isset
@@ -33,17 +35,56 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IssetViewHelper extends AbstractConditionViewHelper {
 
+	use ConditionViewHelperTrait;
+
 	/**
-	 * Renders else-child or else-argument if variable $name exists
-	 *
-	 * @param string $name
-	 * @return string
+	 * Initialize arguments
 	 */
-	public function render($name) {
-		if (TRUE === $this->templateVariableContainer->exists($name)) {
-			return $this->renderThenChild();
+	public function initializeArguments() {
+		parent::initializeArguments();
+		$this->registerArgument('name', 'string', 'name of the variable', TRUE);
+	}
+	/**
+ 	 * Render
+ 	 *
+ 	 * @return string
+ 	 */
+ 	public function render() {
+		return static::renderStatic(
+			$this->arguments,
+			$this->buildRenderChildrenClosure(),
+			$this->renderingContext
+		);
+	}
+
+	/**
+	 * Default implementation for CompilableInterface. See CompilableInterface
+	 * for a detailed description of this method.
+	 *
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+	 * @return mixed
+	 * @see \TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface
+	 */
+	static public function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$hasEvaluated = TRUE;
+
+		if (TRUE === $renderingContext->getTemplateVariableContainer()->exists($arguments['name'])) {
+			$result = static::renderStaticThenChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
+
+			return $renderChildrenClosure();
+		} else {
+			$result = static::renderStaticElseChild($arguments, $hasEvaluated);
+			if ($hasEvaluated) {
+				return $result;
+			}
 		}
-		return $this->renderElseChild();
+
+		return '';
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Variable/IsNullViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Variable/IsNullViewHelperTest.php
@@ -28,6 +28,9 @@ class IsNullViewHelperTest extends AbstractViewHelperTest {
 		);
 		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals($arguments['then'], $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -41,6 +44,9 @@ class IsNullViewHelperTest extends AbstractViewHelperTest {
 		);
 		$result = $this->executeViewHelper($arguments);
 		$this->assertEquals($arguments['else'], $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Condition/Variable/IssetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Variable/IssetViewHelperTest.php
@@ -31,6 +31,9 @@ class IssetViewHelperTest extends AbstractViewHelperTest {
 		);
 		$result = $this->executeViewHelper($arguments, $variables);
 		$this->assertEquals($arguments['then'], $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments, $variables);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -45,6 +48,9 @@ class IssetViewHelperTest extends AbstractViewHelperTest {
 		$variables = array();
 		$result = $this->executeViewHelper($arguments, $variables);
 		$this->assertEquals($arguments['else'], $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments, $variables);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper stopped working since 7.3 because the AbstractConditionViewHelper is now compiled statically by default. Any ConditionViewHelper that
implements it's own render method without taking compiling into account currently simple fail by showing their "false/else" result as soon as they are executed from cache. Non-cached execution
still works, which makes this problem a bit weird to catch. 
Aside from fixing the ViewHelpers itself the Testcases are updated to verify, that the effected viewHelpers render/work the same in cached and uncached context.