### PR TITLE
[TASK] Make the remaining condition viewHelpers static compilable

### DIFF
--- a/Classes/ViewHelpers/Extension/LoadedViewHelper.php
+++ b/Classes/ViewHelpers/Extension/LoadedViewHelper.php
@@ -11,17 +11,28 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Extension;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * ### Extension: Loaded (Condition) ViewHelper
  *
  * Condition to check if an extension is loaded.
  *
+ * ### Example:
+ *
+ *     {v:extension.loaded(extensionName: 'news', then: 'yes', else: 'no')}
+ *
+ *     <v:extension.loaded extensionName="news">
+ *         ...
+ *     </v:extension.loaded>
+ *
  * @author Claus Due <claus@namelesscoder.net>
  * @package Vhs
  * @subpackage ViewHelpers\Extension
  */
 class LoadedViewHelper extends AbstractConditionViewHelper {
+
+	use ConditionViewHelperTrait;
 
 	/**
 	 * Initialize arguments
@@ -32,19 +43,16 @@ class LoadedViewHelper extends AbstractConditionViewHelper {
 	}
 
 	/**
-	 * Render method
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
 	 *
-	 * @return string
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		$extensionName = $this->arguments['extensionName'];
+	static protected function evaluateCondition($arguments = NULL) {
+		$extensionName = $arguments['extensionName'];
 		$extensionKey = GeneralUtility::camelCaseToLowerCaseUnderscored($extensionName);
 		$isLoaded = ExtensionManagementUtility::isLoaded($extensionKey);
-		if (TRUE === $isLoaded) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+		return TRUE === $isLoaded;
 	}
 
 }

--- a/Classes/ViewHelpers/IfViewHelper.php
+++ b/Classes/ViewHelpers/IfViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 
 use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 
 /**
  * @author Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
@@ -17,6 +18,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  * @subpackage ViewHelpers
  */
 class IfViewHelper extends AbstractConditionViewHelper {
+
+	use ConditionViewHelperTrait;
 
 	const OPERATOR_IS_EQUAL = '==';
 	const OPERATOR_IS_NOT_EQUAL = '!=';
@@ -33,7 +36,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	/**
 	 * @var array
 	 */
-	protected $comparisonOperators = array(
+	static protected $comparisonOperators = array(
 		self::OPERATOR_IS_EQUAL => self::OPERATOR_IS_EQUAL,
 		self::OPERATOR_IS_NOT_EQUAL => self::OPERATOR_IS_NOT_EQUAL,
 		self::OPERATOR_IS_GREATER_OR_EQUAL => self::OPERATOR_IS_GREATER_OR_EQUAL,
@@ -45,7 +48,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	/**
 	 * @var array
 	 */
-	protected $logicalOperators = array(
+	static protected $logicalOperators = array(
 		self::OPERATOR_LOGICAL_AND => self::OPERATOR_LOGICAL_AND,
 		self::OPERATOR_LOGICAL_OR => self::OPERATOR_LOGICAL_OR,
 		self::OPERATOR_BOOLEAN_AND => self::OPERATOR_LOGICAL_AND,
@@ -57,7 +60,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	 *
 	 * @var array
 	 */
-	protected $operatorPrecedence = array(
+	static protected $operatorPrecedence = array(
 		self::OPERATOR_LOGICAL_OR => 0,
 		self::OPERATOR_LOGICAL_AND => 1
 	);
@@ -69,21 +72,17 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	 * @api
 	 */
 	public function initializeArguments() {
-		$this->registerArgument('stack', 'array', 'The stack to be evaluated', TRUE);
+		self::registerArgument('stack', 'array', 'The stack to be evaluated', TRUE);
 	}
 
 	/**
-	 * @return string
-	 * @api
+	 * This method decides if the condition is TRUE or FALSE. It can be overriden in extending viewhelpers to adjust functionality.
+	 *
+	 * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper, allows for flexiblity in overriding this method.
+	 * @return bool
 	 */
-	public function render() {
-		$stack = $this->arguments['stack'];
-
-		if (TRUE === $this->evaluateStack($stack)) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
+	static protected function evaluateCondition($arguments = NULL) {
+		return TRUE === self::evaluateStack($arguments['stack']);
 	}
 
 	/**
@@ -91,7 +90,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	 * @param array $stack
 	 * @return boolean
 	 */
-	protected function evaluateStack(array $stack) {
+	static protected function evaluateStack(array $stack) {
 		$stackCount = count($stack);
 
 		if (0 === $stackCount) {
@@ -100,8 +99,8 @@ class IfViewHelper extends AbstractConditionViewHelper {
 			return BooleanNode::convertToBoolean(reset($stack));
 		} elseif (3 === $stackCount) {
 			list ($leftSide, $operator, $rightSide) = array_values($stack);
-			if (TRUE === is_string($operator) && TRUE === isset($this->comparisonOperators[$operator])) {
-				$operator = $this->comparisonOperators[$operator];
+			if (TRUE === is_string($operator) && TRUE === isset(self::$comparisonOperators[$operator])) {
+				$operator = self::$comparisonOperators[$operator];
 				return BooleanNode::evaluateComparator($operator, $leftSide, $rightSide);
 			}
 		}
@@ -111,9 +110,9 @@ class IfViewHelper extends AbstractConditionViewHelper {
 		$operatorIndex = FALSE;
 
 		foreach ($stack as $index => $element) {
-			if (TRUE === is_string($element) && TRUE === isset($this->logicalOperators[$element])) {
-				$currentOperator = $this->logicalOperators[$element];
-				$currentOperatorPrecedence = $this->operatorPrecedence[$currentOperator];
+			if (TRUE === is_string($element) && TRUE === isset(self::$logicalOperators[$element])) {
+				$currentOperator = self::$logicalOperators[$element];
+				$currentOperatorPrecedence = self::$operatorPrecedence[$currentOperator];
 				if ($currentOperatorPrecedence <= $operatorPrecedence) {
 					$operator = $currentOperator;
 					$operatorPrecedence = $currentOperatorPrecedence;
@@ -134,7 +133,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 		$leftSide = array_slice($stack, 0, $operatorIndex);
 		$rightSide = array_slice($stack, $operatorIndex + 1);
 
-		return $this->evaluateLogicalOperator($leftSide, $operator, $rightSide);
+		return self::evaluateLogicalOperator($leftSide, $operator, $rightSide);
 	}
 
 	/**
@@ -144,9 +143,9 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	 * @param array $rightSide
 	 * @return boolean
 	 */
-	protected function evaluateLogicalOperator(array $leftSide, $operator, array $rightSide) {
-		$leftCondition = $this->evaluateStack($this->prepareSideForEvaluation($leftSide));
-		$rightCondition = $this->evaluateStack($this->prepareSideForEvaluation($rightSide));
+	static protected function evaluateLogicalOperator(array $leftSide, $operator, array $rightSide) {
+		$leftCondition = self::evaluateStack(self::prepareSideForEvaluation($leftSide));
+		$rightCondition = self::evaluateStack(self::prepareSideForEvaluation($rightSide));
 
 		if (self::OPERATOR_LOGICAL_AND === $operator) {
 			return $leftCondition && $rightCondition;
@@ -161,7 +160,7 @@ class IfViewHelper extends AbstractConditionViewHelper {
 	 * @param array $side
 	 * @return array
 	 */
-	protected function prepareSideForEvaluation(array $side) {
+	static protected function prepareSideForEvaluation(array $side) {
 		if (1 === count($side)) {
 			$element = reset($side);
 			if (TRUE === is_array($element)) {

--- a/Tests/Unit/ViewHelpers/Extension/LoadedViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Extension/LoadedViewHelperTest.php
@@ -22,16 +22,32 @@ class LoadedViewHelperTest extends AbstractViewHelperTest {
 	 * @test
 	 */
 	public function rendersThenChildIfExtensionIsLoaded() {
-		$test = $this->executeViewHelper(array('extensionName' => 'Vhs', 'then' => 1, 'else' => 0));
-		$this->assertSame(1, $test);
+		$arguments = array(
+			'extensionName' => 'Vhs',
+			'then' => 1, '
+			else' => 0
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertSame(1, $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
 	 * @test
 	 */
 	public function rendersElseChildIfExtensionIsNotLoaded() {
-		$test = $this->executeViewHelper(array('extensionName' => 'Void', 'then' => 1, 'else' => 0));
-		$this->assertSame(0, $test);
+		$arguments = array(
+			'extensionName' => 'Void',
+			 'then' => 1,
+			 'else' => 0
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertSame(0, $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -20,7 +20,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildWithFlatComparison() {
 		$stack = array(array('foo'), '==', array('foo'));
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -28,7 +37,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildWithPrecedence() {
 		$stack = array(1, 'OR', 0, 'AND', 0);
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -36,7 +54,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersElseChildWithFlatArrayComparison() {
 		$stack = array(array('foo'), '==', '3');
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -44,7 +71,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildWithFlatLogicalOperator() {
 		$stack = array(1, '==', 1, 'AND', 1);
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -52,7 +88,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildWithRightStack() {
 		$stack = array(1, '==', 1, 'AND', array(1, '!=', 0));
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -60,7 +105,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersThenChildWithStacks() {
 		$stack = array(array('foo', '!=', 'bar'), 'AND', 1, 'OR', array(1, '==', '0'));
-		$this->assertEquals('then', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('then', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -68,7 +122,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersElseChildWithStacks() {
 		$stack = array(array('foo', '!=', 'bar'), 'AND', array('foo', '==', 'bar'));
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**
@@ -76,7 +139,16 @@ class IfViewHelperTest extends AbstractViewHelperTest {
 	 */
 	public function rendersElseChildWithEmptyStack() {
 		$stack = array();
-		$this->assertEquals('else', $this->executeViewHelper(array('then' => 'then', 'else' => 'else', 'stack' => $stack)));
+		$arguments = array(
+			'then' => 'then',
+			'else' => 'else',
+			'stack' => $stack
+		);
+		$result = $this->executeViewHelper($arguments);
+		$this->assertEquals('else', $result);
+
+		$staticResult = $this->executeViewHelperStatic($arguments);
+		$this->assertEquals($result, $staticResult, 'The regular viewHelper output doesn\'t match the static output!');
 	}
 
 	/**


### PR DESCRIPTION
many viewHelpers extending from AbstractConditionViewHelper stopped working since 7.3 because the AbstractConditionViewHelper is now compiled statically by default. Any ConditionViewHelper that
implements it's own render method without taking compiling into account currently simple fail by showing their "false/else" result as soon as they are executed from cache. Non-cached execution
still works, which makes this problem a bit weird to catch.
Aside from fixing the ViewHelpers itself the Testcases are updated to verify, that the effected viewHelpers render/work the same in cached and uncached context.