### PR TITLE
Include encoding-option to format.tidy-Viewhelper

### DIFF
--- a/Classes/ViewHelpers/Format/TidyViewHelper.php
+++ b/Classes/ViewHelpers/Format/TidyViewHelper.php
@@ -36,15 +36,16 @@ class TidyViewHelper extends AbstractViewHelper {
 	 * Trims content, then trims each line of content
 	 *
 	 * @param string $content
+	 * @param string $encoding
 	 * @throws \RuntimeException
 	 * @return string
 	 */
-	public function render($content = NULL) {
+	public function render($content = NULL, $encoding = 'utf8') {
 		if (NULL === $content) {
 			$content = $this->renderChildren();
 		}
 		if (TRUE === $this->hasTidy) {
-			$tidy = tidy_parse_string($content);
+			$tidy = tidy_parse_string($content, NULL, $encoding);
 			$tidy->cleanRepair();
 			return (string) $tidy;
 		}


### PR DESCRIPTION
The default-encoding of `tidy_parse_string` is not utf8. Include option for encoding with default utf8-encoding.