### PR TITLE
[BUGFIX] Fix current page id for fal resources

### DIFF
--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -61,6 +61,16 @@ class FalViewHelper extends ResourcesFalViewHelper {
 	}
 
 	/**
+	 * AbstractRecordResource usually uses the current cObj as reference,
+	 * but the page is needed here
+	 *
+	 * @return array
+	 */
+	public function getActiveRecord() {
+		return $GLOBALS['TSFE']->page;
+	}
+
+	/**
 	 * @return mixed
 	 * @throws Exception
 	 */


### PR DESCRIPTION
The v:page.resources.fal view helper should look for resources pertaining to the page currently viewed by default.
At the moment, the getActiveRecord() function inherited from AbstractRecordResourceViewHelper is used which returns the current cObj and not the page record.