### PR TITLE
[BUGFIX] Fix user-handling if fe_group is assigned, but no fe_user

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -72,7 +72,6 @@ class PageSelectService implements SingletonInterface {
 		if (TRUE === isset($GLOBALS['TSFE']->fe_user->groupData)) {
 			$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
 		}
-		
 		$pageSelect = new PageRepository();
 		$clauses = array();
 		foreach ($groups as $group) {

--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -69,7 +69,7 @@ class PageSelectService implements SingletonInterface {
 		} else {
 			$groups = array(-1, 0);
 		}
-		if (FALSE === empty($GLOBALS['TSFE']->fe_user->groupData['uid'])) {
+		if (TRUE === isset($GLOBALS['TSFE']->fe_user->groupData)) {
 			$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
 		}
 		

--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -66,13 +66,13 @@ class PageSelectService implements SingletonInterface {
 	private function createPageSelectInstance() {
 		if (TRUE === is_array($GLOBALS['TSFE']->fe_user->user)) {
 			$groups = array(-2, 0);
-			$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
 		} else {
 			$groups = array(-1, 0);
-			if (FALSE === empty($GLOBALS['TSFE']->fe_user->groupData['uid'])) {
-				$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
-			}
 		}
+		if (FALSE === empty($GLOBALS['TSFE']->fe_user->groupData['uid'])) {
+			$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
+		}
+		
 		$pageSelect = new PageRepository();
 		$clauses = array();
 		foreach ($groups as $group) {

--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -69,6 +69,9 @@ class PageSelectService implements SingletonInterface {
 			$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
 		} else {
 			$groups = array(-1, 0);
+			if (FALSE === empty($GLOBALS['TSFE']->fe_user->groupData['uid'])) {
+				$groups = array_merge($groups, (array) array_values($GLOBALS['TSFE']->fe_user->groupData['uid']));
+			}
 		}
 		$pageSelect = new PageRepository();
 		$clauses = array();


### PR DESCRIPTION
In some special cases (with EXT:sfpipauth or other extensions) it is
possible to assign a fe_group but no fe_user. This bugfix ensures vhs
respect group assignment.