### PR TITLE
[BUGFIX] Fix #934 - PageRepository was created without using GeneralUtility::makeInstance()

### DIFF
--- a/Classes/Service/PageSelectService.php
+++ b/Classes/Service/PageSelectService.php
@@ -84,7 +84,8 @@ class PageSelectService implements SingletonInterface {
 		} else {
 			$groups = array(-1, 0);
 		}
-		$pageSelect = new \TYPO3\CMS\Frontend\Page\PageRepository();
+		$pageSelect = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+		/** @var \TYPO3\CMS\Frontend\Page\PageRepository $pageSelect */
 		$clauses = array();
 		foreach ($groups as $group) {
 			$clause = "fe_group = '" . $group . "' OR fe_group LIKE '" .


### PR DESCRIPTION
This change allows EXT:vhs to use Xclassed PageRepository.