### PR TITLE
[FEATURE] ExtensionConfiguration-VH: Allow removing dots from array-keys

### DIFF
--- a/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
@@ -32,9 +32,10 @@ class ExtensionConfigurationViewHelper extends AbstractViewHelper {
 	/**
 	 * @param string $name
 	 * @param string $extensionKey
+	 * @param bool $removeDots
 	 * @return string
 	 */
-	public function render($name, $extensionKey = NULL) {
+	public function render($name, $extensionKey = NULL, $removeDots = FALSE) {
 
 		if (NULL === $extensionKey) {
 			$extensionName = $this->controllerContext->getRequest()->getControllerExtensionName();
@@ -48,7 +49,11 @@ class ExtensionConfigurationViewHelper extends AbstractViewHelper {
 		$extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey]);
 
 		if (TRUE === array_key_exists($name, $extConf)) {
-			return $extConf[$name];
+			$extConfPart = $extConf[$name];
+			if (TRUE === (boolean)$removeDots) {
+				$extConfPart = GeneralUtility::removeDotsFromTS($extConfPart);
+			}
+			return $extConfPart;
 		} else {
 			return NULL;
 		}


### PR DESCRIPTION
In Fluid using array-keys without dots is much more handy. Because of backward-
compatibility and some edge-cases this mode is optional.