### PR TITLE
[TASK] Ignore some files/directories on archive export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+bower.json export-ignore
+phpunit.xml.dist export-ignore
+
+Tests/ export-ignore


### PR DESCRIPTION
In case the extension is pulled via Composer, a few files and directories can
be excluded to reduce the amount of transferred data and disk space usage.