### PR TITLE
[FEATURE] Argument addQueryString for v:page.header.alternate

### DIFF
--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -65,6 +65,7 @@ class AlternateViewHelper extends AbstractViewHelper {
 		$this->registerArgument('languages', 'mixed', 'The languages (either CSV, array or implementing Traversable)', TRUE);
 		$this->registerArgument('pageUid', 'integer', 'The page uid to check', FALSE, 0);
 		$this->registerArgument('normalWhenNoLanguage', 'boolean', 'If TRUE, a missing page overlay should be ignored', FALSE, FALSE);
+		$this->registerArgument('addQueryString', 'boolean', 'If TRUE, the current query parameters will be kept in the URI', FALSE, FALSE);
 	}
 
 	/**
@@ -86,6 +87,7 @@ class AlternateViewHelper extends AbstractViewHelper {
 
 		$pageUid = intval($this->arguments['pageUid']);
 		$normalWhenNoLanguage = $this->arguments['normalWhenNoLanguage'];
+		$addQueryString = $this->arguments['addQueryString'];
 
 		if (0 === $pageUid) {
 			$pageUid = $GLOBALS['TSFE']->id;
@@ -95,7 +97,8 @@ class AlternateViewHelper extends AbstractViewHelper {
 		$uriBuilder = $this->controllerContext->getUriBuilder();
 		$uriBuilder = $uriBuilder->reset()
 			->setTargetPageUid($pageUid)
-			->setCreateAbsoluteUri(TRUE);
+			->setCreateAbsoluteUri(TRUE)
+			->setAddQueryString($addQueryString);
 
 		$this->tagBuilder->reset();
 		$this->tagBuilder->setTagName('link');

--- a/Resources/Private/Schemas/Vhs.xsd
+++ b/Resources/Private/Schemas/Vhs.xsd
@@ -19085,6 +19085,13 @@ default="false">
 </xsd:documentation>
 </xsd:annotation>
 </xsd:attribute>
+<xsd:attribute type="xsd:boolean" name="addQueryString" default="false">
+<xsd:annotation>
+<xsd:documentation>
+<![CDATA[If TRUE, the current query parameters will be kept in the URI]]>
+</xsd:documentation>
+</xsd:annotation>
+</xsd:attribute>
 </xsd:complexType>
 </xsd:element>
 <xsd:element name="page.header.canonical">


### PR DESCRIPTION
The `v:page.header.alternate` ViewHelper should, just like the `f:link.page` ViewHelper, have the option to add an existing QueryString when generating the URI. Links to, for example, news detail pages are currently generated without the query string and are therefore wrong.