### PR TITLE
[BUGFIX] Fix external link handling in AbstractMenuViewHelper

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,3 +27,9 @@ if (FALSE === is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfi
 		'groups' => array('pages', 'all')
 	);
 }
+
+// add url and urltype to fix the rendering of external url doktypes
+if (FALSE === empty($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'])) {
+	$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',';
+}
+$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= 'url,urltype';


### PR DESCRIPTION
the PageRepository doesn't return url + urltype anymore which causes the rendering of that external url
to fail. This commit adds url + urltype to the rootLineFields.