### PR TITLE
[BUGFIX] Fix the cast of the playerId argument

### DIFF
--- a/Classes/ViewHelpers/Media/VimeoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VimeoViewHelper.php
@@ -69,7 +69,7 @@ class VimeoViewHelper extends AbstractTagBasedViewHelper {
 			'autoplay='  . (integer) $this->arguments['autoplay'],
 			'loop='      . (integer) $this->arguments['loop'],
 			'api='       . (integer) $this->arguments['api'],
-			'player_id=' . (integer) $this->arguments['playerId'],
+			'player_id=' . $this->arguments['playerId'],
 		);
 
 		$src .= implode('&', $queryParams);


### PR DESCRIPTION
Hi,

An ultra small PR just to remove the casting of the argument "playerId" as an integer.
On this page https://developer.vimeo.com/player/js-api, we can see that "player_id" should be a string :)