### PR TITLE
Language overlay 

### DIFF
--- a/Classes/Traits/SlideViewHelperTrait.php
+++ b/Classes/Traits/SlideViewHelperTrait.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\Traits;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Service\PageSelectService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -25,6 +26,19 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *   to the ViewHelper arguments
  */
 trait SlideViewHelperTrait {
+
+	/**
+	 * @var PageSelectService
+	 */
+	protected $pageSelect;
+
+	/**
+	 * @param PageSelectService $pageSelectService
+	 * @return void
+	 */
+	public function injectPageSelectService(PageSelectService $pageSelectService) {
+		$this->pageSelect = $pageSelectService;
+	}
 
 	/**
 	 * Default initialisation of arguments - will be used


### PR DESCRIPTION
I had the following situation (simplified)

*  Make two languages: 1 and 2
* Set TypoScript for language 2 
  config.sys_language_mode = content_fallback; 1,0
* Make two pages: A and B
* A has languages 0 and 1
* B has languages 0, 1 and 2

* Use `vhs:content.render` viewhelper to insert content from page B into page A
 ` {v:content.render(pageUid: <pageB.uid>, column: <N>, hideUntranslated: 1)}`

If I open page A in language 0 the content from page B is presented in language 0 (correct)
If I open page A in language 1 the content from page B is presented in language 1 (correct)
If I open page A in language 2 the content from page B is presented in language 1 **(wrong!!!)**

The problem is: The `vhs:content.render` viewhelper uses the language//fallback_language of the current viewd page (A) and not the language//fallback_language of the page where the rendered content is (B).  
Page A has no translation in language 2, so it is shown in with the fallback language 1. This is the right behaviour. But the content from page B should be rendered in language 2, as it is translated in this language. But the fallback_language from page A is just used without checking back, if page B has translation in language 2.
