### PR TITLE
[BUGFIX] Fixed deprecation warnings with TSFE->getPageRenderer()

### DIFF
--- a/Classes/Traits/PageRendererTrait.php
+++ b/Classes/Traits/PageRendererTrait.php
@@ -1,0 +1,29 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Class PageRendererTrait
+ *
+ * Trait implemented by ViewHelpers which require access
+ * to PageRenderer
+ *
+ */
+trait PageRendererTrait {
+
+	/**
+	 * Provides a shared (singleton) instance of PageRenderer
+	 *
+	 * @return \TYPO3\CMS\Core\Page\PageRenderer
+	 */
+	protected function getPageRenderer() {
+		return \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+	}
+
+}

--- a/Classes/ViewHelpers/Page/FooterViewHelper.php
+++ b/Classes/ViewHelpers/Page/FooterViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use FluidTYPO3\Vhs\ViewHelpers\Asset\AbstractAssetViewHelper;
 
 /**
@@ -17,6 +18,8 @@ use FluidTYPO3\Vhs\ViewHelpers\Asset\AbstractAssetViewHelper;
  * @subpackage ViewHelpers\Page
  */
 class FooterViewHelper extends AbstractAssetViewHelper {
+
+	use PageRendererTrait;
 
 	/**
 	 * Render method
@@ -28,7 +31,7 @@ class FooterViewHelper extends AbstractAssetViewHelper {
 			return;
 		}
 		$content = $this->getContent();
-		$GLOBALS['TSFE']->getPageRenderer()->addFooterData($content);
+		$this->getPageRenderer()->addFooterData($content);
 	}
 
 }

--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  */
 
 use FluidTYPO3\Vhs\Service\PageSelectService;
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -23,6 +24,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @subpackage ViewHelpers\Page\Header
  */
 class AlternateViewHelper extends AbstractViewHelper {
+
+	use PageRendererTrait;
 
 	/**
 	 * @var PageSelectService
@@ -105,7 +108,7 @@ class AlternateViewHelper extends AbstractViewHelper {
 		$this->tagBuilder->addAttribute('rel', 'alternate');
 
 		/** @var PageRenderer $pageRenderer */
-		$pageRenderer = $GLOBALS['TSFE']->getPageRenderer();
+		$pageRenderer = $this->getPageRenderer();
 		$usePageRenderer = (1 !== intval($GLOBALS['TSFE']->config['config']['disableAllHeaderCode']));
 		$output = '';
 

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  */
 
 use FluidTYPO3\Vhs\Service\PageSelectService;
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -19,6 +20,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  * @subpackage ViewHelpers\Page\Header
  */
 class CanonicalViewHelper extends AbstractTagBasedViewHelper {
+
+	use PageRendererTrait;
 
 	/**
 	 * @var PageSelectService
@@ -82,7 +85,7 @@ class CanonicalViewHelper extends AbstractTagBasedViewHelper {
 			return $renderedTag;
 		}
 
-		$GLOBALS['TSFE']->getPageRenderer()->addMetaTag($renderedTag);
+		$this->getPageRenderer()->addMetaTag($renderedTag);
 	}
 
 }

--- a/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use FluidTYPO3\Vhs\Traits\TagViewHelperTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
@@ -22,7 +23,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class LinkViewHelper extends AbstractTagBasedViewHelper {
 
-	use TagViewHelperTrait;
+	use TagViewHelperTrait, PageRendererTrait;
 
 	/**
 	 * @var    string
@@ -51,7 +52,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper {
 		if ('BE' === TYPO3_MODE) {
 			return;
 		}
-		$GLOBALS['TSFE']->getPageRenderer()->addMetaTag($this->renderTag($this->tagName));
+		$this->getPageRenderer()->addMetaTag($this->renderTag($this->tagName));
 	}
 
 }

--- a/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  */
 
 use FluidTYPO3\Vhs\Traits\TagViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -23,7 +24,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class MetaViewHelper extends AbstractTagBasedViewHelper {
 
-	use TagViewHelperTrait;
+	use TagViewHelperTrait, PageRendererTrait;
 
 	/**
 	 * @var    string
@@ -55,7 +56,7 @@ class MetaViewHelper extends AbstractTagBasedViewHelper {
 			return;
 		}
 		if (TRUE === isset($this->arguments['content']) && FALSE === empty($this->arguments['content'])) {
-			$GLOBALS['TSFE']->getPageRenderer()
+			$this->getPageRenderer()
 				->addMetaTag($this->renderTag($this->tagName, NULL, array('content' => $this->arguments['content'])));
 		}
 	}

--- a/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -46,6 +47,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TitleViewHelper extends AbstractViewHelper {
 
+	use PageRendererTrait;
+
 	/**
 	 * Arguments initialization
 	 *
@@ -72,7 +75,7 @@ class TitleViewHelper extends AbstractViewHelper {
 			$title = $this->renderChildren();
 		}
 		$title = trim(preg_replace('/\s+/', $this->arguments['whitespaceString'], $title), $this->arguments['whitespaceString']);
-		$GLOBALS['TSFE']->getPageRenderer()->setTitle($title);
+		$this->getPageRenderer()->setTitle($title);
 		if (TRUE === $this->arguments['setIndexedDocTitle']) {
 			$GLOBALS['TSFE']->indexedDocTitle = $title;
 		}


### PR DESCRIPTION
As stated at 

https://wiki.typo3.org/TYPO3.CMS/Releases/7.4/Deprecation#Deprecation:_.2368074_-_Deprecate_getPageRenderer.28.29_methods 

the getPageRenderer()-function has been marked as deprecated with the release of TYPO3 7.4 and will be removed with the release of TYPO3 8.0. PageRenderer implements SingletonInterface, which means that getting a own (shared) instance of it will become mandatory.

Therefore, in favor of DRY-principle, a Trait has been introduced providing a instance of PageRenderer through GeneralUtility-instanciation.