### PR TITLE
[BUGFIX] Fixed addQueryString behaviour in LanguageMenuViewHelper

### DIFF
--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -303,8 +303,9 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper {
 			'returnLast' => 'url',
 			'additionalParams' => '&L=' . $uid,
 			'useCacheHash' => $this->arguments['useCHash'],
-			'addQueryString' => 'GET',
+			'addQueryString' => 1,
 			'addQueryString.' => array(
+				'method' => 'GET',
 				'exclude' => 'id,L,cHash' . ($excludedVars ? ',' . $excludedVars : '')
 			)
 		);


### PR DESCRIPTION
https://docs.typo3.org/typo3cms/TyposcriptReference/Functions/Typolink/Index.html#typolink <-- addQueryString is a boolean with the property method which needs to be set. 