### PR TITLE
[TASK] Remove deprecated dependency

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,6 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' => array(
       'php' => '5.4.0-5.6.99',
       'typo3' => '7.6.0-7.6.99',
-      'cms' => '',
     ),
     'conflicts' => array(
     ),


### PR DESCRIPTION
I just noticed that vhs causes an entry in deprecation.log of TYPO3 7.6.4