### PR TITLE
[TASK] Implement renderStatic where this is currently possible

### DIFF
--- a/Classes/Traits/ConditionViewHelperTrait.php
+++ b/Classes/Traits/ConditionViewHelperTrait.php
@@ -13,6 +13,7 @@ namespace FluidTYPO3\Vhs\Traits;
  * to add srcsets based to the imagetag for better responsiveness
  */
 trait ConditionViewHelperTrait {
+
 	/**
 	 * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
 	 *

--- a/Classes/Traits/DefaultRenderMethodViewHelperTrait.php
+++ b/Classes/Traits/DefaultRenderMethodViewHelperTrait.php
@@ -1,0 +1,38 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Class DefaultRenderMethodViewHelperTrait
+ *
+ * Trait implemented by ViewHelpers which are perfectly
+ * fine with a render() method which only delegates to
+ * renderStatic().
+ *
+ * Do not implement in ViewHelpers which subclass from
+ * other ViewHelpers if any parent implements a render()
+ * method.
+ *
+ * Has the following main responsibilities:
+ *
+ * - generic render method passing arguments, context and closures
+ *   to renderStatic.
+ */
+trait DefaultRenderMethodViewHelperTrait {
+
+	/**
+	 * Delegation to renderStatic
+	 *
+	 * @return mixed
+	 */
+	public function render() {
+		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
+	}
+
+}

--- a/Classes/Traits/PageRendererTrait.php
+++ b/Classes/Traits/PageRendererTrait.php
@@ -22,7 +22,7 @@ trait PageRendererTrait {
 	 *
 	 * @return \TYPO3\CMS\Core\Page\PageRenderer
 	 */
-	protected function getPageRenderer() {
+	protected static function getPageRenderer() {
 		return \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
 	}
 

--- a/Classes/ViewHelpers/Format/HideViewHelper.php
+++ b/Classes/ViewHelpers/Format/HideViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -21,6 +23,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class HideViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Initialize
 	 *
@@ -31,13 +35,15 @@ class HideViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		if (TRUE === (boolean) $this->arguments['disabled']) {
-			return $this->renderChildren();
-		} else {
-			$this->renderChildren();
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$content = $renderChildrenClosure();
+		if ($arguments['disabled']) {
+			return $content;
 		}
 		return NULL;
 	}

--- a/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -44,12 +46,14 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class SanitizeStringViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Basic character map
 	 *
 	 * @var array
 	 */
-	protected $characterMap = array(
+	protected static $characterMap = array(
 		'¹' => 1, '²' => 2, '³' => 3, '°' => 0, '€' => 'eur', 'æ' => 'ae', 'ǽ' => 'ae', 'À' => 'A', 'Á' => 'A', 'Â' => 'A',
 		'Ã' => 'A', 'Å' => 'AA', 'Ǻ' => 'A', 'Ă' => 'A', 'Ǎ' => 'A', 'Æ' => 'AE', 'Ǽ' => 'AE', 'à' => 'a', 'á' => 'a',
 		'â' => 'a', 'ã' => 'a', 'å' => 'aa', 'ǻ' => 'a', 'ă' => 'a', 'ǎ' => 'a', 'ª' => 'a', '@' => 'at', 'Ĉ' => 'C',
@@ -117,18 +121,21 @@ class SanitizeStringViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$string = $this->arguments['string'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$string = $arguments['string'];
 		if (NULL === $string) {
-			$string = $this->renderChildren();
+			$string = $renderChildrenClosure();
 			if (NULL === $string) {
 				return NULL;
 			}
 		}
-		$characterMap = $this->characterMap;
-		$customMap = $this->arguments['customMap'];
+		$characterMap = static::$characterMap;
+		$customMap = $arguments['customMap'];
 		if (TRUE === is_array($customMap) && 0 < count($customMap)) {
 			$characterMap = array_merge($characterMap, $customMap);
 		}
@@ -139,6 +146,7 @@ class SanitizeStringViewHelper extends AbstractViewHelper {
 		$pattern = '/([^a-z0-9\-]){1,}/';
 		$string = preg_replace($pattern, '-', $string);
 		return trim($string, '-');
+
 	}
 
 }

--- a/Classes/ViewHelpers/Format/WordWrapViewHelper.php
+++ b/Classes/ViewHelpers/Format/WordWrapViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -24,6 +26,11 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class WordWrapViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
+	/**
+	 * @return void
+	 */
 	public function initializeArguments() {
 		$this->registerArgument('subject', 'string', 'Text to wrap', FALSE);
 		$this->registerArgument('limit', 'integer', 'Maximum length of resulting parts after wrapping', FALSE, 80);
@@ -32,16 +39,19 @@ class WordWrapViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$subject = $this->arguments['subject'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$subject = $arguments['subject'];
 		if (TRUE === empty($subject)) {
-			$subject = $this->renderChildren();
+			$subject = $renderChildrenClosure();
 		}
-		$limit = (integer) $this->arguments['limit'];
-		$break = $this->arguments['break'];
-		$glue = $this->arguments['glue'];
+		$limit = (integer) $arguments['limit'];
+		$break = $arguments['break'];
+		$glue = $arguments['glue'];
 		$subject = preg_replace('/ +/', ' ', $subject);
 		$subject = str_replace(array("\r\n", "\r"), PHP_EOL, $subject);
 		$subject = wordwrap($subject, $limit, $break, FALSE);

--- a/Classes/ViewHelpers/Link/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/TypolinkViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Link;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -39,6 +41,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TypolinkViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Initializes the arguments for the ViewHelper
 	 */
@@ -47,10 +51,13 @@ class TypolinkViewHelper extends AbstractViewHelper {
 	}
 
 	/**
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
 	 * @return mixed
 	 */
-	public function render() {
-		return $GLOBALS['TSFE']->cObj->typoLink($this->renderChildren(), $this->arguments['configuration']);
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return $GLOBALS['TSFE']->cObj->typoLink($renderChildrenClosure(), $arguments['configuration']);
 	}
 
 }

--- a/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
+++ b/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -20,10 +22,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class AbsoluteUrlViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		$url = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
 		if (0 !== strpos($url, GeneralUtility::getIndpEnv('TYPO3_SITE_URL'))) {
 			$url = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . $url;

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -68,7 +68,7 @@ class CanonicalViewHelper extends AbstractTagBasedViewHelper {
 			return $renderedTag;
 		}
 
-		$this->getPageRenderer()->addMetaTag($renderedTag);
+		static::getPageRenderer()->addMetaTag($renderedTag);
 	}
 
 }

--- a/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
@@ -23,7 +23,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class LinkViewHelper extends AbstractTagBasedViewHelper {
 
-	use TagViewHelperTrait, PageRendererTrait;
+	use TagViewHelperTrait;
+	use PageRendererTrait;
 
 	/**
 	 * @var    string
@@ -52,7 +53,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper {
 		if ('BE' === TYPO3_MODE) {
 			return;
 		}
-		$this->getPageRenderer()->addMetaTag($this->renderTag($this->tagName));
+		static::getPageRenderer()->addMetaTag($this->renderTag($this->tagName));
 	}
 
 }

--- a/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/MetaViewHelper.php
@@ -24,7 +24,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class MetaViewHelper extends AbstractTagBasedViewHelper {
 
-	use TagViewHelperTrait, PageRendererTrait;
+	use TagViewHelperTrait;
+	use PageRendererTrait;
 
 	/**
 	 * @var    string

--- a/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use FluidTYPO3\Vhs\Traits\PageRendererTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -47,6 +49,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TitleViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
 	use PageRendererTrait;
 
 	/**
@@ -61,22 +64,23 @@ class TitleViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Render method
-	 *
-	 * @return void
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		if ('BE' === TYPO3_MODE) {
 			return;
 		}
-		if (FALSE === empty($this->arguments['title'])) {
-			$title = $this->arguments['title'];
+		if (FALSE === empty($arguments['title'])) {
+			$title = $arguments['title'];
 		} else {
-			$title = $this->renderChildren();
+			$title = $renderChildrenClosure();
 		}
-		$title = trim(preg_replace('/\s+/', $this->arguments['whitespaceString'], $title), $this->arguments['whitespaceString']);
-		$this->getPageRenderer()->setTitle($title);
-		if (TRUE === $this->arguments['setIndexedDocTitle']) {
+		$title = trim(preg_replace('/\s+/', $arguments['whitespaceString'], $title), $arguments['whitespaceString']);
+		static::getPageRenderer()->setTitle($title);
+		if (TRUE === $arguments['setIndexedDocTitle']) {
 			$GLOBALS['TSFE']->indexedDocTitle = $title;
 		}
 	}

--- a/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
+++ b/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -25,10 +27,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class StaticPrefixViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		if (FALSE === empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
 			return $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'];
 		}

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -23,6 +25,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class UncacheViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Initialize
 	 *
@@ -35,15 +39,19 @@ class UncacheViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$partialArguments = $this->arguments['arguments'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$templateVariableContainer = $renderingContext->getTemplateVariableContainer();
+		$partialArguments = $arguments['arguments'];
 		if (FALSE === is_array($partialArguments)) {
 			$partialArguments = array();
 		}
-		if (FALSE === isset($partialArguments['settings']) && TRUE === $this->templateVariableContainer->exists('settings')) {
-			$partialArguments['settings'] = $this->templateVariableContainer->get('settings');
+		if (FALSE === isset($partialArguments['settings']) && TRUE === $templateVariableContainer->exists('settings')) {
+			$partialArguments['settings'] = $templateVariableContainer->get('settings');
 		}
 
 		$substKey = 'INT_SCRIPT.' . $GLOBALS['TSFE']->uniqueHash();
@@ -55,10 +63,10 @@ class UncacheViewHelper extends AbstractViewHelper {
 			'cObj' => serialize($templateView),
 			'postUserFunc' => 'render',
 			'conf' => array(
-				'partial' => $this->arguments['partial'],
-				'section' => $this->arguments['section'],
+				'partial' => $arguments['partial'],
+				'section' => $arguments['section'],
 				'arguments' => $partialArguments,
-				'controllerContext' => $this->renderingContext->getControllerContext()
+				'controllerContext' => $renderingContext->getControllerContext()
 			),
 			'content' => $content
 		);

--- a/Classes/ViewHelpers/Site/NameViewHelper.php
+++ b/Classes/ViewHelpers/Site/NameViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -21,12 +23,16 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class NameViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$name = $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'];
-		return $name;
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename'];
 	}
 
 }

--- a/Classes/ViewHelpers/Site/UrlViewHelper.php
+++ b/Classes/ViewHelpers/Site/UrlViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -23,12 +25,16 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class UrlViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$url = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
-		return $url;
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
 	}
 
 }

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -21,18 +23,23 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class DateTimeViewHelper extends AbstractViewHelper {
 
-	/**
-	 * @return \DateTime
-	 */
-	public function render() {
-		return \DateTime::createFromFormat('U', $this->getTimestamp());
-	}
+	use DefaultRenderMethodViewHelperTrait;
 
 	/**
 	 * @return integer
 	 */
-	protected function getTimestamp() {
+	protected static function getTimestamp() {
 		return time();
+	}
+
+	/**
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
+	 */
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return \DateTime::createFromFormat('U', static::getTimestamp());
 	}
 
 }

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -25,17 +27,15 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TimestampViewHelper extends AbstractViewHelper {
 
-	/**
-	 * @return integer
-	 */
-	public function render() {
-		return $this->getTimestamp();
-	}
+	use DefaultRenderMethodViewHelperTrait;
 
 	/**
-	 * @return integer
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	protected function getTimestamp() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		return time();
 	}
 

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -9,8 +9,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  */
 
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -21,6 +23,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @subpackage ViewHelpers\Uri
  */
 class GravatarViewHelper extends AbstractViewHelper {
+
+	use DefaultRenderMethodViewHelperTrait;
 
 	/**
 	 * Base url
@@ -52,14 +56,17 @@ class GravatarViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$email = $this->arguments['email'];
-		$size = $this->checkArgument('size');
-		$imageSet = $this->checkArgument('imageSet');
-		$maximumRating = $this->checkArgument('maximumRating');
-		$secure = (boolean) $this->arguments['secure'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		$email = $arguments['email'];
+		$size = $arguments['size'];
+		$imageSet = $arguments['imageSet'];
+		$maximumRating = $arguments['maximumRating'];
+		$secure = (boolean) $arguments['secure'];
 
 		$url = (TRUE === $secure ? self::GRAVATAR_SECURE_BASEURL : self::GRAVATAR_BASEURL);
 		$url .= md5(strtolower(trim($email)));
@@ -68,17 +75,5 @@ class GravatarViewHelper extends AbstractViewHelper {
 
 		return $url;
 	}
-
-	/**
-	 * Check if an argument is passed
-	 *
-	 * @param $argument
-	 *
-	 * @return mixed
-	 */
-	private function checkArgument($argument) {
-		return TRUE === isset($this->arguments[$argument]) ? $this->arguments[$argument] : NULL;
-	}
-
 
 }

--- a/Classes/ViewHelpers/Uri/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Uri/RequestViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -23,12 +25,16 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class RequestViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
-		$url = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
-		return $url;
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
 	}
 
 }

--- a/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -39,6 +41,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class TypolinkViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Initializes the arguments for the ViewHelper
 	 */
@@ -47,10 +51,13 @@ class TypolinkViewHelper extends AbstractViewHelper {
 	}
 
 	/**
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
 	 * @return mixed
 	 */
-	public function render() {
-		return $GLOBALS['TSFE']->cObj->typoLink_URL($this->arguments['configuration']);
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		return $GLOBALS['TSFE']->cObj->typoLink_URL($arguments['configuration']);
 	}
 
 }

--- a/Classes/ViewHelpers/Variable/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ConvertViewHelper.php
@@ -8,9 +8,11 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -27,6 +29,8 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ConvertViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * Initialize arguments
 	 */
@@ -37,18 +41,18 @@ class ConvertViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Render method
-	 *
-	 * @throws \RuntimeException
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
 	 * @return mixed
 	 */
-	public function render() {
-		if (TRUE === isset($this->arguments['value'])) {
-			$value = $this->arguments['value'];
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
+		if (TRUE === isset($arguments['value'])) {
+			$value = $arguments['value'];
 		} else {
-			$value = $this->renderChildren();
+			$value = $renderChildrenClosure();
 		}
-		$type = $this->arguments['type'];
+		$type = $arguments['type'];
 		if (gettype($value) === $type) {
 			return $value;
 		}
@@ -70,8 +74,8 @@ class ConvertViewHelper extends AbstractViewHelper {
 				settype($value, $type);
 			}
 		} else {
-			if (TRUE === isset($this->arguments['default'])) {
-				$default = $this->arguments['default'];
+			if (TRUE === isset($arguments['default'])) {
+				$default = $arguments['default'];
 				if (gettype($default) !== $type) {
 					throw new \RuntimeException('Supplied argument "default" is not of the type "' . $type .'"', 1364542576);
 				}

--- a/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
@@ -33,21 +34,19 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
  */
 class ExtensionConfigurationViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * @var array
 	 */
 	protected static $configurations = array();
 
+	/**
+	 * @return void
+	 */
 	public function initializeArguments() {
 		$this->registerArgument('extensionKey', 'string', 'Extension key (lowercase_underscored format) to read configuration from');
 		$this->registerArgument('path', 'string', 'Configuration path to read - if NULL, returns all configuration as array');
-	}
-
-	/**
-	 * @return string
-	 */
-	public function render() {
-		return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
 	}
 
 	/**

--- a/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -26,6 +28,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class GetViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * @return void
 	 */
@@ -34,13 +38,16 @@ class GetViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * @return string
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		if (FALSE === $GLOBALS['TSFE'] instanceof TypoScriptFrontendController) {
 			return NULL;
 		}
-		$name = $this->arguments['name'];
+		$name = $arguments['name'];
 		$value = NULL;
 		if (TRUE === isset($GLOBALS['TSFE']->register[$name])) {
 			$value = $GLOBALS['TSFE']->register[$name];

--- a/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -25,6 +27,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class SetViewHelper extends AbstractViewHelper {
 
+	use DefaultRenderMethodViewHelperTrait;
+
 	/**
 	 * @return void
 	 */
@@ -34,16 +38,19 @@ class SetViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Set (override) the value in register $name.
+	 * @param array $arguments
+	 * @param \Closure $renderChildrenClosure
+	 * @param RenderingContextInterface $renderingContext
+	 * @return mixed
 	 */
-	public function render() {
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 		if (FALSE === $GLOBALS['TSFE'] instanceof TypoScriptFrontendController) {
 			return NULL;
 		}
-		$name = $this->arguments['name'];
-		$value = $this->arguments['value'];
+		$name = $arguments['name'];
+		$value = $arguments['value'];
 		if (NULL === $value) {
-			$value = $this->renderChildren();
+			$value = $renderChildrenClosure();
 		}
 		$GLOBALS['TSFE']->register[$name] = $value;
 		return NULL;

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -140,11 +140,6 @@ abstract class AbstractViewHelperTest extends UnitTestCase {
 			ObjectAccess::setProperty($this->renderingContext, 'viewHelperVariableContainer', $viewHelperContainer, TRUE);
 			$this->renderingContext->setControllerContext($controllerContext);
 		}
-		if (TRUE === $instance instanceof \Tx_Fluidwidget_Core_Widget_AbstractWidgetViewHelper) {
-			/** @var WidgetContext $widgetContext */
-			$widgetContext = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\Widget\\WidgetContext');
-			ObjectAccess::setProperty($instance, 'widgetContext', $widgetContext, TRUE);
-		}
 		if (NULL !== $childNode) {
 			$node->addChildNode($childNode);
 			if ($instance instanceof ChildNodeAccessInterface) {

--- a/Tests/Unit/ViewHelpers/Format/SanitizeStringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/SanitizeStringViewHelperTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Format\Url;
+namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Format;
 
 /*
  * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.

--- a/Tests/Unit/ViewHelpers/Uri/TypolinkViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Uri/TypolinkViewHelperTest.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Uri;
  */
 
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -23,11 +24,10 @@ class TypolinkViewHelperTest extends AbstractViewHelperTest {
 	public function renderCallsTypoLinkFunctionOnContentObject() {
 		$class = $this->getViewHelperClassName();
 		$mock = new $class();
-		$mock->setArguments(array('configuration' => array('foo' => 'bar')));
 		$GLOBALS['TSFE'] = new TypoScriptFrontendController(array(), 1, 0);
 		$GLOBALS['TSFE']->cObj = $this->getMock('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer', array('typoLink_URL'));
 		$GLOBALS['TSFE']->cObj->expects($this->once())->method('typoLink_URL')->with(array('foo' => 'bar'))->will($this->returnValue('foobar'));
-		$result = $this->callInaccessibleMethod($mock, 'render');
+		$result = $mock::renderStatic(array('configuration' => array('foo' => 'bar')), function() { }, new RenderingContext());
 		$this->assertEquals('foobar', $result);
 	}
 

--- a/Tests/Unit/ViewHelpers/Variable/ConvertViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/ConvertViewHelperTest.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Variable;
 use FluidTYPO3\Vhs\Tests\Fixtures\Domain\Model\Foo;
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 
 /**
  * @author Björn Fromme <fromme@dreipunktnull.com>, dreipunktnull
@@ -114,6 +115,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
 		$viewHelper->setArguments(array('type' => 'string'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertEquals('', $converted);
 	}
@@ -125,6 +127,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
 		$viewHelper->setArguments(array('type' => 'string'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('string', $converted);
 	}
@@ -136,6 +139,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
 		$viewHelper->setArguments(array('type' => 'array'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('array', $converted);
 	}
@@ -147,6 +151,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
 		$viewHelper->setArguments(array('type' => 'array'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('array', $converted);
 		$this->assertEquals(array('foo'), $converted);
@@ -159,6 +164,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
 		$viewHelper->setArguments(array('type' => 'ObjectStorage'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInstanceOf('TYPO3\\CMS\\Extbase\\Persistence\\ObjectStorage', $converted);
 		$this->assertEquals(0, $converted->count());
@@ -174,6 +180,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($storage));
 		$viewHelper->setArguments(array('type' => 'array'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('array', $converted);
 		$this->assertEquals(1, count($converted));
@@ -186,6 +193,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
 		$viewHelper->setArguments(array('type' => 'boolean'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('boolean', $converted);
 		$this->assertFalse($converted);
@@ -198,6 +206,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(1));
 		$viewHelper->setArguments(array('type' => 'boolean'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('boolean', $converted);
 		$this->assertTrue($converted);
@@ -210,6 +219,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
 		$viewHelper->setArguments(array('type' => 'boolean'));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('boolean', $converted);
 		$this->assertTrue($converted);
@@ -222,6 +232,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest {
 		$viewHelper = $this->getAccessibleMock('FluidTYPO3\Vhs\ViewHelpers\Variable\ConvertViewHelper', array('renderChildren'));
 		$viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(NULL));
 		$viewHelper->setArguments(array('type' => 'boolean', 'default' => TRUE));
+		$viewHelper->setRenderingContext(new RenderingContext());
 		$converted = $viewHelper->render();
 		$this->assertInternalType('boolean', $converted);
 		$this->assertTrue($converted);


### PR DESCRIPTION
Converts all ViewHelpers which can be readily converted to use renderStatic and removes much code that would be duplicated, by moving it to a Trait. Remaining ViewHelpers require additional refactoring of Traits which need to be performed in other pull requests for isolation.