### PR TITLE
Bugfix for duplicate content in workspace previews

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -119,6 +119,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 		if (TRUE === (boolean) $this->arguments['sectionIndexOnly']) {
 			$conditions .= ' AND sectionIndex = 1';
 		}
+		$conditions .= ' AND t3ver_state<=1';
 
 		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', $conditions, '', $order, $limit);
 		return $rows;

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -119,7 +119,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper {
 		if (TRUE === (boolean) $this->arguments['sectionIndexOnly']) {
 			$conditions .= ' AND sectionIndex = 1';
 		}
-		$conditions .= ' AND t3ver_state<=1';
+		$conditions .= ' AND t3ver_state <= 1';
 
 		$rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', $conditions, '', $order, $limit);
 		return $rows;


### PR DESCRIPTION
Show only live and new records in workspaces and hide moved or placeholder records, since their overlays are fetched automatically.