### PR TITLE
[BUGFIX] '(boolean) $this->getCurrentLanguageUid() === 0' is always FALSE in Page/Resources/FalViewHelper

### DIFF
--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -79,7 +79,7 @@ class FalViewHelper extends ResourcesFalViewHelper {
 	 * @return boolean
 	 */
 	protected function isDefaultLanguage() {
-		return (boolean) $this->getCurrentLanguageUid() === 0;
+		return (boolean) ($this->getCurrentLanguageUid() === 0);
 	}
 
 	/**


### PR DESCRIPTION
The result of the comparison is not castetd, instead the result of ```isDefaultLanguage()`` is casted to boolean. It always runs on a comparison between bool and int.