### PR TITLE
[BUGFIX] Collection viewhelper always returning NULL

### DIFF
--- a/Classes/ViewHelpers/Resource/CollectionViewHelper.php
+++ b/Classes/ViewHelpers/Resource/CollectionViewHelper.php
@@ -49,7 +49,7 @@ class CollectionViewHelper extends AbstractResourceViewHelper {
 			/** @var \TYPO3\CMS\Core\Collection\AbstractRecordCollection $collection */
 			$collection = $this->collectionRepository->findByUid($uid);
 			if (NULL !== $collection) {
-				return $collection->loadContents();
+				$collection->loadContents();
 			}
 			return $collection;
 		}

--- a/Classes/ViewHelpers/Resource/CollectionViewHelper.php
+++ b/Classes/ViewHelpers/Resource/CollectionViewHelper.php
@@ -50,9 +50,8 @@ class CollectionViewHelper extends AbstractResourceViewHelper {
 			$collection = $this->collectionRepository->findByUid($uid);
 			if (NULL !== $collection) {
 				return $collection->loadContents();
-			} else {
-				return NULL;
 			}
+			return $collection;
 		}
 		return NULL;
 	}


### PR DESCRIPTION
Fixes the problem, that the resource collection viewhelper returns the return value of `loadContents`, which is `void`, so the result is always `NULL`.

```
{v:resource.collection(uid: uid) ->  v:variable.set(name: 'records')}
```