### PR TITLE
[BUGFIX] Assets ViewHelper. the argument "moveable" is misinterpreted.

### DIFF
--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -543,7 +543,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
     public function assertAllowedInFooter()
     {
         $settings = $this->getAssetSettings();
-        return (isset($settings['movable']) && !$settings['movable']);
+        return (isset($settings['movable']) && $settings['movable']);
     }
 
     /**


### PR DESCRIPTION
If "moveable" is "true" then assertAllowedInFooter gives back "false"