### PR TITLE
[BUGFIX] Adapt to recent changes in image viewhelpers

### DIFF
--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -109,11 +109,12 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     }
 
     /**
+     * @param string|null $imageSource
      * @throws Exception
      */
-    public function preprocessImage()
+    public function preprocessImage($imageSource = null)
     {
-        $src = $this->arguments['src'];
+        $src = (null === $imageSource) ? $this->arguments['src'] : $imageSource;
         $width = $this->arguments['width'];
         $height = $this->arguments['height'];
         $minW = $this->arguments['minW'];
@@ -144,11 +145,11 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         if (false === empty($format)) {
             $setup['ext'] = $format;
         }
-        if (0 < intval($quality)) {
+        if (0 < (integer) $quality) {
             $quality = MathUtility::forceIntegerInRange($quality, 10, 100, 75);
             $setup['params'] = '-quality ' . $quality;
         }
-        if ('BE' === TYPO3_MODE && '../' === substr($src, 0, 3)) {
+        if (TYPO3_MODE === 'BE' && strpos($src, '../') === 0) {
             $src = substr($src, 3);
         }
         $this->imageInfo = $this->contentObject->getImgResource($src, $setup);
@@ -156,15 +157,11 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         if (false === is_array($this->imageInfo)) {
             throw new Exception('Could not get image resource for "' . htmlspecialchars($src) . '".', 1253191060);
         }
-        if ((float) substr(TYPO3_version, 0, 3) < 7.1) {
-            $this->imageInfo[3] = GeneralUtility::png_to_gif_by_imagemagick($this->imageInfo[3]);
-        } else {
-            $this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);
-        }
+        $this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);
         $GLOBALS['TSFE']->imagesOnPage[] = $this->imageInfo[3];
         $publicUrl = rawurldecode($this->imageInfo[3]);
         $this->mediaSource = GeneralUtility::rawUrlEncodeFP($publicUrl);
-        if ('BE' === TYPO3_MODE) {
+        if (TYPO3_MODE === 'BE') {
             $this->resetFrontendEnvironment();
         }
     }

--- a/Classes/ViewHelpers/Media/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/ImageViewHelper.php
@@ -90,11 +90,19 @@ class ImageViewHelper extends AbstractImageViewHelper
      * Render method
      *
      * @return string
+     * @throws \TYPO3\CMS\Fluid\Core\ViewHelper\Exception
      */
     public function render()
     {
         $this->preprocessImage();
+        return $this->renderTag();
+    }
 
+    /**
+     * @return string
+     */
+    public function renderTag()
+    {
         if (false === empty($this->arguments['srcset'])) {
             $srcSetVariants = $this->addSourceSet($this->tag, $this->mediaSource);
         }


### PR DESCRIPTION
This is not much more of a hotfix to make PDF thumbnail generation work again. Some arguments are deprecated due to changes in image viewhelpers. Closes #933.