### PR TITLE
[BUGFIX] No submenus on rootpage

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -381,14 +381,14 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
     /**
      * @param null|integer $pageUid
      * @param integer $entryLevel
-     * @return integer
+     * @return null|integer
      */
-    protected function determinePageUid($pageUid = null, $entryLevel = 0)
+    protected function determineParentPageUid($pageUid = null, $entryLevel = 0)
     {
         $rootLineData = $this->pageService->getRootLine();
         if (null === $pageUid) {
             if (null !== $entryLevel) {
-                if (0 > $entryLevel) {
+                if ($entryLevel < 0) {
                     $entryLevel = count($rootLineData) - 1 + $entryLevel;
                 }
                 $pageUid = $rootLineData[$entryLevel]['uid'];
@@ -397,18 +397,20 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             }
         }
 
-        return (integer) $pageUid;
+        return $pageUid;
     }
 
     /**
      * @param null|integer $pageUid
      * @param integer $entryLevel
-     *
      * @return array
      */
     public function getMenu($pageUid = null, $entryLevel = 0)
     {
-        $pageUid = $this->determinePageUid($pageUid, $entryLevel);
+        $pageUid = $this->determineParentPageUid($pageUid, $entryLevel);
+        if ($pageUid === null) {
+            return [];
+        }
         $showHiddenInMenu = (boolean) $this->arguments['showHiddenInMenu'];
         $showAccessProtected = (boolean) $this->arguments['showAccessProtected'];
         $includeSpacers = (boolean) $this->arguments['includeSpacers'];


### PR DESCRIPTION
This patch fixes an issue when splitting up menus into main and submenus (with an entry level > 1) where root page would have itself as a single submenu entry.