### PR TITLE
[BUGFIX] Remove pages not to be shown from menu

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -432,6 +432,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
         $count = 0;
         $total = count($pages);
         $allowedDocumentTypes = $this->allowedDoktypeList();
+        $processedPages = [];
         foreach ($pages as $index => $page) {
             if (!in_array($page['doktype'], $allowedDocumentTypes)) {
                 continue;
@@ -487,9 +488,10 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             $pages[$index]['linktext'] = $this->getItemTitle($pages[$index]);
             $forceAbsoluteUrl = $this->arguments['forceAbsoluteUrl'];
             $pages[$index]['link'] = $this->pageService->getItemLink($page, $forceAbsoluteUrl);
+            $processedPages[$index] = $pages[$index];
         }
 
-        return $pages;
+        return $processedPages;
     }
 
     /**


### PR DESCRIPTION
This patch fixes an issue where pages that are not to be shown in a menu due to translation settings still were rendered with empty link text.