### PR TITLE
Update AbstractImageViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -168,7 +168,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         if (false === is_array($this->imageInfo)) {
             throw new Exception('Could not get image resource for "' . htmlspecialchars($src) . '".', 1253191060);
         }
-        $this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);
+        //$this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);
         if ($this->hasArgument('canvasWidth') && $this->hasArgument('canvasHeight')) {
             $canvasWidth = (integer) $this->arguments['canvasWidth'];
             $canvasHeight = (integer) $this->arguments['canvasHeight'];


### PR DESCRIPTION
Remove
$this->imageInfo[3] = GraphicalFunctions::pngToGifByImagemagick($this->imageInfo[3]);

Because @TYPO3 8 this function is deprecated and removed (Deprecation: #66906 - Functionality for png_to_gif conversion) and the Viewhelper is not useable at this moment. With removing this Line it does work again.