### PR TITLE
[FEATURE] Integrity attribute support for assets

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -63,6 +63,8 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 class Asset implements AssetInterface
 {
 
+    const INTEGRITY_METHOD = 'sha384';
+
     /**
      * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
      */
@@ -137,6 +139,11 @@ class Asset implements AssetInterface
      * @var boolean
      */
     protected $rewrite = true;
+
+    /**
+     * @var boolean|string
+     */
+    protected $integrity = true;
 
     /**
      * @var array
@@ -575,6 +582,28 @@ class Asset implements AssetInterface
     public function setRemoved($removed)
     {
         $this->removed = $removed;
+        return $this;
+    }
+
+    /**
+     * @return boolean|string
+     */
+    public function getIntegrity()
+    {
+        return $this->integrity;
+    }
+
+    /**
+     * @param boolean|string $integrity
+     * @return Asset
+     */
+    public function setIntegrity($integrity)
+    {
+        // Note: force type boolean here for boolean values, to differ it later from a hash string
+        $this->integrity = filter_var($integrity, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if (null === $this->integrity) {
+            $this->integrity = $integrity;
+        }
         return $this;
     }
 

--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -241,6 +241,7 @@ class AssetService implements SingletonInterface
      */
     protected function buildAssetsChunk($assets)
     {
+        $setup = &$GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.'];
         $spool = [];
         foreach ($assets as $name => $asset) {
             $assetSettings = $this->extractAssetSettings($asset);
@@ -273,7 +274,15 @@ class AssetService implements SingletonInterface
                         array_push($chunks, $this->generateTagForAssetType($type, $assetContent));
                     } else {
                         if (true === $external) {
-                            array_push($chunks, $this->generateTagForAssetType($type, null, $path));
+                            if (!$setup['assets.']['assetTagsNoIntegrity']
+                                && is_string($assetSettings['integrity'])
+                            ) {
+                                $integrity = $assetSettings['integrity'];
+                            }
+                            array_push(
+                                $chunks,
+                                $this->generateTagForAssetType($type, null, $path, $integrity, $external)
+                            );
                         } else {
                             if (true === $rewrite) {
                                 array_push(
@@ -281,13 +290,21 @@ class AssetService implements SingletonInterface
                                     $this->writeCachedMergedFileAndReturnTag(array($name => $asset), $type)
                                 );
                             } else {
+                                if (!$setup['assets.']['assetTagsNoIntegrity']
+                                    && false !== $assetSettings['integrity']
+                                ) {
+                                    $integrity = true === $assetSettings['integrity']
+                                        ? $this->getFileIntegrity($path)
+                                        : $assetSettings['integrity'];
+                                }
                                 $path = substr($path, strlen(PATH_site));
                                 $path = $this->prefixPath($path);
-                                array_push($chunks, $this->generateTagForAssetType($type, null, $path));
+                                array_push($chunks, $this->generateTagForAssetType($type, null, $path, $integrity));
                             }
                         }
                     }
                 }
+                unset($integrity);
             }
             if (0 < count($chunk)) {
                 $mergedFileTag = $this->writeCachedMergedFileAndReturnTag($chunk, $type);
@@ -319,8 +336,14 @@ class AssetService implements SingletonInterface
             || true === (boolean) $GLOBALS['TSFE']->no_cache
             || true === (boolean) $GLOBALS['TSFE']->page['no_cache']
         ) {
+            $skipIntegrity = false;
             foreach ($assets as $name => $asset) {
                 $assetSettings = $this->extractAssetSettings($asset);
+                if (false === $assetSettings['integrity']) {
+                    // Note: If the user don't want to have the integrity on one particular file, we skip it for the
+                    // whole concatenated asset file.
+                    $skipIntegrity = true;
+                }
                 if ((isset($assetSettings['namedChunks']) && 0 < $assetSettings['namedChunks']) ||
                     !isset($assetSettings['namedChunks'])) {
                     $source .= '/* ' . $name . ' */' . LF;
@@ -330,6 +353,11 @@ class AssetService implements SingletonInterface
                 $source .= "\n";
             }
             $this->writeFile($fileAbsolutePathAndFilename, $source);
+        }
+        if (!$GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['assetTagsNoIntegrity']
+            && false === $skipIntegrity
+        ) {
+            $integrity = $this->getFileIntegrity($fileAbsolutePathAndFilename);
         }
         if (false === empty($GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'])) {
             $timestampMode = $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'];
@@ -348,17 +376,19 @@ class AssetService implements SingletonInterface
             }
         }
         $fileRelativePathAndFilename = $this->prefixPath($fileRelativePathAndFilename);
-        return $this->generateTagForAssetType($type, null, $fileRelativePathAndFilename);
+        return $this->generateTagForAssetType($type, null, $fileRelativePathAndFilename, $integrity);
     }
 
     /**
      * @param string $type
      * @param string $content
      * @param string $file
+     * @param string $integrity
+     * @param booleal $external
      * @throws \RuntimeException
      * @return string
      */
-    protected function generateTagForAssetType($type, $content, $file = null)
+    protected function generateTagForAssetType($type, $content, $file = null, $integrity = null, $external = false)
     {
         /** @var \TYPO3\CMS\Fluid\Core\ViewHelper\TagBuilder $tagBuilder */
         $tagBuilder = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\ViewHelper\\TagBuilder');
@@ -375,6 +405,12 @@ class AssetService implements SingletonInterface
                 } else {
                     $tagBuilder->addAttribute('src', $file);
                 }
+                if (null !== $integrity && !empty($integrity)) {
+                    $tagBuilder->addAttribute('integrity', $integrity);
+                    if (true === $external) {
+                        $tagBuilder->addAttribute('crossorigin', 'anonymous');
+                    }
+                }
                 break;
             case 'css':
                 if (null === $file) {
@@ -387,6 +423,12 @@ class AssetService implements SingletonInterface
                     $tagBuilder->setTagName('link');
                     $tagBuilder->addAttribute('rel', 'stylesheet');
                     $tagBuilder->addAttribute('href', $file);
+                }
+                if (null !== $integrity && !empty($integrity)) {
+                    $tagBuilder->addAttribute('integrity', $integrity);
+                    if (true === $external) {
+                        $tagBuilder->addAttribute('crossorigin', 'anonymous');
+                    }
                 }
                 break;
             case 'meta':
@@ -730,5 +772,37 @@ class AssetService implements SingletonInterface
         } else {
             return GeneralUtility::array_merge_recursive_overrule($array1, $array2);
         }
+    }
+
+    /**
+     * @param $file
+     * @return string
+     */
+    protected function getFileIntegrity($file)
+    {
+        if (false === file_exists($file)) {
+            return '';
+        }
+        $integrityFile = sprintf(
+            'typo3temp/vhs-assets-%s.%s',
+            str_replace('vhs-assets-', '', pathinfo($file, PATHINFO_BASENAME)),
+            Asset::INTEGRITY_METHOD
+        );
+        if (false === file_exists($integrityFile)
+            || 0 === filemtime($integrityFile)
+            || true === isset($GLOBALS['BE_USER'])
+            || true === (boolean) $GLOBALS['TSFE']->no_cache
+            || true === (boolean) $GLOBALS['TSFE']->page['no_cache']
+        ) {
+            if (extension_loaded('hash') && function_exists('hash_file')) {
+                $integrity = base64_encode(hash_file(Asset::INTEGRITY_METHOD, $file, true));
+            } elseif (extension_loaded('openssl') && function_exists('openssl_digest')) {
+                $integrity = base64_encode(openssl_digest(file_get_contents($file), Asset::INTEGRITY_METHOD, true));
+            } else {
+                return ''; // Sadly, no integrity generation possible
+            }
+            $this->writeFile($integrityFile, $integrity);
+        }
+        return sprintf('%s-%s', Asset::INTEGRITY_METHOD, $integrity ?: file_get_contents($integrityFile));
     }
 }

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -217,6 +217,16 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
             false,
             false
         );
+        // Note: hash generation for external files could solved with downloading and hashing the given resource. But
+        // it's not implemented to prevent performance issues from waiting for missing resources or slow servers!
+        $this->registerArgument(
+            'integrity',
+            'mixed',
+            'A boolean value, to decide weather an integrity hash will be generated and added to the tag or not. ' .
+            'Can also be a string containing the hash (useful for external scripts, were we can\'t generate a hash)',
+            false,
+            true
+        );
     }
 
     /**
@@ -469,6 +479,11 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
         }
         if (!empty($assetSettings['path']) && !$assetSettings['external']) {
             $assetSettings['path'] = GeneralUtility::getFileAbsFileName($assetSettings['path']);
+        }
+        // Note: force type boolean here for boolean values, to differ it later from a hash string
+        $integrity = filter_var($assetSettings['integrity'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if (null !== $integrity) {
+            $assetSettings['integrity'] = $integrity;
         }
         $assetSettings['name'] = $name;
         $this->assetSettingsCache = $assetSettings;

--- a/Tests/Unit/Service/AssetServiceTest.php
+++ b/Tests/Unit/Service/AssetServiceTest.php
@@ -63,4 +63,33 @@ class AssetServiceTest extends UnitTestCase
             array(array('fluid' => $fluidAsset), true, 1)
         );
     }
+
+    /**
+     * @test
+     */
+    public function testIntegrityCalculation()
+    {
+        // Note: Maybe test this dynamic. This command could be useful:
+        //    ~> openssl dgst -sha256 -binary Tests/Fixtures/Files/dummy.js | openssl base64 -A
+
+        $expectedIntegrities = array(
+           'sha256' => 'sha256-DUTqIDSUj1HagrQbSjhJtiykfXxVQ74BanobipgodCo=',
+           'sha384' => 'sha384-aieE32yQSOy7uEhUkUvR9bVgfJgMsP+B9TthbxbjDDZ2hd4tjV5jMUoj9P8aeSHI',
+           'sha512' => 'sha512-0bz2YVKEoytikWIUFpo6lK/k2cVVngypgaItFoRvNfux/temtdCVxsu+HxmdRT8aNOeJxxREUphbkcAK8KpkWg==',
+        );
+
+        if(!array_key_exists(Asset::INTEGRITY_METHOD, $expectedIntegrities)) {
+            $this->markTestSkipped('There is no expectation for hashing method \'' . Asset::INTEGRITY_METHOD . '\'');
+            return;
+        }
+
+        $expectedIntegrity = $expectedIntegrities[Asset::INTEGRITY_METHOD];
+        $file = 'Tests/Fixtures/Files/dummy.js';
+        $method = (new \ReflectionClass('\FluidTYPO3\Vhs\Service\AssetService'))->getMethod('getFileIntegrity');
+        $instance = $this->getMock('FluidTYPO3\\Vhs\\Service\\AssetService', array('writeFile'));
+        $instance->method('writeFile')->willReturn(null);
+
+        $method->setAccessible(true);
+        $this->assertEquals($expectedIntegrity, $method->invokeArgs($instance, array($file)));
+    }
 }


### PR DESCRIPTION
This feature adds automatic generation of HTML5 integrity-hashes for all css and js assets included with vhs tools.
It is also possible to add the hash manually. This is useful for external scripts, were the automatic generation doesn't works.

Attibute can be true, false or a integrity-hash. true is the default behavior.

See: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
Example: '<v:asset.script path="assets/bootstrap/3.3.7/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUP..." />'
Resolves: #1089