### PR TITLE
[FEATURE] Subresource Integrity (SRI) generation for v:asset.script …

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ plugin.tx_vhs.settings.asset {
 }
 plugin.tx_vhs.assets {
 	mergedAssetsUseHashedFilename = 0 # If set to a 1, Assets are merged into a file named using a hash if Assets' names.
+	tagsAddSubresourceIntegrity = 0 # If set to 1 (weakest),2 or 3 (strongest), Vhs will generate and add the Subresource Integrity (SRI) for every included Asset.
 }
 ```
 


### PR DESCRIPTION
…and style

Vhs can now automaticly generate and add the SRI to the resulting asset tag.
This can be turned on through the option 'assets.tagsAddIntegrityAttribute'.
These values are possible: 0 = off | 1 = sha256 | 2 = sha384 | 3 = sha512

Example: plugin.tx_vhs.assets.tagsAddIntegrityAttribute = 2

This will result in something like...

Example: `<script type="..." src="js/your.js" integrity="sha384-6XaWTzGb6esk97...">`

Resolves: #1094 