### PR TITLE
Add Attribute "sizes" to render apple-touch-icon

### DIFF
--- a/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
@@ -40,6 +40,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
         $this->registerTagAttribute('type', 'string', 'Property: type');
         $this->registerTagAttribute('lang', 'string', 'Property: lang');
         $this->registerTagAttribute('dir', 'string', 'Property: dir');
+        $this->registerTagAttribute('sizes', 'string', 'Property: sizes');
     }
 
     /**


### PR DESCRIPTION
Example: 
```
<v:page.header.link sizes="57x57" rel="apple-touch-icon-precomposed" href="{icon57}"/>
```

https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html