### PR TITLE
[BUGFIX] Use instantiated PageRepository in PageService

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -177,7 +177,7 @@ class PageService implements SingletonInterface
         $hideIfDefaultLanguage = (boolean) GeneralUtility::hideIfDefaultLanguage($l18nCfg);
         $pageOverlay = [];
         if (0 !== $languageUid) {
-            $pageOverlay = $GLOBALS['TSFE']->sys_page->getPageOverlay($pageUid, $languageUid);
+            $pageOverlay = $this->getPageRepository()->getPageOverlay($pageUid, $languageUid);
         }
         $translationAvailable = (0 !== count($pageOverlay));
 


### PR DESCRIPTION
This change uses the correct instance of PageRepository within PageService.

Trying to access the TSFE within the TYPO3 backend would lead to a PHP Fatal Error because `$GLOBALS['TSFE']` is `null`.

I believe this was an oversight during the update to 3.0.0 or 3.0.1.

Best regards,
Maximilian Pfeifer