### PR TITLE
[BUGFIX] Asset merge can produce many identical files

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -312,7 +312,10 @@ class AssetService implements SingletonInterface
     protected function writeCachedMergedFileAndReturnTag($assets, $type)
     {
         $source = '';
-        $assetName = implode('-', array_keys($assets));
+        $keys = array_keys($assets);
+        sort($keys);
+        $assetName = implode('-', $keys);
+        unset($keys);
         if (isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['mergedAssetsUseHashedFilename'])) {
             if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['mergedAssetsUseHashedFilename']) {
                 $assetName = md5($assetName);


### PR DESCRIPTION
**Problem**
Some files created by the `AssetService` can have different file names but the same content. Depending on the complexity of the site there can be many such files that will useless take CPU time to generate and use extra disk space.

**Cause**
The problem with existing approach is that keys returned by `array_keys()` are not necessarily sorted. This causes a different md5 if same assets are added in a different order.

**Solution**
The fix is to sort asset keys before using them.

**Example**
Example of identical files (note sizes of 2nd and last file):

```
MBP3:~/Projects/*** [hotfix/1.0.8-fix-uniqueid-in-vhs-assets *] $ ls -lt www/typo3temp/vhs-assets-*.js
-rw-r--r-- 1 dmitry staff     371 Sep 21 16:26 www/typo3temp/vhs-assets-3414f3cc1a869796d0e367e72da47206.js
-rw-r--r-- 1 dmitry staff 1744946 Sep 21 16:26 www/typo3temp/vhs-assets-3611734b69f4370cff1ab2a27b6f75b0.js
-rw-r--r-- 1 dmitry staff    9647 Sep 21 16:26 www/typo3temp/vhs-assets-162538461d95257ceb787daa340f6de4.js
-rw-r--r-- 1 dmitry staff   39414 Sep 21 16:26 www/typo3temp/vhs-assets-493c38b63756f1822c1d1483a026a180.js
-rw-r--r-- 1 dmitry staff    1702 Sep 21 16:26 www/typo3temp/vhs-assets-73cafecad748442c39a077a754a42327.js
-rw-r--r-- 1 dmitry staff 1744946 Sep 21 16:26 www/typo3temp/vhs-assets-ba7bc28fc7d37e12d9919833780cbfa7.js
MBP3:~/Projects/*** [hotfix/1.0.8-fix-uniqueid-in-vhs-assets *] $ diff -u www/typo3temp/vhs-assets-3611734b69f4370cff1ab2a27b6f75b0.js www/typo3temp/vhs-assets-ba7bc28fc7d37e12d9919833780cbfa7.js
MBP3:~/Projects/*** [hotfix/1.0.8-fix-uniqueid-in-vhs-assets *] $
```