### PR TITLE
[BUGFIX] Exception when you use "quality" with v:media.image

### DIFF
--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -3,6 +3,7 @@ namespace FluidTYPO3\Vhs\Traits;
 
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /*
  * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.


### PR DESCRIPTION
Uncaught TYPO3 Exception
Class 'FluidTYPO3\Vhs\Traits\MathUtility' not found 

Error thrown in file
/html/typo3/typo3conf/ext/vhs/Classes/Traits/SourceSetViewHelperTrait.php in line 93.