### PR TITLE
[REMOVAL] Deprecate v:if in favor of f:if

### DIFF
--- a/Classes/ViewHelpers/IfViewHelper.php
+++ b/Classes/ViewHelpers/IfViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
@@ -15,6 +16,8 @@ use FluidTYPO3\Vhs\Traits\ConditionViewHelperTrait;
 /**
  * If (condition) ViewHelper supporting a stack of conditions
  * instead of a single condition.
+ *
+ * @deprecated
  */
 class IfViewHelper extends AbstractConditionViewHelper
 {
@@ -73,6 +76,7 @@ class IfViewHelper extends AbstractConditionViewHelper
      */
     public function initializeArguments()
     {
+        GeneralUtility::deprecationLog(static::class . ' is deprecated, will be removed when VHS supports TYPO3v8 LTS as minimum');
         self::registerArgument('stack', 'array', 'The stack to be evaluated', true);
     }
 

--- a/Tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -13,6 +13,16 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers;
  */
 class IfViewHelperTest extends AbstractViewHelperTest
 {
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        if (class_exists(\TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper::class)) {
+            $this->markTestSkipped('Test not executed on TYPO3v8 (ViewHelper is deprecated from this version and up)');
+        }
+        parent::setUp();
+    }
 
     /**
      * @test


### PR DESCRIPTION
Deprecate and plan to remove `v:if` (which has the
stack condition argument) in favor of `f:if` as provided
by Fluid Standalone (which parses complex expressions).

To be removed when TYPO3v8 LTS is our minimum.

NB: deprecation logged from initializeArguments in order
to limit the number of logged deprecations to one per
request where v:if is used rather than once per execution.
