### PR TITLE
Bugfix: Backup TSFE to reset it later when simulating frontend environment

### DIFF
--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -31,7 +31,7 @@ trait SourceSetViewHelperTrait
         $srcsets = $this->getSourceSetWidths();
 
         if ('BE' === TYPO3_MODE) {
-            FrontendSimulationUtility::simulateFrontendEnvironment();
+            $tsfeBackup = FrontendSimulationUtility::simulateFrontendEnvironment();
         }
 
         $format = $this->arguments['format'];
@@ -61,7 +61,7 @@ trait SourceSetViewHelperTrait
         $tag->addAttribute('srcset', implode(',', $srcsetVariants));
 
         if ('BE' === TYPO3_MODE) {
-            FrontendSimulationUtility::resetFrontendEnvironment();
+            FrontendSimulationUtility::resetFrontendEnvironment($tsfeBackup);
         }
 
         return $imageSources;


### PR DESCRIPTION
When in development mode, the TYPO3 backend showed PHP warnings, because the argument for method resetFrontendEnvironment() was missing.