### PR TITLE
[TASK] Preparations for LTS-v8 compiling support bridge

### DIFF
--- a/Classes/Utility/ViewHelperUtility.php
+++ b/Classes/Utility/ViewHelperUtility.php
@@ -1,0 +1,34 @@
+<?php
+namespace FluidTYPO3\Vhs\Utility;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer;
+
+/**
+ * ViewHelper Utility
+ *
+ * Contains compatibility methods used in ViewHelpers
+ */
+class ViewHelperUtility
+{
+    /**
+     * Fixes a bug in TYPO3 6.2.0 that the properties metadata is not overlayed on localization.
+     *
+     * @param RenderingContextInterface $renderingContext
+     * @return TemplateVariableContainer|\TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface
+     */
+    public static function getVariableProviderFromRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        if (method_exists($renderingContext, 'getVariableProvider')) {
+            return $renderingContext->getVariableProvider();
+        }
+        return $renderingContext->getTemplateVariableContainer();
+    }
+}

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -123,29 +123,25 @@ abstract class AbstractViewHelperTest extends UnitTestCase
             ObjectAccess::setProperty($container, 'variables', $variables, true);
         }
         ObjectAccess::setProperty($this->renderingContext, 'templateVariableContainer', $container, true);
-        if (null !== $extensionName || null !== $pluginName) {
-            /** @var ViewHelperVariableContainer $viewHelperContainer */
-            $viewHelperContainer = $this->objectManager->get(ViewHelperVariableContainer::class);
-            /** @var UriBuilder $uriBuilder */
-            $uriBuilder = $this->objectManager->get(UriBuilder::class);
-            /** @var Request $request */
-            $request = $this->objectManager->get(Request::class);
-            if (null !== $extensionName) {
-                $request->setControllerExtensionName($extensionName);
-            }
-            if (null !== $pluginName) {
-                $request->setPluginName($pluginName);
-            }
-            /** @var Response $response */
-            $response = $this->objectManager->get(Response::class);
-            /** @var ControllerContext $controllerContext */
-            $controllerContext = $this->objectManager->get(ControllerContext::class);
-            $controllerContext->setRequest($request);
-            $controllerContext->setResponse($response);
-            $controllerContext->setUriBuilder($uriBuilder);
-            ObjectAccess::setProperty($this->renderingContext, 'viewHelperVariableContainer', $viewHelperContainer, true);
-            $this->renderingContext->setControllerContext($controllerContext);
-        }
+
+        /** @var ViewHelperVariableContainer $viewHelperContainer */
+        $viewHelperContainer = $this->objectManager->get(ViewHelperVariableContainer::class);
+        /** @var UriBuilder $uriBuilder */
+        $uriBuilder = $this->objectManager->get(UriBuilder::class);
+        /** @var Request $request */
+        $request = $this->objectManager->get(Request::class);
+        $request->setControllerExtensionName($extensionName);
+        $request->setPluginName($pluginName);
+        /** @var Response $response */
+        $response = $this->objectManager->get(Response::class);
+        /** @var ControllerContext $controllerContext */
+        $controllerContext = $this->objectManager->get(ControllerContext::class);
+        $controllerContext->setRequest($request);
+        $controllerContext->setResponse($response);
+        $controllerContext->setUriBuilder($uriBuilder);
+        ObjectAccess::setProperty($this->renderingContext, 'viewHelperVariableContainer', $viewHelperContainer, true);
+        $this->renderingContext->setControllerContext($controllerContext);
+
         if (null !== $childNode) {
             $node->addChildNode($childNode);
             if ($instance instanceof ChildNodeAccessInterface) {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         }
     },
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "namelesscoder/typo3-cms-fluid-gap": "*"
     },
     "require-dev": {
         "fluidtypo3/development": "^3.0"


### PR DESCRIPTION
This patch adds a couple of changes which will be required
for an in-progress conversion of every ViewHelper which
can support it, to ideal performance when compiled.

A new dependency, namelesscoder/typo3-cms-fluid-gap,
provides the necessary API to achieve this. Slight rewriting
of the test base ensures all ViewHelpers can be tested with
proxying from render() to renderStatic().