### PR TITLE
[TASK] No longer allow failures on HHVM and PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
       env: COVERAGE="NO"
     - php: "7.1"
       env: COVERAGE="NO"
-  allow_failures:
-    - php: "hhvm"
-    - php: "7.1"
 
 cache:
   directories:


### PR DESCRIPTION
The causes for failures are now corrected.