### PR TITLE
[TASK] Implement compile bridge in Math scope

### DIFF
--- a/Classes/Traits/ArrayConsumingViewHelperTrait.php
+++ b/Classes/Traits/ArrayConsumingViewHelperTrait.php
@@ -123,4 +123,13 @@ trait ArrayConsumingViewHelperTrait
         ArrayUtility::mergeRecursiveWithOverrule($array1, $array2);
         return $array1;
     }
+
+    /**
+     * @param mixed $subject
+     * @return boolean
+     */
+    protected static function assertIsArrayOrIterator($subject)
+    {
+        return (boolean) (true === is_array($subject) || true === $subject instanceof \Traversable);
+    }
 }

--- a/Classes/ViewHelpers/Math/AverageViewHelper.php
+++ b/Classes/ViewHelpers/Math/AverageViewHelper.php
@@ -8,6 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Average
  *
@@ -21,6 +24,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class AverageViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
      * @return void
@@ -32,39 +37,32 @@ class AverageViewHelper extends AbstractMultipleMathViewHelper
     }
 
     /**
+     * @param mixed $a
+     * @param mixed $b
+     * @param array $arguments
      * @return mixed
-     * @throw Exception
      */
-    public function render()
+    protected static function calculateAction($a, $b, array $arguments)
     {
-        $a = $this->getInlineArgument();
-        $b = $this->arguments['b'];
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
-        $bIsIterable = $this->assertIsArrayOrIterator($b);
-        if (true === $aIsIterable && null === $b) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
-            $sum = array_sum($a);
-            $distribution = count($a);
-            return $sum / $distribution;
-        } elseif (true === $aIsIterable && false === $bIsIterable) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        $bIsIterable = static::assertIsArrayOrIterator($b);
+        if (true === $aIsIterable) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            if ($b === null) {
+                return array_sum($a) / count($a);
+            }
+            if ($bIsIterable) {
+                $b = static::arrayFromArrayOrTraversableOrCSVStatic($b);
+            }
             foreach ($a as $index => $value) {
-                $a[$index] = $this->calculateAction($value, $b);
+                $bSide = $bIsIterable ? $b[$index] : $b;
+                $a[$index] = static::calculateAction($value, $bSide, $arguments);
             }
             return $a;
-        } elseif (true === isset($a) && null === $b) {
+        }
+        if (null === $b) {
             return $a;
         }
-        return $this->calculate($a, $b);
-    }
-
-    /**
-     * @param mixed $a
-     * @param $b
-     * @return mixed
-     */
-    protected function calculateAction($a, $b)
-    {
         return ($a + $b) / 2;
     }
 }

--- a/Classes/ViewHelpers/Math/CeilViewHelper.php
+++ b/Classes/ViewHelpers/Math/CeilViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Ceil
  *
@@ -17,13 +19,17 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class CeilViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map('ceil', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+        }
         return ceil($a);
     }
 }

--- a/Classes/ViewHelpers/Math/CubeViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubeViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Square
  *
@@ -15,13 +17,17 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class CubeViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map([static::class, 'calculateAction'], $a);
+        }
         return pow($a, 3);
     }
 }

--- a/Classes/ViewHelpers/Math/CubicRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubicRootViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: CubicRoot
  *
@@ -15,13 +17,17 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class CubicRootViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map([static::class, 'calculateAction'], static::arrayFromArrayOrTraversableOrCSVStatic($a));
+        }
         return pow($a, 1 / 3);
     }
 }

--- a/Classes/ViewHelpers/Math/DivisionViewHelper.php
+++ b/Classes/ViewHelpers/Math/DivisionViewHelper.php
@@ -8,6 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Division
  *
@@ -18,14 +21,37 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class DivisionViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @param mixed $b
+     * @param array $arguments
      * @return mixed
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b, array $arguments)
     {
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        $bIsIterable = static::assertIsArrayOrIterator($b);
+        if (true === $aIsIterable && null === $b) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            $sum = array_sum($a);
+            $distribution = count($a);
+            return $sum / $distribution;
+        } elseif (true === $aIsIterable && $b !== null) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            if ($bIsIterable) {
+                $b = static::arrayFromArrayOrTraversableOrCSVStatic($b);
+            }
+            foreach ($a as $index => $value) {
+                $bSide = $bIsIterable ? $b[$index] : $b;
+                $a[$index] = static::calculateAction($value, $bSide, $arguments);
+            }
+            return $a;
+        }
+        if ($b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         return (0 <> $b ? $a / $b : $a);
     }
 }

--- a/Classes/ViewHelpers/Math/FloorViewHelper.php
+++ b/Classes/ViewHelpers/Math/FloorViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Floor
  *
@@ -17,13 +19,17 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class FloorViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map('floor', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+        }
         return floor($a);
     }
 }

--- a/Classes/ViewHelpers/Math/MaximumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MaximumViewHelper.php
@@ -8,6 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Maximum
  *
@@ -16,6 +20,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class MaximumViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
      * @return void
@@ -27,28 +33,21 @@ class MaximumViewHelper extends AbstractMultipleMathViewHelper
     }
 
     /**
-     * @return mixed
-     * @throw Exception
-     */
-    public function render()
-    {
-        $a = $this->getInlineArgument();
-        $b = $this->arguments['b'];
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
-        if (true === $aIsIterable && null === $b) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
-            return max($a);
-        }
-        return $this->calculate($a, $b);
-    }
-
-    /**
      * @param mixed $a
      * @param mixed $b
+     * @param array $arguments
      * @return mixed
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b, array $arguments)
     {
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (true === $aIsIterable && null === $b) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            return max($a);
+        }
+        if ($b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         return max($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Math/MedianViewHelper.php
+++ b/Classes/ViewHelpers/Math/MedianViewHelper.php
@@ -8,6 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Median
  *
@@ -18,17 +21,18 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class MedianViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
+     * @param mixed $a
      * @return mixed
-     * @throw Exception
      */
-    public function render()
+    protected static function calculateAction($a)
     {
-        $a = $this->getInlineArgument();
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
+        $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             sort($a, SORT_NUMERIC);
             $size = count($a);
             $midpoint = $size / 2;

--- a/Classes/ViewHelpers/Math/MinimumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MinimumViewHelper.php
@@ -8,6 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Minimum
  *
@@ -16,6 +20,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class MinimumViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
      * @return void
@@ -27,28 +33,21 @@ class MinimumViewHelper extends AbstractMultipleMathViewHelper
     }
 
     /**
-     * @return mixed
-     * @throw Exception
-     */
-    public function render()
-    {
-        $a = $this->getInlineArgument();
-        $b = $this->arguments['b'];
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
-        if (true === $aIsIterable && null === $b) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
-            return min($a);
-        }
-        return $this->calculate($a, $b);
-    }
-
-    /**
      * @param mixed $a
      * @param mixed $b
+     * @param array $arguments
      * @return mixed
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b, array $arguments)
     {
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (true === $aIsIterable && null === $b) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            return min($a);
+        }
+        if ($b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         return min($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Math/ModuloViewHelper.php
+++ b/Classes/ViewHelpers/Math/ModuloViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Modulo
  * Perform modulo on $input. Returns the same type as $input,
@@ -26,13 +28,14 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class ModuloViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @param mixed $b
      * @return integer
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b)
     {
         return $a % $b;
     }

--- a/Classes/ViewHelpers/Math/PowerViewHelper.php
+++ b/Classes/ViewHelpers/Math/PowerViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Power
  *
@@ -15,13 +17,14 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class PowerViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @param mixed $b
      * @return integer
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b)
     {
         return pow($a, $b);
     }

--- a/Classes/ViewHelpers/Math/ProductViewHelper.php
+++ b/Classes/ViewHelpers/Math/ProductViewHelper.php
@@ -8,6 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * ### Math: Product (multiplication)
  *
@@ -20,30 +24,25 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class ProductViewHelper extends AbstractMultipleMathViewHelper
 {
-
-    /**
-     * @return mixed
-     * @throw Exception
-     */
-    public function render()
-    {
-        $a = $this->getInlineArgument();
-        $b = $this->arguments['b'];
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
-        if (true === $aIsIterable && null === $b) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
-            return array_product($a);
-        }
-        return $this->calculate($a, $b);
-    }
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
      * @param mixed $a
      * @param mixed $b
+     * @param array $arguments
      * @return mixed
      */
-    protected function calculateAction($a, $b)
+    protected static function calculateAction($a, $b, array $arguments)
     {
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (true === $aIsIterable && null === $b) {
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
+            return array_product($a);
+        }
+        if ($b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         return $a * $b;
     }
 }

--- a/Classes/ViewHelpers/Math/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Math/RangeViewHelper.php
@@ -8,6 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Range
  *
@@ -17,24 +20,16 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class RangeViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
+     * @param mixed $a
      * @return mixed
      * @throw Exception
      */
-    public function render()
+    protected static function calculateAction($a)
     {
-        $a = $this->getInlineArgument();
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
-        if (true === $aIsIterable) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
-            sort($a, SORT_NUMERIC);
-            if (1 === count($a)) {
-                return [reset($a), reset($a)];
-            } else {
-                return [array_shift($a), array_pop($a)];
-            }
-        }
-        return $a;
+        return [min($a), max($a)];
     }
 }

--- a/Classes/ViewHelpers/Math/RoundViewHelper.php
+++ b/Classes/ViewHelpers/Math/RoundViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Round
  *
@@ -17,6 +19,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class RoundViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @return void
@@ -29,10 +32,18 @@ class RoundViewHelper extends AbstractSingleMathViewHelper
 
     /**
      * @param mixed $a
+     * @param null $b
+     * @param array $arguments
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a, $b, array $arguments)
     {
-        return round($a, $this->arguments['decimals']);
+        if (static::assertIsArrayOrIterator($a)) {
+            foreach ($a as $index => $value) {
+                $a[$index] = static::calculateAction($value, $b, $arguments);
+            }
+            return $a;
+        }
+        return round($a, $arguments['decimals']);
     }
 }

--- a/Classes/ViewHelpers/Math/SquareRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareRootViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: SquareRoot
  *
@@ -15,13 +17,17 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class SquareRootViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map('sqrt', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+        }
         return sqrt($a);
     }
 }

--- a/Classes/ViewHelpers/Math/SquareViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
 /**
  * Math: Square
  *
@@ -15,13 +17,20 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class SquareViewHelper extends AbstractSingleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
 
     /**
      * @param mixed $a
      * @return integer
      */
-    protected function calculateAction($a)
+    protected static function calculateAction($a)
     {
+        if (static::assertIsArrayOrIterator($a)) {
+            return array_map(
+                [static::class, 'calculateAction'],
+                static::arrayFromArrayOrTraversableOrCSVStatic($a)
+            );
+        }
         return pow($a, 2);
     }
 }

--- a/Classes/ViewHelpers/Math/SubtractViewHelper.php
+++ b/Classes/ViewHelpers/Math/SubtractViewHelper.php
@@ -7,6 +7,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * For the full copyright and license information, please read the
  * LICENSE.md file that was distributed with this source code.
  */
+use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Subtract
@@ -20,6 +23,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 class SubtractViewHelper extends AbstractMultipleMathViewHelper
 {
+    use CompileWithContentArgumentAndRenderStatic;
+    use ArrayConsumingViewHelperTrait;
 
     /**
      * @return void
@@ -31,28 +36,21 @@ class SubtractViewHelper extends AbstractMultipleMathViewHelper
     }
 
     /**
+     * @param mixed $a
+     * @param mixed $b
+     * @param array $arguments
      * @return mixed
-     * @throw Exception
      */
-    public function render()
+    protected static function calculateAction($a, $b, array $arguments)
     {
-        $a = $this->getInlineArgument();
-        $b = $this->arguments['b'];
-        $aIsIterable = $this->assertIsArrayOrIterator($a);
+        $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable && null === $b) {
-            $a = $this->arrayFromArrayOrTraversableOrCSV($a);
+            $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             return -array_sum($a);
         }
-        return $this->calculate($a, $b);
-    }
-
-    /**
-     * @param mixed $a
-     * @param $b
-     * @return mixed
-     */
-    protected function calculateAction($a, $b)
-    {
+        if ($b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         return $a - $b;
     }
 }

--- a/Tests/Unit/ViewHelpers/Math/AbstractMathViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/AbstractMathViewHelperTest.php
@@ -23,7 +23,7 @@ abstract class AbstractMathViewHelperTest extends AbstractViewHelperTest
      */
     protected function executeSingleArgumentTest($a, $expected)
     {
-        $result = $this->executeViewHelper(['a' => $a]);
+        $result = $this->executeViewHelper(['a' => $a, 'fail' => false]);
         $this->assertEquals($expected, $result);
     }
 
@@ -35,7 +35,7 @@ abstract class AbstractMathViewHelperTest extends AbstractViewHelperTest
      */
     protected function executeDualArgumentTest($a, $b, $expected)
     {
-        $result = $this->executeViewHelper(['a' => $a, 'b' => $b]);
+        $result = $this->executeViewHelper(['a' => $a, 'b' => $b, 'fail' => false]);
         $this->assertEquals($expected, $result);
     }
 }

--- a/Tests/Unit/ViewHelpers/Math/AverageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/AverageViewHelperTest.php
@@ -54,12 +54,4 @@ class AverageViewHelperTest extends AbstractMathViewHelperTest
         $this->executeDualArgumentTest([1, 5], [3, 3], [2, 4]);
     }
 
-    /**
-     * @test
-     */
-    public function executeMissingArgumentTest()
-    {
-        $this->expectViewHelperException('Required argument "b" was not supplied');
-        $this->executeViewHelper([]);
-    }
 }

--- a/Tests/Unit/ViewHelpers/Math/DivisionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/DivisionViewHelperTest.php
@@ -36,7 +36,7 @@ class DivisionViewHelperTest extends AbstractMathViewHelperTest
     public function executeMissingArgumentTest()
     {
         $this->expectViewHelperException('Required argument "b" was not supplied');
-        $this->executeViewHelper([]);
+        $this->executeViewHelper(['a' => 1, 'fail' => true]);
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Math/MaximumViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/MaximumViewHelperTest.php
@@ -44,7 +44,7 @@ class MaximumViewHelperTest extends AbstractMathViewHelperTest
     public function executeMissingArgumentTest()
     {
         $this->expectViewHelperException('Required argument "b" was not supplied');
-        $result = $this->executeViewHelper([]);
+        $result = $this->executeViewHelper(['a' => 1, 'fail' => true]);
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Math/MinimumViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/MinimumViewHelperTest.php
@@ -44,7 +44,7 @@ class MinimumViewHelperTest extends AbstractMathViewHelperTest
     public function executeMissingArgumentTest()
     {
         $this->expectViewHelperException('Required argument "b" was not supplied');
-        $this->executeViewHelper([]);
+        $this->executeViewHelper(['a' => 1, 'fail' => true]);
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Math/ProductViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/ProductViewHelperTest.php
@@ -36,7 +36,7 @@ class ProductViewHelperTest extends AbstractMathViewHelperTest
     public function executeMissingArgumentTest()
     {
         $this->expectViewHelperException('Required argument "b" was not supplied');
-        $this->executeViewHelper([]);
+        $this->executeViewHelper(['a' => 1, 'fail' => true]);
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Math/RangeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/RangeViewHelperTest.php
@@ -13,15 +13,6 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Math;
  */
 class RangeViewHelperTest extends AbstractMathViewHelperTest
 {
-
-    /**
-     * @test
-     */
-    public function testSingleArgumentNotIteratorPassesThrough()
-    {
-        $this->executeSingleArgumentTest(1, 1);
-    }
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Math/SubtractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Math/SubtractViewHelperTest.php
@@ -36,7 +36,7 @@ class SubtractViewHelperTest extends AbstractMathViewHelperTest
     public function executeMissingArgumentTest()
     {
         $this->expectViewHelperException('Required argument "b" was not supplied');
-        $result = $this->executeViewHelper([]);
+        $result = $this->executeViewHelper(['a' => 1, 'fail' => true]);
     }
 
     /**


### PR DESCRIPTION
Also moves a utility method to detect iterators or
arrays, to the ArrayConsumingViewHelperTrait.

NB: a few esoteric bugs are also fixed with this,
mainly related to processing array arguments in
math operations. Fewer cases now cause errors.