### PR TITLE
[TASK] Bundle FluidGap classes for 7.6 in non-composer mode

### DIFF
--- a/Resources/Private/Php/FluidGap/CompileWithContentArgumentAndRenderStatic.php
+++ b/Resources/Private/Php/FluidGap/CompileWithContentArgumentAndRenderStatic.php
@@ -1,0 +1,109 @@
+<?php
+namespace NamelessCoder\FluidGap\Traits;
+
+use TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
+
+
+/**
+ * Class CompilableWithContentArgumentAndRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern but has the added common use case that
+ * an argument value must be checked and used instead of
+ * the normal render children closure, if that named
+ * argument is specified and not empty.
+ */
+trait CompileWithContentArgumentAndRenderStatic {
+
+    /**
+     * Name of variable that contains the value to use
+     * instead of render children closure, if specified.
+     * If no name is provided here, the first variable
+     * registered in `initializeArguments` of the ViewHelper
+     * will be used.
+     *
+     * Note: it is significantly better practice to define
+     * this property in your ViewHelper class and so fix it
+     * to one particular argument instead of resolving,
+     * especially when your ViewHelper is called multiple
+     * times within an uncompiled template!
+     *
+     * @var string
+     */
+    protected $contentArgumentName;
+
+    /**
+     * Default render method to render ViewHelper with
+     * first defined optional argument as content.
+     *
+     * @return string Rendered string
+     * @api
+     */
+    public function render() {
+        $argumentName = $this->resolveContentArgumentName();
+        $arguments = $this->arguments;
+        if (!empty($argumentName) && isset($arguments[$argumentName])) {
+            $renderChildrenClosure = function() use ($arguments, $argumentName) { return $arguments[$argumentName]; };
+        } else {
+            $renderChildrenClosure = call_user_func_array(array($this, 'buildRenderChildrenClosure'), array());
+        }
+        return static::renderStatic(
+            $arguments,
+            $renderChildrenClosure,
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param AbstractNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        AbstractNode $node,
+        TemplateCompiler $compiler
+    ) {
+        $contentArgumentName = $this->resolveContentArgumentName();
+        return sprintf(
+            '%s::renderStatic(%s, isset(%s[\'%s\']) ? function() use (%s); return %s[\'%s\']; } : %s, $renderingContext)',
+            static::class,
+            $argumentsName,
+            $argumentsName,
+            $contentArgumentName,
+            $argumentsName,
+            $argumentsName,
+            $contentArgumentName,
+            $closureName
+        );
+    }
+
+    /**
+     * @return string
+     * @throws Exception
+     */
+    protected function resolveContentArgumentName() {
+        if (empty($this->contentArgumentName)) {
+            $registeredArguments = call_user_func_array(array($this, 'prepareArguments'), array());
+            foreach ($registeredArguments as $registeredArgument) {
+                if (!$registeredArgument->isRequired()) {
+                    return $registeredArgument->getName();
+                }
+            }
+            throw new Exception(
+                'Attempting to compile %s failed. Chosen compile method requires that ViewHelper has ' .
+                'at least one registered and optional argument'
+            );
+        }
+        return $this->contentArgumentName;
+    }
+
+}

--- a/Resources/Private/Php/FluidGap/CompileWithRenderStatic.php
+++ b/Resources/Private/Php/FluidGap/CompileWithRenderStatic.php
@@ -1,0 +1,54 @@
+<?php
+namespace NamelessCoder\FluidGap\Traits;
+use TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode;
+
+
+/**
+ * Class CompilableWithRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern.
+ */
+trait CompileWithRenderStatic {
+
+    /**
+     * Default render method - simply calls renderStatic() with a
+     * prepared set of arguments.
+     *
+     * @return string Rendered string
+     * @api
+     */
+    public function render() {
+        return static::renderStatic(
+            $this->arguments,
+            call_user_func_array(array($this, 'buildRenderChildrenClosure'), array()),
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param AbstractNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        AbstractNode $node,
+        TemplateCompiler $compiler
+    ) {
+        return sprintf(
+            '%s::renderStatic(%s, %s, $renderingContext)',
+            static::class,
+            $argumentsName,
+            $closureName
+        );
+    }
+
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -32,3 +32,25 @@ if (FALSE === is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfi
 
 // add navigtion hide, url and urltype to fix the rendering of external url doktypes
 $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= (TRUE === empty($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']) ? '' : ',') . 'nav_hide,url,urltype';
+
+// manual patching to add namelesscoder/typo3-cms-fluid-gap, but only when TYPO3 is *NOT* in composer mode and only
+// if the classes are *NOT* already loaded by another extension using this same trick. Note, on TYPO3 8.4+ the classes
+// will already exist in Fluid itself and we can get by with a simple class alias.
+if (
+    !(
+        defined('TYPO3_COMPOSER_MODE')
+        && TYPO3_COMPOSER_MODE
+        && class_exists(\NamelessCoder\FluidGap\Traits\CompileWithRenderStatic::class)
+        && class_exists(\NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic::class)
+    )
+) {
+    if (defined('TYPO3_branch') && TYPO3_branch === '7.6') {
+        $fluidGapTraitsPath = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('vhs', 'Resources/Private/Php/FluidGap/');
+        require_once $fluidGapTraitsPath . 'CompileWithRenderStatic.php';
+        require_once $fluidGapTraitsPath . 'CompileWithContentArgumentAndRenderStatic.php';
+        unset($fluidGapTraitsPath);
+    } else {
+        class_alias(\TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic::class, 'NamelessCoder\\FluidGap\\Traits\\CompileWithRenderStatic');
+        class_alias(\TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic::class, 'NamelessCoder\\FluidGap\\Traits\\CompileWithContentArgumentAndRenderStatic');
+    }
+}


### PR DESCRIPTION
Uses a bit of careful decision making before loading the
classes, since it is more than likely other extensions might
be using the same trick to include these non-typo3-extension
classes on non-composer setups.