### PR TITLE
Support ObjectStorages on SelectOptionViewHelper in case the select i…

### DIFF
--- a/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Form\Select;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Form\SelectViewHelper;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 /**
@@ -57,10 +58,9 @@ class OptionViewHelper extends AbstractFormFieldViewHelper
             if (false === is_object($this->arguments['value']) && false === is_array($this->arguments['value'])) {
                 if (true === is_array($value)) {
                     $selected = true === in_array($this->arguments['value'], $value) ? 'selected' : '';
-                } else if($value instanceof \TYPO3\CMS\Extbase\Persistence\ObjectStorage && is_numeric($this->arguments['value'])) {
+                } else if(true === ($value instanceof ObjectStorage) && false === is_numeric($this->arguments['value'])) {
                     // Requires that the option values are UIDs of objects in ObjectStorage
-                    $objectStorageObjects = $value->toArray();
-                    foreach ($objectStorageObjects as $object) {
+                    foreach ($value as $object) {
                         if($object->getUid() == $this->arguments['value']) {
                             $selected = 'selected';
                             break;

--- a/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -57,6 +57,15 @@ class OptionViewHelper extends AbstractFormFieldViewHelper
             if (false === is_object($this->arguments['value']) && false === is_array($this->arguments['value'])) {
                 if (true === is_array($value)) {
                     $selected = true === in_array($this->arguments['value'], $value) ? 'selected' : '';
+                } else if($value instanceof \TYPO3\CMS\Extbase\Persistence\ObjectStorage && is_numeric($this->arguments['value'])) {
+                    // Requires that the option values are UIDs of objects in ObjectStorage
+                    $objectStorageObjects = $value->toArray();
+                    foreach ($objectStorageObjects as $object) {
+                        if($object->getUid() == $this->arguments['value']) {
+                            $selected = 'selected';
+                            break;
+                        }
+                    }
                 } else {
                     $selected = (string) $this->arguments['value'] == (string) $value ? 'selected' : '';
                 }

--- a/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -61,7 +61,7 @@ class OptionViewHelper extends AbstractFormFieldViewHelper
                 } else if(true === ($value instanceof ObjectStorage) && false === is_numeric($this->arguments['value'])) {
                     // Requires that the option values are UIDs of objects in ObjectStorage
                     foreach ($value as $object) {
-                        if($object->getUid() == $this->arguments['value']) {
+                        if($object->getUid() === (integer) $this->arguments['value']) {
                             $selected = 'selected';
                             break;
                         }

--- a/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -58,7 +58,7 @@ class OptionViewHelper extends AbstractFormFieldViewHelper
             if (false === is_object($this->arguments['value']) && false === is_array($this->arguments['value'])) {
                 if (true === is_array($value)) {
                     $selected = true === in_array($this->arguments['value'], $value) ? 'selected' : '';
-                } else if(true === ($value instanceof ObjectStorage) && false === is_numeric($this->arguments['value'])) {
+                } else if(true === ($value instanceof ObjectStorage) && true === is_numeric($this->arguments['value'])) {
                     // Requires that the option values are UIDs of objects in ObjectStorage
                     foreach ($value as $object) {
                         if($object->getUid() === (integer) $this->arguments['value']) {


### PR DESCRIPTION
…s configured as "multiple"

Usage example:

```
<v:form.select property="kategorie" id="kategorie" multiple="1" class="form-control" optionLabelField="name" optionValueField="uid" additionalAttributes="{required: 'required'}">
                <v:form.select.option value="">
                    Bitte wählen
                </v:form.select.option>
                <f:for each="{kategorien}" as="ueberKategorie">
                    <v:form.select.optgroup label="{ueberKategorie.name}">
                        <f:for each="{ueberKategorie.unterkategorien}" as="kategorie">
                            <v:form.select.option value="{kategorie.uid}">
                                {kategorie.name}
                            </v:form.select.option>
                        </f:for>
                    </v:form.select.optgroup>
                </f:for>
            </v:form.select>
```