### PR TITLE
[FEATURE] Add Iterator/Split ViewHelper for str_split

### DIFF
--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -1,0 +1,54 @@
+<?php
+namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Converts a string to an array with $length number of bytes
+ * per new array element. Wrapper for PHP's `str_split`.
+ */
+class SplitViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+    use TemplateVariableViewHelperTrait;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('subject', 'string', 'The string that will be split into an array');
+        $this->registerArgument('length', 'integer', 'Number of bytes per chunk in the new array', false, 1);
+        $this->registerAsArgument();
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        if ((integer) $arguments['length'] === 0) {
+            // Difference from PHP str_split: return an empty array if (potentially dynamically defined) length
+            // argument is zero for some reason. PHP would throw a warning; Fluid would logically just return empty.
+            return [];
+        }
+        return str_split($renderChildrenClosure(), $arguments['length']);
+    }
+}

--- a/Tests/Unit/ViewHelpers/Iterator/SplitViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/SplitViewHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Iterator;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
+
+/**
+ * Class SplitViewHelperTest
+ */
+class SplitViewHelperTest extends AbstractViewHelperTest
+{
+
+    /**
+     * @test
+     * @dataProvider getRenderTestValues
+     * @param array $arguments
+     * @param mixed $expectedValue
+     */
+    public function testRender(array $arguments, $expectedValue)
+    {
+        $value = $this->executeViewHelper($arguments);
+        $this->assertEquals($value, $expectedValue);
+    }
+
+    /**
+     * @return array
+     */
+    public function getRenderTestValues()
+    {
+        return [
+            'zero length empty string' => [['subject' => '', 'length' => 0], []],
+            'zero length non-empty string' => [['subject' => 'not-empty', 'length' => 0], []],
+            'non-empty string 1 length' => [['subject' => 'foobar', 'length' => 1], ['f', 'o', 'o', 'b', 'a', 'r']],
+            'non-empty string 2 length' => [['subject' => 'foobar', 'length' => 2], ['fo', 'ob', 'ar']],
+        ];
+    }
+}


### PR DESCRIPTION
Provides a way to split a string into an array with $length
number of bytes of the string in each array value.

In other words, `str_split` for Fluid.