### PR TITLE
[TASK] Require TYPO3Fluid/Fluid compiling Traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env: TYPO3_VERSION=">=7.6.13, <7.6.99"
 matrix:
   include:
     - php: "7.0"
+      env: COVERAGE="NO" TYPO3_VERSION="dev-master"
+    - php: "7.0"
       env: COVERAGE="NO" TYPO3_VERSION=">=7.6.13, <7.6.99"
     - php: "7.0"
       env: COVERAGE="NO" TYPO3_VERSION="^8.4.1"

--- a/Classes/ViewHelpers/CallViewHelper.php
+++ b/Classes/ViewHelpers/CallViewHelper.php
@@ -10,7 +10,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Call ViewHelper
@@ -27,7 +28,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
  *     <!-- arguments for the method -->
  *     <v:call object="{object}" method="doSomethingWithArguments" arguments="{0: 'foo', 1: 'bar'}" />
  */
-class CallViewHelper extends AbstractViewHelper
+class CallViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/ConstViewHelper.php
+++ b/Classes/ViewHelpers/ConstViewHelper.php
@@ -9,14 +9,15 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  */
 
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Const ViewHelper
  *
  * Renders the value of a PHP constant
  */
-class ConstViewHelper extends AbstractViewHelper
+class ConstViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -11,7 +11,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 use TYPO3\CMS\Extbase\Reflection\Exception\PropertyNotAccessibleException;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
-use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode as LegacyFluidObjectAccessorNode;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode as StandaloneFluidObjectAccessorNode;
 use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode as LegacyFluidViewHelperNode;
 use \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode as StandaloneFluidViewHelperNode;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -166,10 +167,10 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
     public function setChildNodes(array $childNodes)
     {
         foreach ($childNodes as $childNode) {
-            if (true === $childNode instanceof ViewHelperNode || $childNode instanceof FluidStandaloneViewHelperNode) {
+            if (true === $childNode instanceof LegacyFluidViewHelperNode || $childNode instanceof StandaloneFluidViewHelperNode) {
                 array_push($this->childViewHelperNodes, $childNode);
             }
-            if (true === $childNode instanceof ObjectAccessorNode || $childNode instanceof LegacyFluidViewHelperNode) {
+            if (true === $childNode instanceof LegacyFluidObjectAccessorNode || $childNode instanceof StandaloneFluidObjectAccessorNode) {
                 array_push($this->childObjectAccessorNodes, $childNode);
             }
         }

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -10,7 +10,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
@@ -18,7 +19,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
 /**
  * Returns random element from array.
  */
-class RandomViewHelper extends AbstractViewHelper
+class RandomViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
     use TemplateVariableViewHelperTrait;

--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -12,13 +12,14 @@ use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Converts a string to an array with $length number of bytes
  * per new array element. Wrapper for PHP's `str_split`.
  */
-class SplitViewHelper extends AbstractViewHelper
+class SplitViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
     use TemplateVariableViewHelperTrait;

--- a/Classes/ViewHelpers/LViewHelper.php
+++ b/Classes/ViewHelpers/LViewHelper.php
@@ -11,7 +11,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### L (localisation) ViewHelper
@@ -28,7 +29,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
  *     <v:l key="some.label" />
  *     <v:l arguments="{0: 'foo', 1: 'bar'}">some.label</v:l>
  */
-class LViewHelper extends AbstractViewHelper
+class LViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/Once/InstanceViewHelper.php
+++ b/Classes/ViewHelpers/Once/InstanceViewHelper.php
@@ -28,14 +28,15 @@ class InstanceViewHelper extends AbstractOnceViewHelper
 {
 
     /**
+     * @param array $arguments
      * @return string
      */
-    protected function getIdentifier()
+    protected static function getIdentifier(array $arguments)
     {
-        if (true === isset($this->arguments['identifier']) && null !== $this->arguments['identifier']) {
-            return $this->arguments['identifier'];
+        if (true === isset($arguments['identifier']) && null !== $arguments['identifier']) {
+            return $arguments['identifier'];
         }
-        $request = $this->renderingContext->getControllerContext()->getRequest();
+        $request = static::$currentRenderingContext->getControllerContext()->getRequest();
         $identifier = implode('_', [
             $request->getControllerActionName(),
             $request->getControllerName(),
@@ -46,25 +47,25 @@ class InstanceViewHelper extends AbstractOnceViewHelper
     }
 
     /**
+     * @param array $arguments
      * @return void
      */
-    protected function storeIdentifier()
+    protected static function storeIdentifier(array $arguments)
     {
-        $index = get_class($this);
-        $identifier = $this->getIdentifier();
-        if (false === is_array($GLOBALS[$index])) {
-            $GLOBALS[$index] = [];
+        $identifier = static::getIdentifier($arguments);
+        if (false === is_array($GLOBALS[static::class])) {
+            $GLOBALS[static::class] = [];
         }
-        $GLOBALS[$index][$identifier] = true;
+        $GLOBALS[static::class][$identifier] = true;
     }
 
     /**
+     * @param array $arguments
      * @return boolean
      */
-    protected function assertShouldSkip()
+    protected static function assertShouldSkip(array $arguments)
     {
-        $index = get_class($this);
-        $identifier = $this->getIdentifier();
-        return isset($GLOBALS[$index][$identifier]);
+        $identifier = static::getIdentifier($arguments);
+        return isset($GLOBALS[static::class][$identifier]);
     }
 }

--- a/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
+++ b/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -16,7 +17,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * Returns a full, absolute URL to this page with all arguments.
  */
-class AbsoluteUrlViewHelper extends AbstractViewHelper
+class AbsoluteUrlViewHelper extends AbstractViewHelper implements CompilableInterface
 {
 
     use CompileWithRenderStatic;

--- a/Classes/ViewHelpers/Page/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Page/InfoViewHelper.php
@@ -10,7 +10,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Service\PageService;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
@@ -19,7 +20,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * ViewHelper to access data of the current page record.
  */
-class InfoViewHelper extends AbstractViewHelper
+class InfoViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
     use TemplateVariableViewHelperTrait;

--- a/Classes/ViewHelpers/Page/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageViewHelper.php
@@ -9,7 +9,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  */
 
 use FluidTYPO3\Vhs\Service\PageService;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
@@ -18,7 +19,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * Returns the current language from languages depending on l18n settings.
  */
-class LanguageViewHelper extends AbstractViewHelper
+class LanguageViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Page/RootlineViewHelper.php
+++ b/Classes/ViewHelpers/Page/RootlineViewHelper.php
@@ -10,7 +10,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Service\PageService;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -18,7 +19,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * ViewHelper to get the rootline of a page.
  */
-class RootlineViewHelper extends AbstractViewHelper
+class RootlineViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
     use TemplateVariableViewHelperTrait;

--- a/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
+++ b/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -21,7 +22,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * does not respect this setting you can use this ViewHelper to prepend that setting
  * after the value is returned from the other ViewHelper.
  */
-class StaticPrefixViewHelper extends AbstractViewHelper
+class StaticPrefixViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Random/NumberViewHelper.php
+++ b/Classes/ViewHelpers/Random/NumberViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Random;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -19,7 +20,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * set to 100000 in order to generate a longer integer string
  * representation. Decimal values can be generated as well.
  */
-class NumberViewHelper extends AbstractViewHelper
+class NumberViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Random/StringViewHelper.php
+++ b/Classes/ViewHelpers/Random/StringViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Random;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -22,7 +23,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Has built-in insurance that first character of random string is
  * an alphabetic character (allowing safe use as DOM id for example).
  */
-class StringViewHelper extends AbstractViewHelper
+class StringViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Render/AsciiViewHelper.php
+++ b/Classes/ViewHelpers/Render/AsciiViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -35,7 +36,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * Will produce a Windows line break, \r\n.
  */
-class AsciiViewHelper extends AbstractViewHelper
+class AsciiViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 
@@ -44,7 +45,7 @@ class AsciiViewHelper extends AbstractViewHelper
      */
     public function initializeArguments()
     {
-        $this->registerArgument('ascii', 'string', 'ASCII character to render');
+        $this->registerArgument('ascii', 'mixed', 'ASCII character to render');
     }
 
     /**

--- a/Classes/ViewHelpers/Render/CacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/CacheViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
@@ -46,7 +47,7 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
  * interact with the PageRenderer or other "live" objects; this
  * includes many of the VHS ViewHelpers!
  */
-class CacheViewHelper extends AbstractRenderViewHelper
+class CacheViewHelper extends AbstractRenderViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/Render/InlineViewHelper.php
+++ b/Classes/ViewHelpers/Render/InlineViewHelper.php
@@ -7,7 +7,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * For the full copyright and license information, please read the
  * LICENSE.md file that was distributed with this source code.
  */
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -22,7 +23,7 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
  * rendering this inline code will be destroyed after
  * sub-rendering is finished.
  */
-class InlineViewHelper extends AbstractRenderViewHelper
+class InlineViewHelper extends AbstractRenderViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/Render/RecordViewHelper.php
+++ b/Classes/ViewHelpers/Render/RecordViewHelper.php
@@ -9,14 +9,15 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * ViewHelper used to render raw content records typically fetched
  * with `<v:content.get(column: '0', render: FALSE) />`.
  */
-class RecordViewHelper extends AbstractContentViewHelper
+class RecordViewHelper extends AbstractContentViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Dispatcher;
@@ -30,7 +31,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  * in GET/POST parameters but must be provided as if the
  * arguments were sent directly to the Controller action.
  */
-class RequestViewHelper extends AbstractRenderViewHelper
+class RequestViewHelper extends AbstractRenderViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -19,7 +20,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Please be aware that this will impact render time.
  * Arguments must be serializable and will be cached.
  */
-class UncacheViewHelper extends AbstractViewHelper
+class UncacheViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Site/NameViewHelper.php
+++ b/Classes/ViewHelpers/Site/NameViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -17,7 +18,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * Returns the site name as specified in `$TYPO3_CONF_VARS`.
  */
-class NameViewHelper extends AbstractViewHelper
+class NameViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Site/UrlViewHelper.php
+++ b/Classes/ViewHelpers/Site/UrlViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -19,7 +20,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Returns the website URL as returned by
  * `\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL')`
  */
-class UrlViewHelper extends AbstractViewHelper
+class UrlViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -17,7 +18,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * Returns the current system UNIX timestamp as DateTime.
  */
-class DateTimeViewHelper extends AbstractViewHelper
+class DateTimeViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -21,7 +22,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  *     <!-- adds exactly one hour to a DateTime and formats it -->
  *     <f:format.date format="H:i">{dateTime.timestamp -> v:math.sum(b: 3600)}</f:format.date>
  */
-class TimestampViewHelper extends AbstractViewHelper
+class TimestampViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/System/UniqIdViewHelper.php
+++ b/Classes/ViewHelpers/System/UniqIdViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -20,7 +21,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Comes in useful when handling/generating html-element-IDs
  * for usage with JavaScript.
  */
-class UniqIdViewHelper extends AbstractViewHelper
+class UniqIdViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -10,14 +10,15 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
 
 
 use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Renders Gravatar URI.
  */
-class GravatarViewHelper extends AbstractViewHelper
+class GravatarViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Uri/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Uri/RequestViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -19,7 +20,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * Returns the Uri of the requested page (site_url + all the GET params)
  * `\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')`.
  */
-class RequestViewHelper extends AbstractViewHelper
+class RequestViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -41,7 +42,7 @@ use TYPO3\CMS\Fluid\ViewHelpers\Uri\TypolinkViewHelper as FluidTypolinkViewHelpe
  *
  * @deprecated Use TYPO3\CMS\Fluid\ViewHelpers\Uri\TypolinkViewHelper, remove in 4.0.0
  */
-class TypolinkViewHelper extends AbstractViewHelper
+class TypolinkViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Variable/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ConvertViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
@@ -23,7 +24,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  * sensible defaults are assigned or $default which obviously has to
  * be of $type as well.
  */
-class ConvertViewHelper extends AbstractViewHelper
+class ConvertViewHelper extends AbstractViewHelper implements CompilableInterface
 {
 
     use CompileWithContentArgumentAndRenderStatic;

--- a/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
@@ -12,7 +12,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * ### ExtConf ViewHelper
@@ -25,7 +26,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
  *
  * Returns setting `bar.baz` from extension 'foo' located in `ext_conf_template.txt`.
  */
-class ExtensionConfigurationViewHelper extends AbstractViewHelper
+class ExtensionConfigurationViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Variable/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/GetViewHelper.php
@@ -12,7 +12,8 @@ use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * ### Variable: Get
@@ -49,7 +50,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
  * default is set to `FALSE`.
  * ```
  */
-class GetViewHelper extends AbstractViewHelper
+class GetViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 

--- a/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
+++ b/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
@@ -12,14 +12,15 @@ use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * ### PregMatch regular expression ViewHelper
  *
  * Implementation of `preg_match' for Fluid.
  */
-class PregMatchViewHelper extends AbstractViewHelper
+class PregMatchViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
     use TemplateVariableViewHelperTrait;

--- a/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -22,7 +23,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  *     <!-- if {variableName} is "Name", outputs value of {dynamicName} -->
  *     {v:variable.register.get(name: 'dynamic{variableName}')}
  */
-class GetViewHelper extends AbstractViewHelper
+class GetViewHelper extends AbstractViewHelper implements CompilableInterface
 {
 
     use CompileWithContentArgumentAndRenderStatic;

--- a/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
@@ -8,7 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
@@ -21,9 +22,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * Using as `{value -> v:variable.register.set(name: 'myVar')}` makes $GLOBALS["TSFE"]->register['myVar']
  * contain `{value}`.
  */
-class SetViewHelper extends AbstractViewHelper
+class SetViewHelper extends AbstractViewHelper implements CompilableInterface
 {
-
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/Classes/ViewHelpers/Variable/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/SetViewHelper.php
@@ -12,7 +12,8 @@ use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable: Set
@@ -56,7 +57,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
  * Using as `{value -> v:variable.set(name: 'myVar')}` makes `{myVar}` contain
  * `{value}`.
  */
-class SetViewHelper extends AbstractViewHelper
+class SetViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
+++ b/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
@@ -12,7 +12,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable: TypoScript
@@ -44,7 +45,7 @@ use NamelessCoder\FluidGap\Traits\CompileWithContentArgumentAndRenderStatic;
  *     <!-- An additional example to demonstrate very compact conditions which prevent wraps from being displayed -->
  *     {wrap.0 -> f:if(condition: settings.wrapBefore)}{menuItem.title}{wrap.1 -> f:if(condition: settings.wrapAfter)}
  */
-class TyposcriptViewHelper extends AbstractViewHelper
+class TyposcriptViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithContentArgumentAndRenderStatic;
 

--- a/Classes/ViewHelpers/Variable/UnsetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/UnsetViewHelper.php
@@ -8,7 +8,11 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ViewHelperUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * ### Variable: Unset
@@ -32,21 +36,33 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  *     <!-- DOES NOT WORK! -->
  *     <v:variable.unset name="myObject.propertyName" />
  */
-class UnsetViewHelper extends AbstractViewHelper
+class UnsetViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
 
     /**
-     * Unsets variable $name if it exists in the container
-     *
-     * @param string $name
      * @return void
      */
-    public function render($name)
+    public function initializeArguments()
     {
-        if (property_exists($this, 'variableProvider')) {
-            unset($this->variableProvider[$name]);
-        } elseif (true === $this->templateVariableContainer->exists($name)) {
-            $this->templateVariableContainer->remove($name);
+        $this->registerArgument('name', 'string', 'Name of variable in variable container', true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $name = $arguments['name'];
+        $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);
+        if ($variableProvider->exists($name)) {
+            $variableProvider->remove($name);
         }
     }
 }

--- a/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Condition\Page;
 
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
 
 /**
  * Class IsChildPageViewHelperTest

--- a/Tests/Unit/ViewHelpers/Iterator/KeysViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/KeysViewHelperTest.php
@@ -27,19 +27,6 @@ class KeysViewHelperTest extends AbstractViewHelperTest
             'subject' => $array,
         ];
         $output = $this->executeViewHelper($arguments);
-        $output2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), [], ['v' => $array]);
         $this->assertEquals($expected, $output);
-        $this->assertEquals($output, $output2);
-    }
-
-    /**
-     * @test
-     */
-    public function supportsAsArgument()
-    {
-        $array = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
-        $arguments = ['as' => 'v', 'subject' => $array];
-        $result = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v.1'), $arguments);
-        $this->assertEquals('b', $result);
     }
 }

--- a/Tests/Unit/ViewHelpers/Iterator/PopViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/PopViewHelperTest.php
@@ -24,14 +24,7 @@ class PopViewHelperTest extends AbstractViewHelperTest
      */
     public function testRender(array $arguments, $expectedValue)
     {
-        if (true === isset($arguments['as'])) {
-            $value = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('variable'), $arguments);
-        } else {
-            $value = $this->executeViewHelper($arguments);
-            $value2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), [], ['v' => $arguments['subject']]);
-            $this->assertEquals($value, $value2);
-        }
-        $this->assertEquals($value, $expectedValue);
+        $this->assertEquals($this->executeViewHelper($arguments), $expectedValue);
     }
 
     /**
@@ -42,9 +35,7 @@ class PopViewHelperTest extends AbstractViewHelperTest
         return [
             [['subject' => []], null],
             [['subject' => ['foo', 'bar']], 'bar'],
-            [['subject' => ['foo', 'bar'], 'as' => 'variable'], 'bar'],
             [['subject' => new \ArrayIterator(['foo', 'bar'])], 'bar'],
-            [['subject' => new \ArrayIterator(['foo', 'bar']), 'as' => 'variable'], 'bar'],
         ];
     }
 

--- a/Tests/Unit/ViewHelpers/Iterator/RandomViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/RandomViewHelperTest.php
@@ -25,15 +25,7 @@ class RandomViewHelperTest extends AbstractViewHelperTest
      */
     public function testRender(array $arguments, array $asArray)
     {
-        if (true === isset($arguments['as'])) {
-            $value = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('variable'), $arguments);
-        } else {
-            $value = $this->executeViewHelper($arguments);
-            $value2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), [], ['v' => $arguments['subject']]);
-            if (null !== $value2) {
-                $this->assertContains($value2, $asArray);
-            }
-        }
+        $value = $this->executeViewHelper($arguments);
         if (null !== $value) {
             $this->assertContains($value, $asArray);
         } else {
@@ -52,11 +44,8 @@ class RandomViewHelperTest extends AbstractViewHelperTest
         $queryResult->expects($this->any())->method('valid')->will($this->returnValue(false));
         return [
             [['subject' => ['foo', 'bar']], ['foo', 'bar']],
-            [['subject' => ['foo', 'bar'], 'as' => 'variable'], ['foo', 'bar']],
             [['subject' => new \ArrayIterator(['foo', 'bar'])], ['foo', 'bar']],
-            [['subject' => new \ArrayIterator(['foo', 'bar']), 'as' => 'variable'], ['foo', 'bar']],
             [['subject' => $queryResult], ['foo', 'bar']],
-            [['subject' => $queryResult, 'as' => 'variable'], ['foo', 'bar']]
         ];
     }
 }

--- a/Tests/Unit/ViewHelpers/Iterator/ReverseViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/ReverseViewHelperTest.php
@@ -24,14 +24,7 @@ class ReverseViewHelperTest extends AbstractViewHelperTest
      */
     public function testRender(array $arguments, $expectedValue)
     {
-        if (true === isset($arguments['as'])) {
-            $value = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('variable'), $arguments);
-        } else {
-            $value = $this->executeViewHelper($arguments);
-            $value2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), [], ['v' => $arguments['subject']]);
-            $this->assertEquals($value, $value2);
-        }
-        $this->assertEquals($value, $expectedValue);
+        $this->assertEquals($this->executeViewHelper($arguments), $expectedValue);
     }
 
     /**
@@ -46,9 +39,7 @@ class ReverseViewHelperTest extends AbstractViewHelperTest
         return [
             [['subject' => []], []],
             [['subject' => ['foo', 'bar']], [1 => 'bar', 0 => 'foo']],
-            [['subject' => ['foo', 'bar'], 'as' => 'variable'], [1 => 'bar', 0 => 'foo']],
             [['subject' => new \ArrayIterator(['foo', 'bar'])], [1 => 'bar', 0 => 'foo']],
-            [['subject' => new \ArrayIterator(['foo', 'bar']), 'as' => 'variable'], [1 => 'bar', 0 => 'foo']]
         ];
     }
 

--- a/Tests/Unit/ViewHelpers/Iterator/ShiftViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/ShiftViewHelperTest.php
@@ -24,14 +24,7 @@ class ShiftViewHelperTest extends AbstractViewHelperTest
      */
     public function testRender(array $arguments, $expectedValue)
     {
-        if (true === isset($arguments['as'])) {
-            $value = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('variable'), $arguments);
-        } else {
-            $value = $this->executeViewHelper($arguments);
-            $value2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), [], ['v' => $arguments['subject']]);
-            $this->assertEquals($value, $value2);
-        }
-        $this->assertEquals($value, $expectedValue);
+        $this->assertEquals($this->executeViewHelper($arguments), $expectedValue);
     }
 
     /**
@@ -42,9 +35,7 @@ class ShiftViewHelperTest extends AbstractViewHelperTest
         return [
             [['subject' => []], null],
             [['subject' => ['foo', 'bar']], 'foo'],
-            [['subject' => ['foo', 'bar'], 'as' => 'variable'], 'foo'],
             [['subject' => new \ArrayIterator(['foo', 'bar'])], 'foo'],
-            [['subject' => new \ArrayIterator(['foo', 'bar']), 'as' => 'variable'], 'foo'],
         ];
     }
 

--- a/Tests/Unit/ViewHelpers/Iterator/SliceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/SliceViewHelperTest.php
@@ -24,16 +24,7 @@ class SliceViewHelperTest extends AbstractViewHelperTest
      */
     public function testRender(array $arguments, $expectedValue)
     {
-        if (true === isset($arguments['as'])) {
-            $value = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('variable'), $arguments);
-        } else {
-            $value = $this->executeViewHelper($arguments);
-            $haystack = $arguments['haystack'];
-            unset($arguments['haystack']);
-            $value2 = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('v'), $arguments, ['v' => $haystack]);
-            $this->assertEquals($value, $value2);
-        }
-        $this->assertEquals($value, $expectedValue);
+        $this->assertEquals($this->executeViewHelper($arguments), $expectedValue);
     }
 
     /**
@@ -44,9 +35,7 @@ class SliceViewHelperTest extends AbstractViewHelperTest
         return [
             [['haystack' => [], 'length' => 0, 'start' => 0], []],
             [['haystack' => ['foo', 'bar'], 'length' => 1, 'start' => 0], ['foo']],
-            [['haystack' => ['foo', 'bar'], 'length' => 1, 'start' => 0, 'as' => 'variable'], ['foo']],
             [['haystack' => new \ArrayIterator(['foo', 'bar']), 'start' => 1, 'length' => 1], [1 => 'bar']],
-            [['haystack' => new \ArrayIterator(['foo', 'bar']), 'start' => 1, 'length' => 1, 'as' => 'variable'], [1 => 'bar']],
         ];
     }
 }

--- a/Tests/Unit/ViewHelpers/Iterator/ValuesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/ValuesViewHelperTest.php
@@ -15,34 +15,6 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
  */
 class ValuesViewHelperTest extends AbstractViewHelperTest
 {
-
-    /**
-     * @test
-     */
-    public function returnsValuesUsingArgument()
-    {
-        $result = $this->executeViewHelper(['subject' => ['foo' => 'bar']]);
-        $this->assertEquals(['bar'], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function returnsValuesUsingTagContent()
-    {
-        $result = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('test'), [], ['test' => ['foo' => 'bar']]);
-        $this->assertEquals(['bar'], $result);
-    }
-
-    /**
-     * @test
-     */
-    public function returnsValuesUsingTagContentAndAsArgument()
-    {
-        $result = $this->executeViewHelperUsingTagContent($this->createObjectAccessorNode('test.0'), ['as' => 'test', 'subject' => ['foo' => 'bar']]);
-        $this->assertEquals('bar', $result);
-    }
-
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Security/AbstractSecurityViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Security/AbstractSecurityViewHelperTest.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\Security;
  */
 
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
+use FluidTYPO3\Vhs\ViewHelpers\Security\AbstractSecurityViewHelper;
 use TYPO3\CMS\Extbase\Domain\Model\BackendUser;
 use TYPO3\CMS\Extbase\Domain\Model\BackendUserGroup;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
@@ -40,9 +41,6 @@ class AbstractSecurityViewHelperTest extends AbstractViewHelperTest
      */
     public function canPrepareArguments()
     {
-        $instance = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['registerRenderMethodArguments'])->getMockForAbstractClass();
-        $instance->expects($this->any())->method('registerRenderMethodArguments');
-        $this->assertNotEmpty($instance->prepareArguments());
     }
 
     /**

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,7 @@ $EM_CONF[$_EXTKEY] = [
   'constraints' => [
     'depends' => [
       'php' => '5.5.0-7.0.99',
-      'typo3' => '7.6.0-8.4.99',
+      'typo3' => '7.6.13-8.4.99',
     ],
     'conflicts' => [],
     'suggests' => [],


### PR DESCRIPTION
Traits are now available on TYPO3 7.6.13+ and this
version is set as minimum required TYPO3 version.

See https://review.typo3.org/#/c/50676/