### PR TITLE
[TASK] Apply escapeOutput=false to appropriate ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/CallViewHelper.php
+++ b/Classes/ViewHelpers/CallViewHelper.php
@@ -38,6 +38,11 @@ class CallViewHelper extends AbstractViewHelper implements CompilableInterface
     protected $escapeOutput = false;
 
     /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/ConstViewHelper.php
+++ b/Classes/ViewHelpers/ConstViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
@@ -22,6 +23,11 @@ class ConstViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()
@@ -29,8 +35,17 @@ class ConstViewHelper extends AbstractViewHelper implements CompilableInterface
         $this->registerArgument('name', 'string', 'Name of constant to retrieve');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext)
-    {
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
         return constant($renderChildrenClosure());
     }
 }

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -30,6 +30,10 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
      */
     protected $configurationManager;
 
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
     /**
      * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager

--- a/Classes/ViewHelpers/Count/BytesViewHelper.php
+++ b/Classes/ViewHelpers/Count/BytesViewHelper.php
@@ -27,6 +27,11 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 class BytesViewHelper extends AbstractViewHelper
 {
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Count/LinesViewHelper.php
+++ b/Classes/ViewHelpers/Count/LinesViewHelper.php
@@ -27,6 +27,11 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 class LinesViewHelper extends AbstractViewHelper
 {
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Count/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Count/SubstringViewHelper.php
@@ -27,6 +27,11 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 class SubstringViewHelper extends AbstractViewHelper
 {
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Count/WordsViewHelper.php
+++ b/Classes/ViewHelpers/Count/WordsViewHelper.php
@@ -27,6 +27,11 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 class WordsViewHelper extends AbstractViewHelper
 {
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -77,12 +77,18 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
      * @var ObjectAccessorNode[]
      */
     protected $childObjectAccessorNodes = [];
+
+
     /**
-     * With this flag, you can disable the escaping interceptor inside this ViewHelper.
-     * THIS MIGHT CHANGE WITHOUT NOTICE, NO PUBLIC API!
      * @var boolean
      */
-    protected $escapingInterceptorEnabled = false;
+    protected $escapeOutput = false;
+
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
     /**
      * @return string
      */

--- a/Classes/ViewHelpers/Extension/AbstractExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Extension/AbstractExtensionViewHelper.php
@@ -16,6 +16,10 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 abstract class AbstractExtensionViewHelper extends AbstractViewHelper
 {
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
     /**
      * @return void

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -25,6 +25,11 @@ class ChunkViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
@@ -80,6 +80,11 @@ class ColumnViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
@@ -84,6 +84,11 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/FirstViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FirstViewHelper.php
@@ -23,6 +23,11 @@ class FirstViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
@@ -26,6 +26,11 @@ class ImplodeViewHelper extends ExplodeViewHelper implements CompilableInterface
     protected static $method = 'implode';
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
@@ -21,6 +21,11 @@ class IndexOfViewHelper extends ContainsViewHelper
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/LastViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LastViewHelper.php
@@ -23,6 +23,11 @@ class LastViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/NextViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/NextViewHelper.php
@@ -21,6 +21,11 @@ class NextViewHelper extends ContainsViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/PopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PopViewHelper.php
@@ -25,6 +25,11 @@ class PopViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
@@ -21,6 +21,11 @@ class PreviousViewHelper extends ContainsViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -26,6 +26,11 @@ class RandomViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
@@ -25,6 +25,11 @@ class ShiftViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Link/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/TypolinkViewHelper.php
@@ -49,6 +49,11 @@ class TypolinkViewHelper extends AbstractViewHelper
     use DefaultRenderMethodViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initializes the arguments for the ViewHelper
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -26,6 +26,11 @@ abstract class AbstractSingleMathViewHelper extends AbstractViewHelper implement
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Media/AbstractMediaTagViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaTagViewHelper.php
@@ -18,4 +18,5 @@ abstract class AbstractMediaTagViewHelper extends AbstractMediaViewHelper
 {
 
     use TagViewHelperTrait;
+
 }

--- a/Classes/ViewHelpers/Media/ExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExtensionViewHelper.php
@@ -18,6 +18,11 @@ class ExtensionViewHelper extends AbstractViewHelper
 {
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments.
      *
      * @return void

--- a/Classes/ViewHelpers/Media/Image/AbstractImageInfoViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageInfoViewHelper.php
@@ -27,6 +27,11 @@ abstract class AbstractImageInfoViewHelper extends AbstractViewHelper
     protected $resourceFactory;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Construct resource factory
      */
     public function __construct()

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -52,6 +52,11 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     protected $imageInfo;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param ConfigurationManagerInterface $configurationManager
      * @return void
      */

--- a/Classes/ViewHelpers/Media/SizeViewHelper.php
+++ b/Classes/ViewHelpers/Media/SizeViewHelper.php
@@ -19,6 +19,11 @@ class SizeViewHelper extends AbstractViewHelper
 {
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments.
      *
      * @return void

--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -45,6 +45,11 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
     private $backupValues = [];
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param PageService $pageService
      */
     public function injectPageService(PageService $pageService)

--- a/Classes/ViewHelpers/MenuViewHelper.php
+++ b/Classes/ViewHelpers/MenuViewHelper.php
@@ -24,6 +24,9 @@ use FluidTYPO3\Vhs\ViewHelpers\Menu\AbstractMenuViewHelper;
 class MenuViewHelper extends AbstractMenuViewHelper
 {
 
+    /**
+     * @return void
+     */
     public function initializeArguments()
     {
         parent::initializeArguments();
@@ -31,9 +34,7 @@ class MenuViewHelper extends AbstractMenuViewHelper
             'pageUid',
             'integer',
             'Optional parent page UID to use as top level of menu. If left out will be detected from ' .
-            'rootLine using $entryLevel',
-            false,
-            null
+            'rootLine using $entryLevel'
         );
     }
 }

--- a/Classes/ViewHelpers/Page/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Page/InfoViewHelper.php
@@ -31,6 +31,11 @@ class InfoViewHelper extends AbstractViewHelper implements CompilableInterface
     protected static $pageService;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Page/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageViewHelper.php
@@ -24,6 +24,11 @@ class LanguageViewHelper extends AbstractViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @var PageService
      */
     protected static $pageService;

--- a/Classes/ViewHelpers/Page/RootlineViewHelper.php
+++ b/Classes/ViewHelpers/Page/RootlineViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Service\PageService;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -25,7 +26,12 @@ class RootlineViewHelper extends AbstractViewHelper implements CompilableInterfa
     use TemplateVariableViewHelperTrait;
 
     /**
-     * @api
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * @return void
      */
     public function initializeArguments()
     {
@@ -34,8 +40,17 @@ class RootlineViewHelper extends AbstractViewHelper implements CompilableInterfa
         $this->registerArgument('pageUid', 'integer', 'Optional page uid to use.');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, \TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface $renderingContext)
-    {
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
         $pageUid = (integer) $arguments['pageUid'];
         if (0 === $pageUid) {
             $pageUid = $GLOBALS['TSFE']->id;

--- a/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
+++ b/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
@@ -27,6 +27,11 @@ class StaticPrefixViewHelper extends AbstractViewHelper implements CompilableInt
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/ViewHelpers/Random/NumberViewHelper.php
+++ b/Classes/ViewHelpers/Random/NumberViewHelper.php
@@ -25,6 +25,11 @@ class NumberViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Random/StringViewHelper.php
+++ b/Classes/ViewHelpers/Random/StringViewHelper.php
@@ -27,6 +27,14 @@ class StringViewHelper extends AbstractViewHelper implements CompilableInterface
 {
     use CompileWithRenderStatic;
 
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * @return void
+     */
     public function initializeArguments()
     {
         $this->registerArgument('length', 'integer', 'Length of string to generate');

--- a/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
+++ b/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
@@ -38,6 +38,11 @@ abstract class AbstractRenderViewHelper extends AbstractViewHelper
     protected $configurationManager;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param \TYPO3\CMS\Extbase\Object\ObjectManagerInterface $objectManager
      * @return void
      */

--- a/Classes/ViewHelpers/Render/AsciiViewHelper.php
+++ b/Classes/ViewHelpers/Render/AsciiViewHelper.php
@@ -41,6 +41,11 @@ class AsciiViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -25,6 +25,11 @@ class UncacheViewHelper extends AbstractViewHelper implements CompilableInterfac
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Resource/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/LanguageViewHelper.php
@@ -37,6 +37,11 @@ class LanguageViewHelper extends AbstractViewHelper
     const LOCALLANG_DEFAULT = 'locallang.xlf';
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Registers all arguments for this ViewHelper.
      *
      * @return void

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -43,6 +43,11 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
     protected $configurationManager;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager
      * @return void
      */

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -56,6 +56,11 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
     protected $fileRepository;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Constructor
      */
     public function __construct()

--- a/Classes/ViewHelpers/Site/NameViewHelper.php
+++ b/Classes/ViewHelpers/Site/NameViewHelper.php
@@ -23,6 +23,11 @@ class NameViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/ViewHelpers/Site/UrlViewHelper.php
+++ b/Classes/ViewHelpers/Site/UrlViewHelper.php
@@ -25,6 +25,11 @@ class UrlViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -23,6 +23,11 @@ class DateTimeViewHelper extends AbstractViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return integer
      */
     protected static function getTimestamp()

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -27,6 +27,11 @@ class TimestampViewHelper extends AbstractViewHelper implements CompilableInterf
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/ViewHelpers/System/UniqIdViewHelper.php
+++ b/Classes/ViewHelpers/System/UniqIdViewHelper.php
@@ -26,6 +26,11 @@ class UniqIdViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -23,6 +23,11 @@ class GravatarViewHelper extends AbstractViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Base url
      *
      * @var string

--- a/Classes/ViewHelpers/Uri/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Uri/RequestViewHelper.php
@@ -25,6 +25,11 @@ class RequestViewHelper extends AbstractViewHelper implements CompilableInterfac
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @param array $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext

--- a/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Uri/TypolinkViewHelper.php
@@ -47,6 +47,11 @@ class TypolinkViewHelper extends AbstractViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initializes the arguments for the ViewHelper
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Variable/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/SetViewHelper.php
@@ -62,6 +62,11 @@ class SetViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()


### PR DESCRIPTION
In order to work on TYPO3v8+ the escaping needs to be
explicitly set in ViewHelpers (those which do not inherit
from ViewHelpers which automatically do not escape).