### PR TITLE
[BUGFIX] Fix incorrect content fetching in workspaces

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -9,6 +9,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  */
 
 use FluidTYPO3\Vhs\Traits\SlideViewHelperTrait;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -140,15 +142,32 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
                 $languageCondition .= ' AND uid NOT IN (' . $nestedQuery . ')';
             }
             $languageCondition .= ')';
-            $conditions = "pid = '" . (integer) $pageUid . "' AND colPos = '" . (integer) $column . "'" .
-                $GLOBALS['TSFE']->cObj->enableFields('tt_content') . ' AND ' . $languageCondition;
+            $conditions = "pid = '" . (integer) $pageUid . "' AND colPos = '" . (integer) $column . "' AND hidden = 0" .
+                $this->contentObject->enableFields('tt_content', false, ['pid' => true]) . ' AND ' . $languageCondition;
         }
         if (true === (boolean) $this->arguments['sectionIndexOnly']) {
             $conditions .= ' AND sectionIndex = 1';
         }
-        $conditions .= ' AND t3ver_state <= 1';
+        if (ExtensionManagementUtility::isLoaded('workspaces')) {
+            $conditions .= BackendUtility::versioningPlaceholderClause('tt_content');
+        }
 
         $rows = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('*', 'tt_content', $conditions, '', $order, $limit);
+
+        if (!ExtensionManagementUtility::isLoaded('workspaces')) {
+            return $rows;
+        }
+
+        $workspaceId = isset($GLOBALS['BE_USER']) ? $GLOBALS['BE_USER']->workspace : 0;
+        if ($workspaceId) {
+            foreach ($rows as $index => $row) {
+                if (BackendUtility::getMovePlaceholder('tt_content', $row['uid'])) {
+                    unset($rows[$index]);
+                } else {
+                    $rows[$index] = $row;
+                }
+            }
+        }
         return $rows;
     }
 


### PR DESCRIPTION
This patch fixes all content-related ViewHelpers when
used in combination with workspaces. Solves issues
which caused live and preview workspaces to show
incorrect content or wrongly positioned content.

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/