### PR TITLE
[BUGFIX] Register parent arguments where necessary

### DIFF
--- a/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/LinkViewHelper.php
@@ -35,6 +35,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
         $this->registerTagAttribute('rel', 'string', 'Property: rel');
         $this->registerTagAttribute('href', 'string', 'Property: href');
         $this->registerTagAttribute('type', 'string', 'Property: type');


### PR DESCRIPTION
I think the fluid discrepancy between 7.6 and 8.x causes some tensions here.

We need to keep an eye out where there are arguments that were registered through the constructor in CMS 7.6 but need a call to `parent::inititArgs` now.

Fixes: #1100 