### PR TITLE
[TASK] Annotate throwing methods accordingly

### DIFF
--- a/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -189,6 +189,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
      * Render the option tags.
      *
      * @return array
+     * @throws Exception
      */
     protected function getOptions()
     {

--- a/Classes/ViewHelpers/Format/DateRangeViewHelper.php
+++ b/Classes/ViewHelpers/Format/DateRangeViewHelper.php
@@ -124,6 +124,7 @@ class DateRangeViewHelper extends AbstractViewHelper
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed
+     * @throws Exception
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {

--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -112,6 +112,7 @@ class EncodeViewHelper extends AbstractViewHelper
      * @param string $recursionMarker
      * @param string $dateTimeFormat
      * @return mixed
+     * @throws Exception
      */
     protected static function encodeValue($value, $useTraversableKeys, $preventRecursion, $recursionMarker, $dateTimeFormat)
     {

--- a/Classes/ViewHelpers/Format/MarkdownViewHelper.php
+++ b/Classes/ViewHelpers/Format/MarkdownViewHelper.php
@@ -60,6 +60,7 @@ class MarkdownViewHelper extends AbstractViewHelper
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed|null|string
+     * @throws Exception
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {

--- a/Classes/ViewHelpers/Iterator/FirstViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FirstViewHelper.php
@@ -42,6 +42,7 @@ class FirstViewHelper extends AbstractViewHelper implements CompilableInterface
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return null
+     * @throws Exception
      */
     public static function renderStatic(
         array $arguments,

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -14,7 +14,6 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
 
 /**
  * Returns random element from array.

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -94,7 +94,7 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
      * Returns the same type as $subject. Ignores NULL values which would be
      * OK to use in an f:for (empty loop as result)
      * @return mixed
-     * @throws \Exception
+     * @throws Exception
      */
     public function render()
     {
@@ -116,7 +116,7 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
                 // a NULL value is respected and ignored, but any
                 // unrecognized value other than this is considered a
                 // fatal error.
-                throw new \Exception(
+                ErrorUtility::throwViewHelperException(
                     'Unsortable variable type passed to Iterator/SortViewHelper. Expected any of Array, QueryResult, ' .
                     ' ObjectStorage or Iterator implementation but got ' . gettype($subject),
                     1351958941
@@ -209,6 +209,7 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
      * Parses the supplied flags into the proper value for the sorting
      * function.
      * @return int
+     * @throws Exception
      */
     protected function getSortFlags()
     {

--- a/Classes/ViewHelpers/Math/AbstractMultipleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractMultipleMathViewHelper.php
@@ -8,10 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
 
@@ -53,6 +50,7 @@ abstract class AbstractMultipleMathViewHelper extends AbstractSingleMathViewHelp
      * @param mixed $b
      * @param array $arguments
      * @return mixed
+     * @throws Exception
      */
     protected static function calculate($a, $b = null, array $arguments = [])
     {

--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -51,6 +51,7 @@ abstract class AbstractSingleMathViewHelper extends AbstractViewHelper implement
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed
+     * @throws Exception
      */
     public static function renderStatic(
         array $arguments,

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -9,7 +9,6 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
  */
 
 
-use FluidTYPO3\Vhs\Traits\DefaultRenderMethodViewHelperTrait;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;


### PR DESCRIPTION
The ViewHelper Exception is imported in many places and it made sense
to annotate throwing methods directly.

Also removes some unused imports