### PR TITLE
[BUGFIX] IteratorViewHelpers - insert missing $escapeOutput for TYPO3v8+

### DIFF
--- a/Classes/ViewHelpers/Iterator/AbstractLoopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/AbstractLoopViewHelper.php
@@ -49,13 +49,13 @@ abstract class AbstractLoopViewHelper extends AbstractViewHelper
     ) {
         if (false === empty($iterationArgument)) {
             $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);
-            $cycle = intval(($i - $from) / $step) + 1;
+            $cycle = (integer) (($i - $from) / $step) + 1;
             $iteration = [
                 'index' => $i,
                 'cycle' => $cycle,
-                'isOdd' => (0 === $cycle % 2 ? false : true),
-                'isEven' => (0 === $cycle % 2 ? true : false),
-                'isFirst' => ($i === $from ? true : false),
+                'isOdd' => 0 === $cycle % 2 ? false : true,
+                'isEven' => 0 === $cycle % 2 ? true : false,
+                'isFirst' => $i === $from ? true : false,
                 'isLast' => static::isLast($i, $from, $to, $step)
             ];
             $variableProvider->add($iterationArgument, $iteration);

--- a/Classes/ViewHelpers/Iterator/DiffViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/DiffViewHelper.php
@@ -23,6 +23,11 @@ class DiffViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
@@ -25,6 +25,11 @@ class ExplodeViewHelper extends AbstractViewHelper implements CompilableInterfac
     use TemplateVariableViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @var string
      */
     protected static $method = 'explode';

--- a/Classes/ViewHelpers/Iterator/FilterViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FilterViewHelper.php
@@ -29,6 +29,11 @@ class FilterViewHelper extends AbstractViewHelper implements CompilableInterface
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/ForViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ForViewHelper.php
@@ -21,6 +21,11 @@ class ForViewHelper extends AbstractLoopViewHelper implements CompilableInterfac
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()
@@ -48,9 +53,9 @@ class ForViewHelper extends AbstractLoopViewHelper implements CompilableInterfac
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $to = intval($arguments['to']);
-        $from = intval($arguments['from']);
-        $step = intval($arguments['step']);
+        $to = (integer) $arguments['to'];
+        $from = (integer) $arguments['from'];
+        $step = (integer) $arguments['step'];
         $iteration = $arguments['iteration'];
         $content = '';
         $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);

--- a/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
@@ -41,7 +41,7 @@ class IndexOfViewHelper extends ContainsViewHelper
         $evaluation = self::assertHaystackHasNeedle($arguments['haystack'], $arguments['needle'], $arguments);
 
         if (false !== $evaluation) {
-            return intval($evaluation);
+            return (integer) $evaluation;
         }
         return -1;
     }

--- a/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
@@ -23,6 +23,11 @@ class IntersectViewHelper extends AbstractViewHelper implements CompilableInterf
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/KeysViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/KeysViewHelper.php
@@ -25,6 +25,11 @@ class KeysViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/LoopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LoopViewHelper.php
@@ -20,6 +20,11 @@ class LoopViewHelper extends AbstractLoopViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void
@@ -38,9 +43,9 @@ class LoopViewHelper extends AbstractLoopViewHelper implements CompilableInterfa
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $count = intval($arguments['count']);
-        $minimum = intval($arguments['minimum']);
-        $maximum = intval($arguments['maximum']);
+        $count = (integer) $arguments['count'];
+        $minimum = (integer) $arguments['minimum'];
+        $maximum = (integer) $arguments['maximum'];
         $iteration = $arguments['iteration'];
         $content = '';
         $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);

--- a/Classes/ViewHelpers/Iterator/MergeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/MergeViewHelper.php
@@ -23,6 +23,11 @@ class MergeViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/PushViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PushViewHelper.php
@@ -31,6 +31,11 @@ class PushViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RangeViewHelper.php
@@ -35,6 +35,11 @@ class RangeViewHelper extends AbstractViewHelper implements CompilableInterface
     use TemplateVariableViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
@@ -28,6 +28,11 @@ class ReverseViewHelper extends AbstractViewHelper implements CompilableInterfac
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/SliceViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SliceViewHelper.php
@@ -25,6 +25,11 @@ class SliceViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    
+    protected $escapeOutput = false;
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -41,6 +41,11 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Contains all flags that are allowed to be used
      * with the sorting functions
      *
@@ -196,7 +201,7 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
         $field = $this->arguments['sortBy'];
         $value = ObjectAccess::getPropertyPath($object, $field);
         if (true === $value instanceof \DateTime) {
-            $value = intval($value->format('U'));
+            $value = (integer) $value->format('U');
         } elseif (true === $value instanceof ObjectStorage || true === $value instanceof LazyObjectStorage) {
             $value = $value->count();
         } elseif (is_array($value)) {

--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -24,6 +24,11 @@ class SplitViewHelper extends AbstractViewHelper implements CompilableInterface
     use TemplateVariableViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
@@ -66,6 +66,11 @@ class UniqueViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
@@ -42,6 +42,11 @@ class ValuesViewHelper extends AbstractViewHelper implements CompilableInterface
     use ArrayConsumingViewHelperTrait;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments
      *
      * @return void


### PR DESCRIPTION
and use (integer) instead of intval().
removed some unnecessary brackets.