### PR TITLE
[BUGFIX] IteratorViewHelpers - insert missing $escapeChildren for TYPO3v8+

### DIFF
--- a/Classes/ViewHelpers/Iterator/AbstractLoopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/AbstractLoopViewHelper.php
@@ -19,6 +19,16 @@ abstract class AbstractLoopViewHelper extends AbstractViewHelper
 {
 
     /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -27,6 +27,11 @@ class ChunkViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
@@ -82,6 +82,11 @@ class ColumnViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/DiffViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/DiffViewHelper.php
@@ -25,6 +25,11 @@ class DiffViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
@@ -27,6 +27,11 @@ class ExplodeViewHelper extends AbstractViewHelper implements CompilableInterfac
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
@@ -86,6 +86,11 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/FilterViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FilterViewHelper.php
@@ -31,6 +31,11 @@ class FilterViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/FirstViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FirstViewHelper.php
@@ -25,6 +25,11 @@ class FirstViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ForViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ForViewHelper.php
@@ -21,11 +21,6 @@ class ForViewHelper extends AbstractLoopViewHelper implements CompilableInterfac
     use CompileWithRenderStatic;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * @return void
      */
     public function initializeArguments()

--- a/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
@@ -26,11 +26,6 @@ class ImplodeViewHelper extends ExplodeViewHelper implements CompilableInterface
     protected static $method = 'implode';
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IndexOfViewHelper.php
@@ -21,11 +21,6 @@ class IndexOfViewHelper extends ContainsViewHelper
     use CompileWithRenderStatic;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
@@ -25,6 +25,11 @@ class IntersectViewHelper extends AbstractViewHelper implements CompilableInterf
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/KeysViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/KeysViewHelper.php
@@ -27,6 +27,11 @@ class KeysViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/LastViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LastViewHelper.php
@@ -25,6 +25,11 @@ class LastViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/LoopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LoopViewHelper.php
@@ -20,11 +20,6 @@ class LoopViewHelper extends AbstractLoopViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * Initialize
      *
      * @return void

--- a/Classes/ViewHelpers/Iterator/MergeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/MergeViewHelper.php
@@ -25,6 +25,11 @@ class MergeViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/NextViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/NextViewHelper.php
@@ -21,11 +21,6 @@ class NextViewHelper extends ContainsViewHelper implements CompilableInterface
     use CompileWithRenderStatic;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/PopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PopViewHelper.php
@@ -27,6 +27,11 @@ class PopViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PreviousViewHelper.php
@@ -21,11 +21,6 @@ class PreviousViewHelper extends ContainsViewHelper implements CompilableInterfa
     use CompileWithRenderStatic;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Iterator/PushViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PushViewHelper.php
@@ -33,6 +33,11 @@ class PushViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -27,6 +27,11 @@ class RandomViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RangeViewHelper.php
@@ -37,6 +37,11 @@ class RangeViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
@@ -30,6 +30,11 @@ class ReverseViewHelper extends AbstractViewHelper implements CompilableInterfac
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
@@ -27,6 +27,11 @@ class ShiftViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/SliceViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SliceViewHelper.php
@@ -27,8 +27,13 @@ class SliceViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
-    
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
+
     /**
      * Initialize arguments
      *

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -43,6 +43,11 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -26,6 +26,11 @@ class SplitViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
@@ -68,6 +68,11 @@ class UniqueViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
@@ -44,6 +44,11 @@ class ValuesViewHelper extends AbstractViewHelper implements CompilableInterface
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**


### PR DESCRIPTION
Inserted where necessary.
Remove $escapeOutput if set in parent classes.