### PR TITLE
[BUGFIX] Set escaping behavior in Math ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -28,6 +28,11 @@ abstract class AbstractSingleMathViewHelper extends AbstractViewHelper implement
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**


### PR DESCRIPTION
This change avoids needless htmlspecialchars at the childrens.