### PR TITLE
[BUGFIX] Set escaping behavior in Media ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Media/ExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExtensionViewHelper.php
@@ -23,6 +23,11 @@ class ExtensionViewHelper extends AbstractViewHelper
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**

--- a/Classes/ViewHelpers/Media/FilesViewHelper.php
+++ b/Classes/ViewHelpers/Media/FilesViewHelper.php
@@ -21,6 +21,16 @@ class FilesViewHelper extends AbstractViewHelper
     use CompileWithContentArgumentAndRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Initialize arguments.
      *
      * @return void

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -53,11 +53,6 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     protected $imageInfo;
 
     /**
-     * @var boolean
-     */
-    protected $escapeOutput = false;
-
-    /**
      * @param ConfigurationManagerInterface $configurationManager
      * @return void
      */

--- a/Classes/ViewHelpers/Media/SizeViewHelper.php
+++ b/Classes/ViewHelpers/Media/SizeViewHelper.php
@@ -24,6 +24,11 @@ class SizeViewHelper extends AbstractViewHelper
     /**
      * @var boolean
      */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
     protected $escapeOutput = false;
 
     /**


### PR DESCRIPTION
Inserts missing escaping behavior and removes $escapeOutput in ```Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php```because it is set in one of the parent classes.