### PR TITLE
[BUGFIX] RenderCache - at each call, $renderChildrenClosure() was called

### DIFF
--- a/Classes/ViewHelpers/Render/CacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/CacheViewHelper.php
@@ -76,7 +76,6 @@ class CacheViewHelper extends AbstractRenderViewHelper implements CompilableInte
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $content = $renderChildrenClosure();
         $identity = $arguments['identity'];
         if (false === ctype_alnum(preg_replace('/[\-_]/i', '', $identity))) {
             if (true === $identity instanceof DomainObjectInterface) {
@@ -97,6 +96,7 @@ class CacheViewHelper extends AbstractRenderViewHelper implements CompilableInte
         if (true === static::has($identity)) {
             return static::retrieve($identity);
         }
+        $content = $renderChildrenClosure();
         static::store($content, $identity);
         return $content;
     }


### PR DESCRIPTION
$renderChildrenClosure()  is now only executed if the identity doesn't exists in the cache.