### PR TITLE
[FEATURE] Add onlyProperties parameter to v:resource.file

### DIFF
--- a/Classes/ViewHelpers/Resource/FileViewHelper.php
+++ b/Classes/ViewHelpers/Resource/FileViewHelper.php
@@ -28,6 +28,13 @@ class FileViewHelper extends AbstractResourceViewHelper
     {
         parent::initializeArguments();
         $this->registerAsArgument();
+        $this->registerArgument(
+            'onlyAttributes',
+            'boolean',
+            'Whether to return only the attributes array of the sys_file record and not the File object itself',
+            false,
+            true
+        );
     }
 
     /**
@@ -35,7 +42,7 @@ class FileViewHelper extends AbstractResourceViewHelper
      */
     public function render()
     {
-        $files = $this->getFiles(true);
+        $files = $this->getFiles($this->arguments['onlyAttributes']);
         if (1 === count($files)) {
             $files = array_shift($files);
         }

--- a/Classes/ViewHelpers/Resource/FileViewHelper.php
+++ b/Classes/ViewHelpers/Resource/FileViewHelper.php
@@ -29,9 +29,9 @@ class FileViewHelper extends AbstractResourceViewHelper
         parent::initializeArguments();
         $this->registerAsArgument();
         $this->registerArgument(
-            'onlyAttributes',
+            'onlyProperties',
             'boolean',
-            'Whether to return only the attributes array of the sys_file record and not the File object itself',
+            'Whether to return only the properties array of the sys_file record and not the File object itself',
             false,
             true
         );
@@ -42,7 +42,7 @@ class FileViewHelper extends AbstractResourceViewHelper
      */
     public function render()
     {
-        $files = $this->getFiles($this->arguments['onlyAttributes']);
+        $files = $this->getFiles($this->arguments['onlyProperties']);
         if (1 === count($files)) {
             $files = array_shift($files);
         }


### PR DESCRIPTION
The Resource\FileViewHelper currently is only able to return the
attributes of requested file as an array although the underlying logic
is more powerful and could also return the actual TYPO3 File resource
instance. This instance would also be necessary to work e.g. with the
MediaViewHelper in fluid, so adding a parameter here to let the user
decide what he wants opens up new possibilities like correctly rendering
videos stored as sys_file references in flux forms.