### PR TITLE
ensures that typo3-ter dependencies are fulfilled even if you install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,10 @@
         "php": ">=7.0.0",
         "typo3/cms": ">=7.6.13, <=7.6.99|^8.4.1"
     },
+    "replace": {
+        "vhs": "self.version",
+        "typo3-ter/vhs": "self.version"
+    },
     "require-dev": {
         "fluidtypo3/development": "^3.0"
     },


### PR DESCRIPTION
from github or packagist. fixes #1262 