### PR TITLE
[BUGFIX] content.render fallback language

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -131,9 +131,15 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
             $order = $order . ' ' . $sortDirection;
         }
         $hideUntranslated = (boolean) $this->arguments['hideUntranslated'];
+
         $currentLanguage = $GLOBALS['TSFE']->sys_language_content;
-        $defaultLanguage = $GLOBALS['TSFE']->sys_language_contentOL;
-        $languageCondition = '(sys_language_uid IN (-1,' . $defaultLanguage . ',' . $currentLanguage . ')';
+        $languageUids = [-1, $currentLanguage];
+
+        if (null !== $GLOBALS['TSFE']->sys_language_contentOL) {
+            $languageUids[] = $GLOBALS['TSFE']->sys_language_contentOL;
+        }
+
+        $languageCondition = sprintf('(sys_language_uid IN (%s)', explode(", ", $languageUids));
         if (0 < $currentLanguage) {
             if (true === $hideUntranslated) {
                 $languageCondition .= ' AND l18n_parent > 0';

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -139,7 +139,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
             $languageUids[] = $GLOBALS['TSFE']->sys_language_contentOL;
         }
 
-        $languageCondition = sprintf('(sys_language_uid IN (%s)', explode(", ", $languageUids));
+        $languageCondition = sprintf('(sys_language_uid IN (%s)', implode(", ", $languageUids));
         if (0 < $currentLanguage) {
             if (true === $hideUntranslated) {
                 $languageCondition .= ' AND l18n_parent > 0';

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -132,7 +132,8 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         }
         $hideUntranslated = (boolean) $this->arguments['hideUntranslated'];
         $currentLanguage = $GLOBALS['TSFE']->sys_language_content;
-        $languageCondition = '(sys_language_uid IN (-1,' . $currentLanguage . ')';
+        $defaultLanguage = $GLOBALS['TSFE']->sys_language_contentOL;
+        $languageCondition = '(sys_language_uid IN (-1,' . $defaultLanguage . ',' . $currentLanguage . ')';
         if (0 < $currentLanguage) {
             if (true === $hideUntranslated) {
                 $languageCondition .= ' AND l18n_parent > 0';


### PR DESCRIPTION
reference: fix language fallback #1135
> So the better approach would be to use the defined content fallback from config.sys_language_mode.
Condition: <v:content.render pageUid="{activePageUid}" column="4" />
Tested with langs (en, uk, fr): 
- en: default language with content ✓
- uk: not translated page => shows default content ✓
- fr: translated page => shows fr content ✓