### PR TITLE
[BUGFIX] Allow any doktypes < 200 in BreadCrumbViewHelper (#1181)

### DIFF
--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -59,19 +59,13 @@ class BreadCrumbViewHelper extends AbstractMenuViewHelper
         $showHidden = (boolean) $this->arguments['showHiddenInMenu'];
         foreach ($rawRootLineData as $record) {
             $isHidden = (boolean) $record['nav_hide'];
-            $allowedDoktypes = [
-                PageRepository::DOKTYPE_DEFAULT,
-                PageRepository::DOKTYPE_LINK,
-                PageRepository::DOKTYPE_SHORTCUT,
-                PageRepository::DOKTYPE_MOUNTPOINT
-            ];
 
             if (true === (boolean) $this->arguments['includeSpacers']) {
-                $allowedDoktypes[] = PageRepository::DOKTYPE_SPACER;
+                $isAllowedDoktype = (int) $record['doktype'] <= PageRepository::DOKTYPE_SPACER;
+            } else {
+                $isAllowedDoktype = (int) $record['doktype'] < PageRepository::DOKTYPE_SPACER;
             }
 
-            $isAllowedDoktype = in_array((int) $record['doktype'], $allowedDoktypes);
-            
             if ((true === $showHidden && true === $isHidden || false === $isHidden) && true === $isAllowedDoktype) {
                 array_push($rootLineData, $record);
             }


### PR DESCRIPTION
Includes all page doktpyes in breadcrumb smaller than 200

Ref: #1181