### PR TITLE
[BUGFIX] Correct handling of language overlays

### DIFF
--- a/Classes/Traits/SlideViewHelperTrait.php
+++ b/Classes/Traits/SlideViewHelperTrait.php
@@ -76,7 +76,7 @@ trait SlideViewHelperTrait
             'from the parent pages below those. You can invert this behaviour (actual page elements at bottom) ' .
             'by setting this flag))',
             false,
-            0
+            false
         );
     }
 
@@ -115,7 +115,7 @@ trait SlideViewHelperTrait
         $slideCollectReverse = (boolean) $this->arguments['slideCollectReverse'];
         $slideCollect = (integer) $this->arguments['slideCollect'];
 
-        if (0 < $slideCollect) {
+        if ($slideCollect && !$slide) {
             $slide = $slideCollect;
         }
 
@@ -128,13 +128,12 @@ trait SlideViewHelperTrait
             if (true === $slideCollectReverse && 0 !== $slideCollect) {
                 $reverse = true;
             }
-            $rootLine = $this->getPageService()->getRootLine($pageUid, null, $reverse);
+            $rootLine = $this->getPageService()->getRootLine($pageUid, null);
             if (-1 !== $slide) {
-                if (true === $reverse) {
-                    $rootLine = array_slice($rootLine, - $slide);
-                } else {
-                    $rootLine = array_slice($rootLine, 0, $slide);
-                }
+                $rootLine = array_slice($rootLine, 0, $slide);
+            }
+            if ($reverse) {
+                $rootLine = array_reverse($rootLine);
             }
             foreach ($rootLine as $page) {
                 $storagePageUids[] = (integer) $page['uid'];

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -121,9 +121,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         }
         $this->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $this->tagName = $this->arguments['tagName'];
-
-        // to set the tagName we should call initialize()
-        $this->initialize();
+        $this->tag->setTagName($this->tagName);
 
         $this->languageMenu = $this->parseLanguageMenu();
         $this->templateVariableContainer->add($this->arguments['as'], $this->languageMenu);
@@ -277,16 +275,14 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
             'flag' => $this->arguments['defaultIsoFlag']
         ];
 
-        $select = 'uid, title, flag';
+        $select = 'uid,title,flag';
         $from = 'sys_language';
         $limitLanguages = static::arrayFromArrayOrTraversableOrCSVStatic($this->arguments['languages'] ?? []);
         if (!empty($limitLanguages)) {
-            $where = 'uid IN (' . implode(',', $limitLanguages) . ')';
+            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => -1, 'uidInList' => implode(',', $limitLanguages)]);
         } else {
-            $where = '1=1';
+            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => 'root']);
         }
-        $where .= $this->cObj->enableFields('sys_language');
-        $sysLanguage = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows($select, $from, $where);
 
         foreach ($sysLanguage as $value) {
             $tempArray[$value['uid']] = [
@@ -316,21 +312,13 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         }
 
         // Select all pages_language_overlay records on the current page. Each represents a possibility for a language.
-        $pageArray = [];
         $table = 'pages_language_overlay';
-        $whereClause = 'pid=' . $this->getPageUid() . ' ';
-        $whereClause .= $GLOBALS['TSFE']->sys_page->enableFields($table);
-        $sysLang = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('DISTINCT sys_language_uid', $table, $whereClause);
-
-        if (false === empty($sysLang)) {
-            foreach ($sysLang as $val) {
-                $pageArray[$val['sys_language_uid']] = $val['sys_language_uid'];
-            }
-        }
+        $sysLang = $GLOBALS['TSFE']->cObj->getRecords($table, ['selectFields' => 'sys_language_uid', 'pidInList' => $this->getPageUid()]);
+        $languageUids = array_column($sysLang, 'sys_language_uid');
 
         foreach ($languageMenu as $key => $value) {
             $current = $GLOBALS['TSFE']->sys_language_uid === (integer) $key ? 1 : 0;
-            $inactive = $pageArray[$key] || (integer) $key === $this->defaultLangUid ? 0 : 1;
+            $inactive = in_array($key, $languageUids) || (integer) $key === $this->defaultLangUid ? 0 : 1;
             $url = $this->getLanguageUrl($key);
             if (true === empty($url)) {
                 $url = GeneralUtility::getIndpEnv('REQUEST_URI');


### PR DESCRIPTION
This patch removes nearly all VHS content pulling logic, replacing it with the frontend-only ContentObjectRenderer method to getRecords().

The fix affects:

* Content overlay modes `content_fallback` and `strict` now correctly respected
* Workspace and preview overlay is now done by core internals
* Language menu generation uses same API and gets overlayed for language/workspace preview
* Content sliding slideCollect no longer overrides slide depth if slide depth is set
* Content sliding behavior reversal functionality ("slideCollectReverse" argument) restored

Close: #1297
Close: #1321
Close: #1323
Close: #761
Close: #1049