### PR TITLE
[BUGFIX] Correctly instantiate ObjectManager

### DIFF
--- a/Classes/View/UncacheTemplateView.php
+++ b/Classes/View/UncacheTemplateView.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Vhs\View;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Fluid\Compatibility\TemplateParserBuilder;
 use TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler;
@@ -52,7 +53,7 @@ class UncacheTemplateView extends TemplateView
      */
     public function __wakeup()
     {
-        $this->objectManager = GeneralUtility::makeInstance(ObjectManagerInterface::class);
+        $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
     }
 
     /**


### PR DESCRIPTION
`ObjectManagerInterface` doesnt seem to be resolved correctly on wakeup. - As a workaround, and since ObjectManager is a singleton anyways and thus is resolved earlier, we can grab the prepared instance without using the interface here.

Ref: https://github.com/FluidTYPO3/vhs/commit/94c3d77daffa0f9ad65c3b6136f26f0131bab90f#commitcomment-24065966

Closes #1369