### PR TITLE
[BUGFIX] Use shortcut target page for active/subpage check

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -460,6 +460,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             }
             $targetPage = $this->pageService->getShortcutTargetPage($page);
             if ($targetPage !== null) {
+                $originalPageUid = $targetPage['uid'];
                 if ($this->pageService->shouldUseShortcutTarget($this->arguments)) {
                     $pages[$index] = $targetPage;
                 }


### PR DESCRIPTION
This ensures that shortcut menu items are marked as active if the visitor is currently located on the shortcut target page.