### PR TITLE
[BUGFIX] Correctly format.eliminate multibyte chars

### DIFF
--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -130,7 +130,7 @@ class EliminateViewHelper extends AbstractViewHelper
         if (true === is_array($characters)) {
             $subjects = $characters;
         } else {
-            $subjects = str_split($characters);
+            $subjects = preg_split('//u', $characters, null, PREG_SPLIT_NO_EMPTY);
         }
         foreach ($subjects as $subject) {
             if (true === $caseSensitive) {

--- a/Tests/Unit/ViewHelpers/Format/EliminateViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/EliminateViewHelperTest.php
@@ -158,6 +158,17 @@ class EliminateViewHelperTest extends AbstractViewHelperTest
     /**
      * @test
      */
+    public function removesMultibyteCharactersAsString()
+    {
+        $arguments = $this->arguments;
+        $arguments['characters'] = 'æ本';
+        $result = $this->executeViewHelperUsingTagContent('aäæå本bc', $arguments);
+        $this->assertSame('aäåbc', $result);
+    }
+
+    /**
+     * @test
+     */
     public function removesCharactersAsArray()
     {
         $arguments = $this->arguments;


### PR DESCRIPTION
str_split() fails to consider multi-byte characters, while this ViewHelper will most probably be used to remove such characters.

Resolves: #1397