### PR TITLE
[BUGFIX] Check position before inserting assets at marker

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -228,7 +228,10 @@ class AssetService implements SingletonInterface
             $tag = true === $inFooter ? '</body>' : '</head>';
             $content = $GLOBALS['TSFE']->content;
             $position = strrpos($content, $tag);
-            $GLOBALS['TSFE']->content = substr_replace($content, $assetMarker . LF, $position, 0);
+
+            if ($position) {
+                $GLOBALS['TSFE']->content = substr_replace($content, $assetMarker . LF, $position, 0);
+            }
         }
         if (true === is_array($assets)) {
             $chunk = $this->buildAssetsChunk($assets);


### PR DESCRIPTION
Hey there,

first of all, many thanks for VHS!

This pull request checks the position, respectively if a `head` or `body` tag exists, before inserting assets at marker.

We have websites with "services", which render small portions of HTML with no `head` or `body` tags via page types, which should not contain assets. Before VHS 4.3.0 this was possible. With VHS 4.3.0 the assets get always inserted at the top.

I don't know, if this should be handled by VHS or better by the integrator, e.g. disable assets at all by certain page types?

Thanks again!