### PR TITLE
[BUGFIX] Revoke 'Properly use shortcut target uid'

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -464,7 +464,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
                     $pages[$index] = $targetPage;
                 }
                 if ($this->pageService->shouldUseShortcutUid($this->arguments)) {
-                    $page[$index]['uid'] = $targetPage['uid'];
+                    $page['uid'] = $targetPage['uid'];
                 }
             }
             if (true === $this->pageService->isActive($originalPageUid, $showAccessProtected)) {


### PR DESCRIPTION
Fixes #1422 by revoking an earlier incorrect patch.