### PR TITLE
[BUGFIX] enforce fixPermissions when writing asset files

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -744,7 +744,7 @@ class AssetService implements SingletonInterface
      */
     protected function writeFile($file, $contents)
     {
-        GeneralUtility::writeFile($file, $contents);
+        GeneralUtility::writeFile($file, $contents, true);
     }
 
     /**


### PR DESCRIPTION
Sometimes TYPO3 caches can't be deleted with `typo3cms cache:flush --force` because of wrong file permissions of the EXT:vhs assets.
With this patch, `GeneralUtility:fixPermissions()` will be enforced to make use of `$TYPO3_CONF_VARS['BE']['fileCreateMask']`.