### PR TITLE
Move class into the default image tag

### DIFF
--- a/Classes/ViewHelpers/Media/PictureViewHelper.php
+++ b/Classes/ViewHelpers/Media/PictureViewHelper.php
@@ -96,6 +96,10 @@ class PictureViewHelper extends AbstractTagBasedViewHelper
         $defaultImage = new TagBuilder('img');
         $defaultImage->addAttribute('src', $defaultSource);
         $defaultImage->addAttribute('alt', $this->arguments['alt']);
+        
+        if (false === empty($this->arguments['class'])) {
+            $defaultImage->addAttribute('class', $this->arguments['class']);
+        }
 
         if (false === empty($this->arguments['title'])) {
             $defaultImage->addAttribute('title', $this->arguments['title']);
@@ -103,9 +107,6 @@ class PictureViewHelper extends AbstractTagBasedViewHelper
         $content .= $defaultImage->render();
 
         $this->tag->setContent($content);
-        if (false === empty($this->arguments['class'])) {
-            $this->tag->addAttribute('class', $this->arguments['class']);
-        }
         return $this->tag->render();
     }
 }


### PR DESCRIPTION
By adding the class to the image tag it won't actually style the image, but just the picture tag.

By moving it to the default image tag, it would allow to use the class to actually style the img.

Example:
https://codepen.io/fjacobi/pen/vpqzQG