### PR TITLE
[TASK] Allow installation of TYPO3 master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,7 @@ before_script:
   - export TYPO3_PATH_WEB=$PWD/build/web
 
 install:
-  - composer require --no-update "typo3/cms-core:$TYPO3_VERSION"
-  - composer require --no-update "typo3/cms-extbase:$TYPO3_VERSION"
-  - composer require --no-update "typo3/cms-fluid:$TYPO3_VERSION"
-  - composer require --no-update "typo3/cms-backend:$TYPO3_VERSION"
-  - composer require --no-update "typo3/cms-frontend:$TYPO3_VERSION"
-  - composer install --prefer-dist
+  - composer require "typo3/cms-core:$TYPO3_VERSION"
 
 script: if [[ "$COVERAGE" != "NO" ]]; then ./vendor/bin/phpunit --coverage-clover=build/logs/clover.xml; else ./vendor/bin/phpunit; fi
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
       "preferred-install": "dist"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "homepage": "https://fluidtypo3.org",
     "license": "GPL-2.0-or-later",
     "autoload": {
@@ -33,15 +34,16 @@
     },
     "require": {
         "php": ">=7.0.0",
-        "typo3/cms-core": "^8.7|dev-master",
-        "typo3/cms-extbase": "^8.7|dev-master",
-        "typo3/cms-fluid": "^8.7|dev-master",
-        "typo3/cms-frontend": "^8.7|dev-master",
-        "typo3/cms-backend": "^8.7|dev-master"
+        "typo3/cms-core": "^8.7 || dev-master",
+        "typo3/cms-extbase": "^8.7 || dev-master",
+        "typo3/cms-fluid": "^8.7 || dev-master",
+        "typo3/cms-frontend": "^8.7 || dev-master",
+        "typo3/cms-backend": "^8.7 || dev-master"
     },
     "replace": {
         "vhs": "self.version",
-        "typo3-ter/vhs": "self.version"
+        "typo3-ter/vhs": "self.version",
+        "typo3/cms-version": "*"
     },
     "require-dev": {
         "fluidtypo3/development": "^4.0"


### PR DESCRIPTION
Add replacement to typo3/cms-version in this package
as this package was removed for TYPO3 8 and merged
into typo3/cms-workspaces.

Simplify travis build by only requiring typo3/cms-core.
This is enough because all TYPO3 packages require
this package in the same version. If typo3/cms-core is required
in dev-master, all other are also installed in dev-master.

This has the additional benefit, that other direct dependencies
to TYPO3 framework packages remain unchanged, thus it is checked
by composer whether they are allowed to be installed in the version
requested for typo3/cms-core.

Add prefer-stable: true to always fetch stable versions when
possible even when composer is called without --prefer-dist.

Last but not least, replace the deprecated or operator "|"
whith the new "||" operator.