### PR TITLE
Adds support for external image urls

### DIFF
--- a/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
@@ -58,11 +58,17 @@ abstract class AbstractMediaViewHelper extends AbstractTagBasedViewHelper
      */
     public static function preprocessSourceUri($src, array $arguments)
     {
-        $src = $GLOBALS['TSFE']->absRefPrefix . str_replace('%2F', '/', rawurlencode($src));
-        if (false === empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
-            $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
-        } elseif ('BE' === TYPO3_MODE || false === (boolean) $arguments['relative']) {
-            $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . ltrim($src, '/');
+        $parsedSrc = parse_url($src);
+        if (isset($parsedSrc['host'])) {
+            $scheme = isset($parsedSrc['scheme']) ? $parsedSrc['scheme'] : (GeneralUtility::getIndpEnv('TYPO3_SSL') ? 'https' : 'http');
+            $src = $scheme . '://' . $parsedSrc['host'] . str_replace('%2F', '/', rawurlencode($parsedSrc['path']));
+        } else {
+            $src = $GLOBALS['TSFE']->absRefPrefix . str_replace('%2F', '/', rawurlencode($src));
+            if (false === empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
+                $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
+            } elseif ('BE' === TYPO3_MODE || false === (boolean) $arguments['relative']) {
+                $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . ltrim($src, '/');
+            }
         }
         return $src;
     }


### PR DESCRIPTION
I finally managed to create a pull request. This pull request fixes #1439.

What I did is add a check whether we are dealing with an already fully qualified URI or not (`if (isset($parsedSrc['host']))`). The `else` part is the function as it was before. This implementation is inspired by what TYPO3 Core does: https://github.com/TYPO3-CMS/extbase/blob/96fffc2b245dc29a78bcb06a64cdb9d138f169c9/Classes/Service/ImageService.php#L84-L103

This of course does not add full support for FAL (e.g. no image processing), but it enables fully qualified URIs to be used in frontend and backend.