### PR TITLE
[BUGFIX] Fix condition.string.isNumeric viewhelper

### DIFF
--- a/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
@@ -33,6 +33,6 @@ class IsNumericViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === ctype_digit($arguments['value']);
+        return true === is_numeric($arguments['value']);
     }
 }


### PR DESCRIPTION
The argument value type does not match the parameter type of ctype_digit() and results in a negative check for integer values passed to the viewhelper. Using is_numeric() instead of ctype_digit() fixes the problem.

Fixes: #1471