### PR TITLE
[BUGFIX] Remove return {} on empty value in order to allow false and null values (#1486)

### DIFF
--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -97,9 +97,6 @@ class EncodeViewHelper extends AbstractViewHelper
         $preventRecursion = (boolean) $arguments['preventRecursion'];
         $recursionMarker = $arguments['recursionMarker'];
         $dateTimeFormat = $arguments['dateTimeFormat'];
-        if (true === empty($value)) {
-            return '{}';
-        }
         static::$encounteredClasses = [];
         $json = static::encodeValue($value, $useTraversableKeys, $preventRecursion, $recursionMarker, $dateTimeFormat);
         return $json;

--- a/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
@@ -72,9 +72,49 @@ class EncodeViewHelperTest extends AbstractViewHelperTest
     /**
      * @test
      */
-    public function returnsEmptyJsonObjectForEmptyArguments()
+    public function returnsEmptyObjectOnTopLevel()
     {
-        $this->assertEquals('{}', $this->executeViewHelper([]));
+        $this->assertEquals('{}', $this->executeViewHelper(['value' => new \stdClass()]));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsEmptyArrayOnTopLevel()
+    {
+        $this->assertEquals('[]', $this->executeViewHelper(['value' => []]));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFalseOnTopLevel()
+    {
+        $this->assertEquals('false', $this->executeViewHelper(['value' => false]));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsTrueOnTopLevel()
+    {
+        $this->assertEquals('true', $this->executeViewHelper(['value' => true]));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsNumberOnTopLevel()
+    {
+        $this->assertEquals('1.0', $this->executeViewHelper(['value' => 1.0]));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsNullOnTopLevel()
+    {
+        $this->assertEquals('null', $this->executeViewHelper(['value' => null]));
     }
 
     /**


### PR DESCRIPTION
See #1486.