### PR TITLE
Remove replacement of typo3/cms-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,7 @@
     },
     "replace": {
         "vhs": "self.version",
-        "typo3-ter/vhs": "self.version",
-        "typo3/cms-version": "*"
+        "typo3-ter/vhs": "self.version"
     },
     "require-dev": {
         "fluidtypo3/development": "^4.0"


### PR DESCRIPTION
Contrary to the assumption that typo3/cms-version was removed in
TYPO3 8.7, it was removed in TYPO3 9.

This means we must not replace it in our package to
allow user to install it