### PR TITLE
[FEATURE] Support nesting in v:variable.set

### DIFF
--- a/Tests/Unit/ViewHelpers/Variable/SetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/SetViewHelperTest.php
@@ -40,6 +40,86 @@ class SetViewHelperTest extends AbstractViewHelperTest
     /**
      * @test
      */
+    public function canSetVariableNestedOneLevelInArrayValue()
+    {
+        $variables = new \ArrayObject(['test' => ['test1' => ['test2' => true]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2', 'value' => false], $variables);
+        $this->assertFalse($variables['test']['test1']['test2']);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableNestedTwoLevelsInArrayValue()
+    {
+        $variables = new \ArrayObject(['test' => ['test1' => ['test2' => ['test3' => true]]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2.test3', 'value' => false], $variables);
+        $this->assertFalse($variables['test']['test1']['test2']['test3']);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableInObject()
+    {
+        $variables = new \ArrayObject(['test' => (object) ['test' => true]]);
+        $this->executeViewHelper(['name' => 'test.test', 'value' => false], $variables);
+        $this->assertFalse($variables['test']->test);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableInArrayNestedInObject()
+    {
+        $variables = new \ArrayObject(['test' => (object) ['test1' => ['test2' => true]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2', 'value' => false], $variables);
+        $this->assertFalse($variables['test']->test1['test2']);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableNestedInArrayNestedInObject()
+    {
+        $variables = new \ArrayObject(['test' => (object) ['test1' => ['test2' => ['test3' => true]]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2.test3', 'value' => false], $variables);
+        $this->assertFalse($variables['test']->test1['test2']['test3']);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableInObjectNestedInArrayNestedInObject()
+    {
+        $variables = new \ArrayObject(['test' => (object) ['test1' => ['test2' => (object) ['test3' => true]]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2.test3', 'value' => false], $variables);
+        $this->assertFalse($variables['test']->test1['test2']->test3);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableInArrayNestedInObjectNestedInArray()
+    {
+        $variables = new \ArrayObject(['test' => ['test1' => (object) ['test2' => ['test3' => true]]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2.test3', 'value' => false], $variables);
+        $this->assertFalse($variables['test']['test1']->test2['test3']);
+    }
+
+    /**
+     * @test
+     */
+    public function canSetVariableInNestedArrayNestedInObjectNestedInArray()
+    {
+        $variables = new \ArrayObject(['test' => ['test1' => (object) ['test2' => ['test3' => ['test4' => true]]]]]);
+        $this->executeViewHelper(['name' => 'test.test1.test2.test3.test4', 'value' => false], $variables);
+        $this->assertFalse($variables['test']['test1']->test2['test3']['test4']);
+    }
+
+    /**
+     * @test
+     */
     public function ignoresNestedVariableIfRootDoesNotExist()
     {
         $variables = new \ArrayObject(['test' => ['test' => true]]);
@@ -55,6 +135,15 @@ class SetViewHelperTest extends AbstractViewHelperTest
         $domainObject = new Foo();
         $variables = new \ArrayObject(['test' => $domainObject]);
         $result = $this->executeViewHelper(['name' => 'test.propertydoesnotexist', 'value' => false], $variables);
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresNestedVariableIfPathDoesNotExist() {
+        $variables = new \ArrayObject(['test' => ['test' => ['test' => true]]]);
+        $result = $this->executeViewHelper(['name' => 'test.doesnotexist.test.test', 'value' => false], $variables);
         $this->assertNull($result);
     }
 


### PR DESCRIPTION
SetViewHelper could only set direct child properties of arrays or
objects before, which is inconvenient when working with nested
structures. This change adds code to access properties nested at
arbitrary levels inside mixed array/object hierarchies.



This is actually much more complicated then I'd like, but so far I haven't found an easy way around it. Suggestions to make it more readable very welcome. Maybe there's already a helper function for this somewhere that I missed?