### PR TITLE
[TASK] Add fail-allowed builds for notice and deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,29 @@ php:
 
 matrix:
   include:
-    - php: "7.2"
-      env: COVERAGE="NO" TYPO3_VERSION="dev-master"
     - php: "7.0"
       env: COVERAGE="NO" TYPO3_VERSION="^8.7"
     - php: "7.1"
       env: COVERAGE="NO" TYPO3_VERSION="^8.7"
     - php: "7.2"
       env: COVERAGE="YES" TYPO3_VERSION="^8.7"
-    - php: "7.2"
-      env: COVERAGE="NO" TYPO3_VERSION="^9"
     - php: "7.3"
       env: COVERAGE="NO" TYPO3_VERSION="^9"
+    - php: "7.4"
+      env: COVERAGE="NO" TYPO3_VERSION="^9"
+    - php: "7.4"
+      name: TYPO3 master
+      env: COVERAGE="NO" TYPO3_VERSION="dev-master"
+    - php: "7.4"
+      name: PHP notices
+      env: COVERAGE="NO" TYPO3_VERSION="^9" FORCE_ERROR_MODE="1039"
+    - php: "7.4"
+      name: PHP deprecations
+      env: COVERAGE="NO" TYPO3_VERSION="^9" FORCE_ERROR_MODE="24583"
   allow_failures:
     - env: COVERAGE="NO" TYPO3_VERSION="dev-master"
+    - env: COVERAGE="NO" TYPO3_VERSION="^9" FORCE_ERROR_MODE="1039"
+    - env: COVERAGE="NO" TYPO3_VERSION="^9" FORCE_ERROR_MODE="24583"
 
 cache:
   directories:

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -30,4 +30,11 @@ $autoloader = require __DIR__ . '/../vendor/autoload.php';
     ]
 );
 
-ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_USER_DEPRECATED);
+$forceErrorMode = getenv('FORCE_ERROR_MODE');
+if ((string)$forceErrorMode === '') {
+    $errorMode = E_ERROR | E_WARNING | E_PARSE;
+} else {
+    $errorMode = (int)$forceErrorMode;
+}
+
+ini_set('error_reporting', $errorMode);


### PR DESCRIPTION
Adds two new error-silenced builds that allow seeing E_NOTICE and E_USER_DEPRECATED warnings separately, based on TYPO3 dev-master.