### PR TITLE
[BUGFIX] Fix #1504: use "pages" instead of "pages_language_overlay" since TYPO3 9.5

### DIFF
--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -313,8 +313,8 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
             }
         }
 
-        // Select all pages_language_overlay records on the current page. Each represents a possibility for a language.
-        $table = 'pages_language_overlay';
+        // Select all language overlay records on the current page. Each represents a possibility for a language.
+        $table = version_compare(TYPO3_branch, '9.5', '<') ? 'pages_language_overlay' : 'pages';
         $sysLang = $GLOBALS['TSFE']->cObj->getRecords($table, ['selectFields' => 'sys_language_uid', 'pidInList' => $this->getPageUid(), 'languageField' => 0]);
         $languageUids = array_column($sysLang, 'sys_language_uid');
 


### PR DESCRIPTION
This fixes an exception about missing TCA definition for `pages_language_overlay` in TYPO3 9.5.0+ while maintaining compatibility with lower TYPO3 versions.

Close: #1504