### PR TITLE
[TASK] Use FQN for global function calls to improve performance

### DIFF
--- a/Classes/Asset.php
+++ b/Classes/Asset.php
@@ -205,7 +205,7 @@ class Asset implements AssetInterface
     {
         $asset = self::getInstance();
         $asset->setContent($content);
-        $asset->setName(md5($content));
+        $asset->setName(\md5($content));
         return $asset->finalize();
     }
 
@@ -253,7 +253,7 @@ class Asset implements AssetInterface
         if (true === empty($path)) {
             return $this->getContent();
         }
-        $content = file_get_contents($path);
+        $content = \file_get_contents($path);
         return $content;
     }
 
@@ -264,12 +264,12 @@ class Asset implements AssetInterface
     {
         $name = $this->getName();
         if (true === empty($name)) {
-            $name = md5($this->standalone . '//' . $this->type . '//' . $this->path . '//' . $this->content);
+            $name = \md5($this->standalone . '//' . $this->type . '//' . $this->path . '//' . $this->content);
             if ($this->fluid) {
-                $name .= '_' . md5(serialize($this->variables));
+                $name .= '_' . \md5(\serialize($this->variables));
             }
         }
-        if (false === isset($GLOBALS['VhsAssets']) || false === is_array($GLOBALS['VhsAssets'])) {
+        if (false === isset($GLOBALS['VhsAssets']) || false === \is_array($GLOBALS['VhsAssets'])) {
             $GLOBALS['VhsAssets'] = [];
         }
         $GLOBALS['VhsAssets'][$name] = $this;
@@ -317,7 +317,7 @@ class Asset implements AssetInterface
     public function setType($type)
     {
         $this->type = $type;
-        if ('css' == strtolower($type)) {
+        if ('css' == \strtolower($type)) {
             $this->setMovable(false);
         }
         return $this;
@@ -436,9 +436,9 @@ class Asset implements AssetInterface
      */
     public function getContent()
     {
-        $path = (0 === strpos($this->path, '/') ? $this->path : GeneralUtility::getFileAbsFileName($this->path));
-        if (true === empty($this->content) && null !== $this->path && file_exists($path)) {
-            return file_get_contents($path);
+        $path = (0 === \strpos($this->path, '/') ? $this->path : GeneralUtility::getFileAbsFileName($this->path));
+        if (true === empty($this->content) && null !== $this->path && \file_exists($path)) {
+            return \file_get_contents($path);
         }
         return $this->content;
     }
@@ -471,14 +471,14 @@ class Asset implements AssetInterface
             $this->path = null;
             return $this;
         }
-        if (false === strpos($path, '://') && 0 !== strpos($path, '/')) {
+        if (false === \strpos($path, '://') && 0 !== \strpos($path, '/')) {
             $path = GeneralUtility::getFileAbsFileName($path);
         }
         if (null === $this->type) {
-            $this->setType(pathinfo($path, PATHINFO_EXTENSION));
+            $this->setType(\pathinfo($path, PATHINFO_EXTENSION));
         }
         if (null === $this->name) {
-            $this->setName(pathinfo($path, PATHINFO_FILENAME));
+            $this->setName(\pathinfo($path, PATHINFO_FILENAME));
         }
         $this->path = $path;
         return $this;
@@ -559,8 +559,8 @@ class Asset implements AssetInterface
             }
         }
         $settings = (array) self::$settingsCache;
-        $properties = get_class_vars(get_class($this));
-        foreach (array_keys($properties) as $propertyName) {
+        $properties = \get_class_vars(\get_class($this));
+        foreach (\array_keys($properties) as $propertyName) {
             $properties[$propertyName] = $this->$propertyName;
         }
 

--- a/Classes/Mbstring.php
+++ b/Classes/Mbstring.php
@@ -77,7 +77,7 @@ final class Mbstring
 
     public static function mb_convert_encoding($s, $toEncoding, $fromEncoding = null)
     {
-        if (is_array($fromEncoding) || false !== strpos($fromEncoding, ',')) {
+        if (\is_array($fromEncoding) || false !== \strpos($fromEncoding, ',')) {
             $fromEncoding = self::mb_detect_encoding($s, $fromEncoding);
         } else {
             $fromEncoding = self::getEncoding($fromEncoding);
@@ -86,12 +86,12 @@ final class Mbstring
         $toEncoding = self::getEncoding($toEncoding);
 
         if ('BASE64' === $fromEncoding) {
-            $s = base64_decode($s);
+            $s = \base64_decode($s);
             $fromEncoding = $toEncoding;
         }
 
         if ('BASE64' === $toEncoding) {
-            return base64_encode($s);
+            return \base64_encode($s);
         }
 
         if ('HTML-ENTITIES' === $toEncoding || 'HTML' === $toEncoding) {
@@ -99,18 +99,18 @@ final class Mbstring
                 $fromEncoding = 'Windows-1252';
             }
             if ('UTF-8' !== $fromEncoding) {
-                $s = iconv($fromEncoding, 'UTF-8//IGNORE', $s);
+                $s = \iconv($fromEncoding, 'UTF-8//IGNORE', $s);
             }
 
-            return preg_replace_callback('/[\x80-\xFF]+/', array(__CLASS__, 'html_encoding_callback'), $s);
+            return \preg_replace_callback('/[\x80-\xFF]+/', array(__CLASS__, 'html_encoding_callback'), $s);
         }
 
         if ('HTML-ENTITIES' === $fromEncoding) {
-            $s = html_entity_decode($s, ENT_COMPAT, 'UTF-8');
+            $s = \html_entity_decode($s, ENT_COMPAT, 'UTF-8');
             $fromEncoding = 'UTF-8';
         }
 
-        return iconv($fromEncoding, $toEncoding.'//IGNORE', $s);
+        return \iconv($fromEncoding, $toEncoding.'//IGNORE', $s);
     }
 
     public static function mb_convert_variables($toEncoding, $fromEncoding, &$a = null, &$b = null, &$c = null, &$d = null, &$e = null, &$f = null)
@@ -118,7 +118,7 @@ final class Mbstring
         $vars = array(&$a, &$b, &$c, &$d, &$e, &$f);
 
         $ok = true;
-        array_walk_recursive($vars, function (&$v) use (&$ok, $toEncoding, $fromEncoding) {
+        \array_walk_recursive($vars, function (&$v) use (&$ok, $toEncoding, $fromEncoding) {
             if (false === $v = Mbstring::mb_convert_encoding($v, $toEncoding, $fromEncoding)) {
                 $ok = false;
             }
@@ -129,12 +129,12 @@ final class Mbstring
 
     public static function mb_decode_mimeheader($s)
     {
-        return iconv_mime_decode($s, 2, self::$internalEncoding);
+        return \iconv_mime_decode($s, 2, self::$internalEncoding);
     }
 
     public static function mb_encode_mimeheader($s, $charset = null, $transferEncoding = null, $linefeed = null, $indent = null)
     {
-        trigger_error('mb_encode_mimeheader() is bugged. Please use iconv_mime_encode() instead', E_USER_WARNING);
+        \trigger_error('mb_encode_mimeheader() is bugged. Please use iconv_mime_encode() instead', E_USER_WARNING);
     }
 
     public static function mb_convert_case($s, $mode, $encoding = null)
@@ -147,16 +147,16 @@ final class Mbstring
 
         if ('UTF-8' === $encoding) {
             $encoding = null;
-            if (!preg_match('//u', $s)) {
-                $s = @iconv('UTF-8', 'UTF-8//IGNORE', $s);
+            if (!\preg_match('//u', $s)) {
+                $s = @\iconv('UTF-8', 'UTF-8//IGNORE', $s);
             }
         } else {
-            $s = iconv($encoding, 'UTF-8//IGNORE', $s);
+            $s = \iconv($encoding, 'UTF-8//IGNORE', $s);
         }
 
         if (MB_CASE_TITLE == $mode) {
-            $s = preg_replace_callback('/\b\p{Ll}/u', array(__CLASS__, 'title_case_upper'), $s);
-            $s = preg_replace_callback('/\B[\p{Lu}\p{Lt}]+/u', array(__CLASS__, 'title_case_lower'), $s);
+            $s = \preg_replace_callback('/\b\p{Ll}/u', array(__CLASS__, 'title_case_upper'), $s);
+            $s = \preg_replace_callback('/\B[\p{Lu}\p{Lt}]+/u', array(__CLASS__, 'title_case_lower'), $s);
         } else {
             if (MB_CASE_UPPER == $mode) {
                 static $upper = null;
@@ -166,7 +166,7 @@ final class Mbstring
                 $map = $upper;
             } else {
                 if (self::MB_CASE_FOLD === $mode) {
-                    $s = str_replace(self::$caseFold[0], self::$caseFold[1], $s);
+                    $s = \str_replace(self::$caseFold[0], self::$caseFold[1], $s);
                 }
 
                 static $lower = null;
@@ -179,16 +179,16 @@ final class Mbstring
             static $ulenMask = array("\xC0" => 2, "\xD0" => 2, "\xE0" => 3, "\xF0" => 4);
 
             $i = 0;
-            $len = strlen($s);
+            $len = \strlen($s);
 
             while ($i < $len) {
                 $ulen = $s[$i] < "\x80" ? 1 : $ulenMask[$s[$i] & "\xF0"];
-                $uchr = substr($s, $i, $ulen);
+                $uchr = \substr($s, $i, $ulen);
                 $i += $ulen;
 
                 if (isset($map[$uchr])) {
                     $uchr = $map[$uchr];
-                    $nlen = strlen($uchr);
+                    $nlen = \strlen($uchr);
 
                     if ($nlen == $ulen) {
                         $nlen = $i;
@@ -196,7 +196,7 @@ final class Mbstring
                             $s[--$nlen] = $uchr[--$ulen];
                         } while ($ulen);
                     } else {
-                        $s = substr_replace($s, $uchr, $i - $ulen, $ulen);
+                        $s = \substr_replace($s, $uchr, $i - $ulen, $ulen);
                         $len += $nlen - $ulen;
                         $i   += $nlen - $ulen;
                     }
@@ -208,7 +208,7 @@ final class Mbstring
             return $s;
         }
 
-        return iconv('UTF-8', $encoding.'//IGNORE', $s);
+        return \iconv('UTF-8', $encoding.'//IGNORE', $s);
     }
 
     public static function mb_internal_encoding($encoding = null)
@@ -219,7 +219,7 @@ final class Mbstring
 
         $encoding = self::getEncoding($encoding);
 
-        if ('UTF-8' === $encoding || false !== @iconv($encoding, $encoding, ' ')) {
+        if ('UTF-8' === $encoding || false !== @\iconv($encoding, $encoding, ' ')) {
             self::$internalEncoding = $encoding;
 
             return true;
@@ -234,7 +234,7 @@ final class Mbstring
             return self::$language;
         }
 
-        switch ($lang = strtolower($lang)) {
+        switch ($lang = \strtolower($lang)) {
             case 'uni':
             case 'neutral':
                 self::$language = $lang;
@@ -252,7 +252,7 @@ final class Mbstring
 
     public static function mb_encoding_aliases($encoding)
     {
-        switch (strtoupper($encoding)) {
+        switch (\strtoupper($encoding)) {
             case 'UTF8':
             case 'UTF-8':
                 return array('utf8');
@@ -270,7 +270,7 @@ final class Mbstring
             $encoding = self::$internalEncoding;
         }
 
-        return self::mb_detect_encoding($var, array($encoding)) || false !== @iconv($encoding, $encoding, $var);
+        return self::mb_detect_encoding($var, array($encoding)) || false !== @\iconv($encoding, $encoding, $var);
     }
 
     public static function mb_detect_encoding($str, $encodingList = null, $strict = false)
@@ -278,29 +278,29 @@ final class Mbstring
         if (null === $encodingList) {
             $encodingList = self::$encodingList;
         } else {
-            if (!is_array($encodingList)) {
-                $encodingList = array_map('trim', explode(',', $encodingList));
+            if (!\is_array($encodingList)) {
+                $encodingList = \array_map('trim', \explode(',', $encodingList));
             }
-            $encodingList = array_map('strtoupper', $encodingList);
+            $encodingList = \array_map('strtoupper', $encodingList);
         }
 
         foreach ($encodingList as $enc) {
             switch ($enc) {
                 case 'ASCII':
-                    if (!preg_match('/[\x80-\xFF]/', $str)) {
+                    if (!\preg_match('/[\x80-\xFF]/', $str)) {
                         return $enc;
                     }
                     break;
 
                 case 'UTF8':
                 case 'UTF-8':
-                    if (preg_match('//u', $str)) {
+                    if (\preg_match('//u', $str)) {
                         return 'UTF-8';
                     }
                     break;
 
                 default:
-                    if (0 === strncmp($enc, 'ISO-8859-', 9)) {
+                    if (0 === \strncmp($enc, 'ISO-8859-', 9)) {
                         return $enc;
                     }
             }
@@ -315,15 +315,15 @@ final class Mbstring
             return self::$encodingList;
         }
 
-        if (!is_array($encodingList)) {
-            $encodingList = array_map('trim', explode(',', $encodingList));
+        if (!\is_array($encodingList)) {
+            $encodingList = \array_map('trim', \explode(',', $encodingList));
         }
-        $encodingList = array_map('strtoupper', $encodingList);
+        $encodingList = \array_map('strtoupper', $encodingList);
 
         foreach ($encodingList as $enc) {
             switch ($enc) {
                 default:
-                    if (strncmp($enc, 'ISO-8859-', 9)) {
+                    if (\strncmp($enc, 'ISO-8859-', 9)) {
                         return false;
                     }
                 case 'ASCII':
@@ -341,33 +341,33 @@ final class Mbstring
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return strlen($s);
+            return \strlen($s);
         }
 
-        return @iconv_strlen($s, $encoding);
+        return @\iconv_strlen($s, $encoding);
     }
 
     public static function mb_strpos($haystack, $needle, $offset = 0, $encoding = null)
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return strpos($haystack, $needle, $offset);
+            return \strpos($haystack, $needle, $offset);
         }
 
         if ('' === $needle .= '') {
-            trigger_error(__METHOD__.': Empty delimiter', E_USER_WARNING);
+            \trigger_error(__METHOD__.': Empty delimiter', E_USER_WARNING);
 
             return false;
         }
 
-        return iconv_strpos($haystack, $needle, $offset, $encoding);
+        return \iconv_strpos($haystack, $needle, $offset, $encoding);
     }
 
     public static function mb_strrpos($haystack, $needle, $offset = 0, $encoding = null)
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return strrpos($haystack, $needle, $offset);
+            return \strrpos($haystack, $needle, $offset);
         }
 
         if ($offset != (int) $offset) {
@@ -381,7 +381,7 @@ final class Mbstring
             }
         }
 
-        $pos = iconv_strrpos($haystack, $needle, $encoding);
+        $pos = \iconv_strrpos($haystack, $needle, $encoding);
 
         return false !== $pos ? $offset + $pos : false;
     }
@@ -398,7 +398,7 @@ final class Mbstring
 
     public static function mb_substitute_character($c = null)
     {
-        if (0 === strcasecmp($c, 'none')) {
+        if (0 === \strcasecmp($c, 'none')) {
             return true;
         }
 
@@ -409,11 +409,11 @@ final class Mbstring
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return substr($s, $start, null === $length ? 2147483647 : $length);
+            return \substr($s, $start, null === $length ? 2147483647 : $length);
         }
 
         if ($start < 0) {
-            $start = iconv_strlen($s, $encoding) + $start;
+            $start = \iconv_strlen($s, $encoding) + $start;
             if ($start < 0) {
                 $start = 0;
             }
@@ -422,13 +422,13 @@ final class Mbstring
         if (null === $length) {
             $length = 2147483647;
         } elseif ($length < 0) {
-            $length = iconv_strlen($s, $encoding) + $length - $start;
+            $length = \iconv_strlen($s, $encoding) + $length - $start;
             if ($length < 0) {
                 return '';
             }
         }
 
-        return iconv_substr($s, $start, $length, $encoding).'';
+        return \iconv_substr($s, $start, $length, $encoding).'';
     }
 
     public static function mb_stripos($haystack, $needle, $offset = 0, $encoding = null)
@@ -450,10 +450,10 @@ final class Mbstring
     {
         $encoding = self::getEncoding($encoding);
         if ('CP850' === $encoding || 'ASCII' === $encoding) {
-            return strrchr($haystack, $needle, $part);
+            return \strrchr($haystack, $needle, $part);
         }
         $needle = self::mb_substr($needle, 0, 1, $encoding);
-        $pos = iconv_strrpos($haystack, $needle, $encoding);
+        $pos = \iconv_strrpos($haystack, $needle, $encoding);
 
         return self::getSubpart($pos, $part, $haystack, $encoding);
     }
@@ -476,15 +476,15 @@ final class Mbstring
 
     public static function mb_strstr($haystack, $needle, $part = false, $encoding = null)
     {
-        $pos = strpos($haystack, $needle);
+        $pos = \strpos($haystack, $needle);
         if (false === $pos) {
             return false;
         }
         if ($part) {
-            return substr($haystack, 0, $pos);
+            return \substr($haystack, 0, $pos);
         }
 
-        return substr($haystack, $pos);
+        return \substr($haystack, $pos);
     }
 
     public static function mb_get_info($type = 'all')
@@ -531,17 +531,17 @@ final class Mbstring
         $encoding = self::getEncoding($encoding);
 
         if ('UTF-8' !== $encoding) {
-            $s = iconv($encoding, 'UTF-8//IGNORE', $s);
+            $s = \iconv($encoding, 'UTF-8//IGNORE', $s);
         }
 
-        $s = preg_replace('/[\x{1100}-\x{115F}\x{2329}\x{232A}\x{2E80}-\x{303E}\x{3040}-\x{A4CF}\x{AC00}-\x{D7A3}\x{F900}-\x{FAFF}\x{FE10}-\x{FE19}\x{FE30}-\x{FE6F}\x{FF00}-\x{FF60}\x{FFE0}-\x{FFE6}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}]/u', '', $s, -1, $wide);
+        $s = \preg_replace('/[\x{1100}-\x{115F}\x{2329}\x{232A}\x{2E80}-\x{303E}\x{3040}-\x{A4CF}\x{AC00}-\x{D7A3}\x{F900}-\x{FAFF}\x{FE10}-\x{FE19}\x{FE30}-\x{FE6F}\x{FF00}-\x{FF60}\x{FFE0}-\x{FFE6}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}]/u', '', $s, -1, $wide);
 
-        return ($wide << 1) + iconv_strlen($s, 'UTF-8');
+        return ($wide << 1) + \iconv_strlen($s, 'UTF-8');
     }
 
     public static function mb_substr_count($haystack, $needle, $encoding = null)
     {
-        return substr_count($haystack, $needle);
+        return \substr_count($haystack, $needle);
     }
 
     public static function mb_output_handler($contents, $status)
@@ -552,17 +552,17 @@ final class Mbstring
     public static function mb_chr($code, $encoding = null)
     {
         if (0x80 > $code %= 0x200000) {
-            $s = chr($code);
+            $s = \chr($code);
         } elseif (0x800 > $code) {
-            $s = chr(0xC0 | $code >> 6).chr(0x80 | $code & 0x3F);
+            $s = \chr(0xC0 | $code >> 6).\chr(0x80 | $code & 0x3F);
         } elseif (0x10000 > $code) {
-            $s = chr(0xE0 | $code >> 12).chr(0x80 | $code >> 6 & 0x3F).chr(0x80 | $code & 0x3F);
+            $s = \chr(0xE0 | $code >> 12).\chr(0x80 | $code >> 6 & 0x3F).\chr(0x80 | $code & 0x3F);
         } else {
-            $s = chr(0xF0 | $code >> 18).chr(0x80 | $code >> 12 & 0x3F).chr(0x80 | $code >> 6 & 0x3F).chr(0x80 | $code & 0x3F);
+            $s = \chr(0xF0 | $code >> 18).\chr(0x80 | $code >> 12 & 0x3F).\chr(0x80 | $code >> 6 & 0x3F).\chr(0x80 | $code & 0x3F);
         }
 
         if ('UTF-8' !== $encoding = self::getEncoding($encoding)) {
-            $s = mb_convert_encoding($s, $encoding, 'UTF-8');
+            $s = \mb_convert_encoding($s, $encoding, 'UTF-8');
         }
 
         return $s;
@@ -571,10 +571,10 @@ final class Mbstring
     public static function mb_ord($s, $encoding = null)
     {
         if ('UTF-8' !== $encoding = self::getEncoding($encoding)) {
-            $s = mb_convert_encoding($s, 'UTF-8', $encoding);
+            $s = \mb_convert_encoding($s, 'UTF-8', $encoding);
         }
 
-        $code = ($s = unpack('C*', substr($s, 0, 4))) ? $s[1] : 0;
+        $code = ($s = \unpack('C*', \substr($s, 0, 4))) ? $s[1] : 0;
         if (0xF0 <= $code) {
             return (($code - 0xF0) << 18) + (($s[2] - 0x80) << 12) + (($s[3] - 0x80) << 6) + $s[4] - 0x80;
         }
@@ -604,11 +604,11 @@ final class Mbstring
     {
         $i = 1;
         $entities = '';
-        $m = unpack('C*', htmlentities($m[0], ENT_COMPAT, 'UTF-8'));
+        $m = \unpack('C*', \htmlentities($m[0], ENT_COMPAT, 'UTF-8'));
 
         while (isset($m[$i])) {
             if (0x80 > $m[$i]) {
-                $entities .= chr($m[$i++]);
+                $entities .= \chr($m[$i++]);
                 continue;
             }
             if (0xF0 <= $m[$i]) {
@@ -637,7 +637,7 @@ final class Mbstring
 
     private static function getData($file)
     {
-        if (file_exists($file = __DIR__.'/Resources/unidata/'.$file.'.php')) {
+        if (\file_exists($file = __DIR__.'/Resources/unidata/'.$file.'.php')) {
             return require $file;
         }
 
@@ -650,7 +650,7 @@ final class Mbstring
             return self::$internalEncoding;
         }
 
-        $encoding = strtoupper($encoding);
+        $encoding = \strtoupper($encoding);
 
         if ('8BIT' === $encoding || 'BINARY' === $encoding) {
             return 'CP850';

--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -103,9 +103,9 @@ class AssetService implements SingletonInterface
         $settings = $this->getSettings();
         $cached = (boolean) $cached;
         $buildTypoScriptAssets = (!static::$typoScriptAssetsBuilt && ($cached || $GLOBALS['TSFE']->no_cache));
-        if ($buildTypoScriptAssets && isset($settings['asset']) && is_array($settings['asset'])) {
+        if ($buildTypoScriptAssets && isset($settings['asset']) && \is_array($settings['asset'])) {
             foreach ($settings['asset'] as $name => $typoScriptAsset) {
-                if (!isset($GLOBALS['VhsAssets'][$name]) && is_array($typoScriptAsset)) {
+                if (!isset($GLOBALS['VhsAssets'][$name]) && \is_array($typoScriptAsset)) {
                     if (!isset($typoScriptAsset['name'])) {
                         $typoScriptAsset['name'] = $name;
                     }
@@ -114,7 +114,7 @@ class AssetService implements SingletonInterface
             }
             static::$typoScriptAssetsBuilt = true;
         }
-        if (!isset($GLOBALS['VhsAssets']) || !is_array($GLOBALS['VhsAssets'])) {
+        if (!isset($GLOBALS['VhsAssets']) || !\is_array($GLOBALS['VhsAssets'])) {
             return;
         }
         $assets = $GLOBALS['VhsAssets'];
@@ -128,7 +128,7 @@ class AssetService implements SingletonInterface
             if (true === $useDebugUtility) {
                 DebuggerUtility::var_dump($assets);
             } else {
-                echo var_export($assets, true);
+                echo \var_export($assets, true);
             }
         }
         $this->placeAssetsInHeaderAndFooter($assets, $cached);
@@ -143,11 +143,11 @@ class AssetService implements SingletonInterface
     {
         $content = $caller->content;
         $matches = [];
-        preg_match_all('/\<\![\-]+\ VhsAssetsDependenciesLoaded ([^ ]+) [\-]+\>/i', $content, $matches);
+        \preg_match_all('/\<\![\-]+\ VhsAssetsDependenciesLoaded ([^ ]+) [\-]+\>/i', $content, $matches);
         foreach ($matches[1] as $key => $match) {
-            $extractedDependencies = explode(',', $matches[1][$key]);
-            static::$cachedDependencies = array_merge(static::$cachedDependencies, $extractedDependencies);
-            $content = str_replace($matches[0][$key], '', $content);
+            $extractedDependencies = \explode(',', $matches[1][$key]);
+            static::$cachedDependencies = \array_merge(static::$cachedDependencies, $extractedDependencies);
+            $content = \str_replace($matches[0][$key], '', $content);
         }
         $caller->content = $content;
         $this->buildAll($parameters, $caller, false);
@@ -194,8 +194,8 @@ class AssetService implements SingletonInterface
             || !isset($settings['enableFooterRelocation']);
         foreach ($assets as $name => $asset) {
             $variables = $asset->getVariables();
-            if (0 < count($variables)) {
-                $name .= '-' . md5(serialize($variables));
+            if (0 < \count($variables)) {
+                $name .= '-' . \md5(\serialize($variables));
             }
             if (true === ($this->assertAssetAllowedInFooter($asset) && $footerRelocationEnabled)) {
                 $footer[$name] = $asset;
@@ -207,7 +207,7 @@ class AssetService implements SingletonInterface
             $uncachedSuffix = 'Uncached';
         } else {
             $uncachedSuffix = '';
-            $dependenciesString = '<!-- VhsAssetsDependenciesLoaded ' . implode(',', array_keys($assets)) . ' -->';
+            $dependenciesString = '<!-- VhsAssetsDependenciesLoaded ' . \implode(',', \array_keys($assets)) . ' -->';
             $this->insertAssetsAtMarker('DependenciesLoaded', $dependenciesString);
         }
         $this->insertAssetsAtMarker('Header' . $uncachedSuffix, $header);
@@ -223,22 +223,22 @@ class AssetService implements SingletonInterface
     protected function insertAssetsAtMarker($markerName, $assets)
     {
         $assetMarker = '<!-- VhsAssets' . $markerName . ' -->';
-        if (false === strpos($GLOBALS['TSFE']->content, $assetMarker)) {
-            $inFooter = (boolean) (false !== strpos($markerName, 'Footer'));
+        if (false === \strpos($GLOBALS['TSFE']->content, $assetMarker)) {
+            $inFooter = (boolean) (false !== \strpos($markerName, 'Footer'));
             $tag = true === $inFooter ? '</body>' : '</head>';
             $content = $GLOBALS['TSFE']->content;
-            $position = strrpos($content, $tag);
+            $position = \strrpos($content, $tag);
 
             if ($position) {
-                $GLOBALS['TSFE']->content = substr_replace($content, $assetMarker . LF, $position, 0);
+                $GLOBALS['TSFE']->content = \substr_replace($content, $assetMarker . LF, $position, 0);
             }
         }
-        if (true === is_array($assets)) {
+        if (true === \is_array($assets)) {
             $chunk = $this->buildAssetsChunk($assets);
         } else {
             $chunk = $assets;
         }
-        $GLOBALS['TSFE']->content = str_replace($assetMarker, $chunk, $GLOBALS['TSFE']->content);
+        $GLOBALS['TSFE']->content = \str_replace($assetMarker, $chunk, $GLOBALS['TSFE']->content);
     }
 
     /**
@@ -270,43 +270,43 @@ class AssetService implements SingletonInterface
                 if (false === $standalone) {
                     $chunk[$name] = $asset;
                 } else {
-                    if (0 < count($chunk)) {
+                    if (0 < \count($chunk)) {
                         $mergedFileTag = $this->writeCachedMergedFileAndReturnTag($chunk, $type);
-                        array_push($chunks, $mergedFileTag);
+                        \array_push($chunks, $mergedFileTag);
                         $chunk = [];
                     }
                     if (true === empty($path)) {
                         $assetContent = $this->extractAssetContent($asset);
-                        array_push($chunks, $this->generateTagForAssetType($type, $assetContent, null, null, $assetSettings));
+                        \array_push($chunks, $this->generateTagForAssetType($type, $assetContent, null, null, $assetSettings));
                     } else {
                         if (true === $external) {
-                            array_push(
+                            \array_push(
                                 $chunks,
                                 $this->generateTagForAssetType($type, null, $path, null, $assetSettings)
                             );
                         } else {
                             if (true === $rewrite) {
-                                array_push(
+                                \array_push(
                                     $chunks,
                                     $this->writeCachedMergedFileAndReturnTag([$name => $asset], $type)
                                 );
                             } else {
                                 $integrity = $this->getFileIntegrity($path);
-                                $path = mb_substr($path, mb_strlen(PATH_site));
+                                $path = \mb_substr($path, \mb_strlen(PATH_site));
                                 $path = $this->prefixPath($path);
-                                array_push($chunks, $this->generateTagForAssetType($type, null, $path, $integrity, $assetSettings));
+                                \array_push($chunks, $this->generateTagForAssetType($type, null, $path, $integrity, $assetSettings));
                             }
                         }
                     }
                 }
                 unset($integrity);
             }
-            if (0 < count($chunk)) {
+            if (0 < \count($chunk)) {
                 $mergedFileTag = $this->writeCachedMergedFileAndReturnTag($chunk, $type);
-                array_push($chunks, $mergedFileTag);
+                \array_push($chunks, $mergedFileTag);
             }
         }
-        return implode(LF, $chunks);
+        return \implode(LF, $chunks);
     }
 
     /**
@@ -317,19 +317,19 @@ class AssetService implements SingletonInterface
     protected function writeCachedMergedFileAndReturnTag($assets, $type)
     {
         $source = '';
-        $keys = array_keys($assets);
-        sort($keys);
-        $assetName = implode('-', $keys);
+        $keys = \array_keys($assets);
+        \sort($keys);
+        $assetName = \implode('-', $keys);
         unset($keys);
         if (isset($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['mergedAssetsUseHashedFilename'])) {
             if ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['mergedAssetsUseHashedFilename']) {
-                $assetName = md5($assetName);
+                $assetName = \md5($assetName);
             }
         }
         $fileRelativePathAndFilename = $this->getTempPath() . 'vhs-assets-' . $assetName . '.' . $type;
         $fileAbsolutePathAndFilename = GeneralUtility::getFileAbsFileName($fileRelativePathAndFilename);
-        if (false === file_exists($fileAbsolutePathAndFilename)
-            || 0 === filemtime($fileAbsolutePathAndFilename)
+        if (false === \file_exists($fileAbsolutePathAndFilename)
+            || 0 === \filemtime($fileAbsolutePathAndFilename)
             || true === isset($GLOBALS['BE_USER'])
             || true === (boolean) $GLOBALS['TSFE']->no_cache
             || true === (boolean) $GLOBALS['TSFE']->page['no_cache']
@@ -348,15 +348,15 @@ class AssetService implements SingletonInterface
         }
         if (false === empty($GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'])) {
             $timestampMode = $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'];
-            if (true === file_exists($fileRelativePathAndFilename)) {
-                $lastModificationTime = filemtime($fileRelativePathAndFilename);
+            if (true === \file_exists($fileRelativePathAndFilename)) {
+                $lastModificationTime = \filemtime($fileRelativePathAndFilename);
                 if ('querystring' === $timestampMode) {
                     $fileRelativePathAndFilename .= '?' . $lastModificationTime;
                 } elseif ('embed' === $timestampMode) {
-                    $fileRelativePathAndFilename = substr_replace(
+                    $fileRelativePathAndFilename = \substr_replace(
                         $fileRelativePathAndFilename,
                         '.' . $lastModificationTime,
-                        strrpos($fileRelativePathAndFilename, '.'),
+                        \strrpos($fileRelativePathAndFilename, '.'),
                         0
                     );
                 }
@@ -366,8 +366,8 @@ class AssetService implements SingletonInterface
         $integrity = $this->getFileIntegrity($fileAbsolutePathAndFilename);
 
         $assetSettings = null;
-        if (count($assets) === 1) {
-            $extractedAssetSettings = $this->extractAssetSettings($assets[array_keys($assets)[0]]);
+        if (\count($assets) === 1) {
+            $extractedAssetSettings = $this->extractAssetSettings($assets[\array_keys($assets)[0]]);
             if ($extractedAssetSettings['standalone']) {
                 $assetSettings = $extractedAssetSettings;
             }
@@ -503,28 +503,28 @@ class AssetService implements SingletonInterface
     protected function sortAssetsByDependency($assets)
     {
         $placed = [];
-        $assetNames = (0 < count($assets)) ? array_combine(array_keys($assets), array_keys($assets)) : [];
-        while ($asset = array_shift($assets)) {
+        $assetNames = (0 < \count($assets)) ? \array_combine(\array_keys($assets), \array_keys($assets)) : [];
+        while ($asset = \array_shift($assets)) {
             $postpone = false;
             /** @var AssetInterface $asset */
             $assetSettings = $this->extractAssetSettings($asset);
-            $name = array_shift($assetNames);
+            $name = \array_shift($assetNames);
             $dependencies = $assetSettings['dependencies'];
-            if (false === is_array($dependencies)) {
+            if (false === \is_array($dependencies)) {
                 $dependencies = GeneralUtility::trimExplode(',', $assetSettings['dependencies'], true);
             }
             foreach ($dependencies as $dependency) {
-                if (true === array_key_exists($dependency, $assets)
+                if (true === \array_key_exists($dependency, $assets)
                     && false === isset($placed[$dependency])
-                    && false === in_array($dependency, static::$cachedDependencies)
+                    && false === \in_array($dependency, static::$cachedDependencies)
                 ) {
                     // shove the Asset back to the end of the queue, the dependency has
                     // not yet been encountered and moving this item to the back of the
                     // queue ensures it will be encountered before re-encountering this
                     // specific Asset
-                    if (0 === count($assets)) {
+                    if (0 === \count($assets)) {
                         throw new \RuntimeException(
-                            sprintf(
+                            \sprintf(
                                 'Asset "%s" depends on "%s" but "%s" was not found',
                                 $name,
                                 $dependency,
@@ -552,7 +552,7 @@ class AssetService implements SingletonInterface
     protected function renderAssetAsFluidTemplate($asset)
     {
         $settings = $this->extractAssetSettings($asset);
-        if (isset($settings['variables']) && is_array($settings['variables'])) {
+        if (isset($settings['variables']) && \is_array($settings['variables'])) {
             $variables =  $settings['variables'];
         } else {
             $variables = [];
@@ -594,11 +594,11 @@ class AssetService implements SingletonInterface
      */
     protected function detectAndCopyFileReferences($contents, $originalDirectory)
     {
-        if (false !== stripos($contents, 'url')) {
+        if (false !== \stripos($contents, 'url')) {
             $regex = '/url(\\(\\s*["\']?(?!\\/)([^"\']+)["\']?\\s*\\))/iU';
             $contents = $this->copyReferencedFilesAndReplacePaths($contents, $regex, $originalDirectory, '(\'|\')');
         }
-        if (false !== stripos($contents, '@import')) {
+        if (false !== \stripos($contents, '@import')) {
             $regex = '/@import\\s*(["\']?(?!\\/)([^"\']+)["\']?)/i';
             $contents = $this->copyReferencedFilesAndReplacePaths($contents, $regex, $originalDirectory, '"|"');
         }
@@ -618,26 +618,26 @@ class AssetService implements SingletonInterface
     {
         $matches = [];
         $replacements = [];
-        $wrap = explode('|', $wrap);
-        preg_match_all($regex, $contents, $matches);
+        $wrap = \explode('|', $wrap);
+        \preg_match_all($regex, $contents, $matches);
         foreach ($matches[2] as $matchCount => $match) {
-            $match = trim($match, '\'" ');
-            if (false === strpos($match, ':') && !preg_match('/url\\s*\\(/i', $match)) {
-                $checksum = md5($originalDirectory . $match);
-                if (0 < preg_match('/([^\?#]+)(.+)?/', $match, $items)) {
+            $match = \trim($match, '\'" ');
+            if (false === \strpos($match, ':') && !\preg_match('/url\\s*\\(/i', $match)) {
+                $checksum = \md5($originalDirectory . $match);
+                if (0 < \preg_match('/([^\?#]+)(.+)?/', $match, $items)) {
                     list(, $path, $suffix) = $items;
                 } else {
                     $path = $match;
                     $suffix = '';
                 }
-                $newPath = basename($path);
-                $extension = pathinfo($newPath, PATHINFO_EXTENSION);
+                $newPath = \basename($path);
+                $extension = \pathinfo($newPath, PATHINFO_EXTENSION);
                 $temporaryFileName = 'vhs-assets-css-' . $checksum . '.' . $extension;
-                $temporaryFile = constant('PATH_site') . $this->getTempPath() . $temporaryFileName;
+                $temporaryFile = \constant('PATH_site') . $this->getTempPath() . $temporaryFileName;
                 $rawPath = GeneralUtility::getFileAbsFileName(
                     $originalDirectory . (empty($originalDirectory) ? '' : '/')
                 ) . $path;
-                $realPath = realpath($rawPath);
+                $realPath = \realpath($rawPath);
                 if (false === $realPath) {
                     GeneralUtility::sysLog(
                         'Asset at path "' . $rawPath . '" not found. Processing skipped.',
@@ -645,8 +645,8 @@ class AssetService implements SingletonInterface
                         GeneralUtility::SYSLOG_SEVERITY_WARNING
                     );
                 } else {
-                    if (false === file_exists($temporaryFile)) {
-                        copy($realPath, $temporaryFile);
+                    if (false === \file_exists($temporaryFile)) {
+                        \copy($realPath, $temporaryFile);
                         GeneralUtility::fixPermissions($temporaryFile);
                     }
                     $replacements[$matches[1][$matchCount]] = $wrap[0] . $temporaryFileName . $suffix . $wrap[1];
@@ -654,7 +654,7 @@ class AssetService implements SingletonInterface
             }
         }
         if (false === empty($replacements)) {
-            $contents = str_replace(array_keys($replacements), array_values($replacements), $contents);
+            $contents = \str_replace(\array_keys($replacements), \array_values($replacements), $contents);
         }
         return $contents;
     }
@@ -700,7 +700,7 @@ class AssetService implements SingletonInterface
         } else {
             $path = GeneralUtility::getFileAbsFileName($asset['path']);
         }
-        $content = file_get_contents($path);
+        $content = \file_get_contents($path);
         return $content;
     }
 
@@ -713,12 +713,12 @@ class AssetService implements SingletonInterface
     {
         $assetSettings = $this->extractAssetSettings($asset);
         $fileRelativePathAndFilename = $assetSettings['path'];
-        $fileRelativePath = dirname($assetSettings['path']);
+        $fileRelativePath = \dirname($assetSettings['path']);
         $absolutePathAndFilename = GeneralUtility::getFileAbsFileName($fileRelativePathAndFilename);
         $isExternal = true === isset($assetSettings['external']) && true === (boolean) $assetSettings['external'];
         $isFluidTemplate = true === isset($assetSettings['fluid']) && true === (boolean) $assetSettings['fluid'];
         if (false === empty($fileRelativePathAndFilename)) {
-            if (false === $isExternal && false === file_exists($absolutePathAndFilename)) {
+            if (false === $isExternal && false === \file_exists($absolutePathAndFilename)) {
                 throw new \RuntimeException('Asset "' . $absolutePathAndFilename . '" does not exist.');
             }
             if (true === $isFluidTemplate) {
@@ -747,12 +747,12 @@ class AssetService implements SingletonInterface
         if ('all' !== $parameters['cacheCmd']) {
             return;
         }
-        $assetCacheFiles = glob(GeneralUtility::getFileAbsFileName($this->getTempPath() . 'vhs-assets-*'));
+        $assetCacheFiles = \glob(GeneralUtility::getFileAbsFileName($this->getTempPath() . 'vhs-assets-*'));
         if (false === $assetCacheFiles) {
             return;
         }
         foreach ($assetCacheFiles as $assetCacheFile) {
-            touch($assetCacheFile, 0);
+            \touch($assetCacheFile, 0);
         }
         static::$cacheCleared = true;
     }
@@ -788,35 +788,35 @@ class AssetService implements SingletonInterface
             if (0 < $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['tagsAddSubresourceIntegrity']
                 && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['tagsAddSubresourceIntegrity'] < 4
             ) {
-                if (false === file_exists($file)) {
+                if (false === \file_exists($file)) {
                     return '';
                 }
 
                 $integrityMethod = ['sha256','sha384','sha512'][
                     $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['assets.']['tagsAddSubresourceIntegrity'] - 1
                 ];
-                $integrityFile = sprintf(
+                $integrityFile = \sprintf(
                     $this->getTempPath() . 'vhs-assets-%s.%s',
-                    str_replace('vhs-assets-', '', pathinfo($file, PATHINFO_BASENAME)),
+                    \str_replace('vhs-assets-', '', \pathinfo($file, PATHINFO_BASENAME)),
                     $integrityMethod
                 );
 
-                if (false === file_exists($integrityFile)
-                    || 0 === filemtime($integrityFile)
+                if (false === \file_exists($integrityFile)
+                    || 0 === \filemtime($integrityFile)
                     || true === isset($GLOBALS['BE_USER'])
                     || true === (boolean) $GLOBALS['TSFE']->no_cache
                     || true === (boolean) $GLOBALS['TSFE']->page['no_cache']
                 ) {
-                    if (extension_loaded('hash') && function_exists('hash_file')) {
-                        $integrity = base64_encode(hash_file($integrityMethod, $file, true));
-                    } elseif (extension_loaded('openssl') && function_exists('openssl_digest')) {
-                        $integrity = base64_encode(openssl_digest(file_get_contents($file), $integrityMethod, true));
+                    if (\extension_loaded('hash') && \function_exists('hash_file')) {
+                        $integrity = \base64_encode(\hash_file($integrityMethod, $file, true));
+                    } elseif (\extension_loaded('openssl') && \function_exists('openssl_digest')) {
+                        $integrity = \base64_encode(\openssl_digest(\file_get_contents($file), $integrityMethod, true));
                     } else {
                         return ''; // Sadly, no integrity generation possible
                     }
                     $this->writeFile($integrityFile, $integrity);
                 }
-                return sprintf('%s-%s', $integrityMethod, $integrity ?: file_get_contents($integrityFile));
+                return \sprintf('%s-%s', $integrityMethod, $integrity ?: \file_get_contents($integrityFile));
             }
         }
         return '';
@@ -831,7 +831,7 @@ class AssetService implements SingletonInterface
      */
     private function getTempPath()
     {
-        if (version_compare(TYPO3_version, 8.0, '>=')) {
+        if (\version_compare(TYPO3_version, 8.0, '>=')) {
             return 'typo3temp/assets/';
         } else {
             return 'typo3temp/';

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -64,13 +64,13 @@ class PageService implements SingletonInterface
     ) {
         $pageRepository = $this->getPageRepository();
         $pageConstraints = $this->getPageConstraints($excludePages, $includeNotInMenu, $includeMenuSeparator);
-        $cacheKey = md5($pageUid . $pageConstraints . (integer) $disableGroupAccessCheck);
+        $cacheKey = \md5($pageUid . $pageConstraints . (integer) $disableGroupAccessCheck);
         if (false === isset(static::$cachedMenus[$cacheKey])) {
             if (true === (boolean) $disableGroupAccessCheck) {
                 $pageRepository->where_groupAccess = '';
             }
 
-            static::$cachedMenus[$cacheKey] = array_filter(
+            static::$cachedMenus[$cacheKey] = \array_filter(
                 $pageRepository->getMenu($pageUid, '*', 'sorting', $pageConstraints),
                 function($page) {
                     return $this->hidePageForLanguageUid($page) === false;
@@ -88,7 +88,7 @@ class PageService implements SingletonInterface
      */
     public function getPage($pageUid, $disableGroupAccessCheck = false)
     {
-        $cacheKey = md5($pageUid . (integer) $disableGroupAccessCheck);
+        $cacheKey = \md5($pageUid . (integer) $disableGroupAccessCheck);
         if (false === isset(static::$cachedPages[$cacheKey])) {
             static::$cachedPages[$cacheKey] = $this->getPageRepository()->getPage($pageUid, $disableGroupAccessCheck);
         }
@@ -107,7 +107,7 @@ class PageService implements SingletonInterface
         if (null === $pageUid) {
             $pageUid = $GLOBALS['TSFE']->id;
         }
-        $cacheKey = md5($pageUid . (integer) $reverse . (integer) $disableGroupAccessCheck);
+        $cacheKey = \md5($pageUid . (integer) $reverse . (integer) $disableGroupAccessCheck);
         if (false === isset(static::$cachedRootlines[$cacheKey])) {
             $pageRepository = $this->getPageRepository();
             if (true === (boolean) $disableGroupAccessCheck) {
@@ -115,7 +115,7 @@ class PageService implements SingletonInterface
             }
             $rootline = $pageRepository->getRootLine($pageUid);
             if (true === $reverse) {
-                $rootline = array_reverse($rootline);
+                $rootline = \array_reverse($rootline);
             }
             static::$cachedRootlines[$cacheKey] = $rootline;
         }
@@ -148,11 +148,11 @@ class PageService implements SingletonInterface
             $constraints[] = 'doktype != ' . PageRepository::DOKTYPE_SPACER;
         }
 
-        if (0 < count($excludePages)) {
-            $constraints[] = 'uid NOT IN (' . implode(',', $excludePages) . ')';
+        if (0 < \count($excludePages)) {
+            $constraints[] = 'uid NOT IN (' . \implode(',', $excludePages) . ')';
         }
 
-        return 'AND ' . implode(' AND ', $constraints);
+        return 'AND ' . \implode(' AND ', $constraints);
     }
 
     /**
@@ -163,7 +163,7 @@ class PageService implements SingletonInterface
      */
     public function hidePageForLanguageUid($page = null, $languageUid = -1, $normalWhenNoLanguage = true)
     {
-        if (is_array($page)) {
+        if (\is_array($page)) {
             $pageUid = $page['uid'];
             $pageRecord = $page;
         } else {
@@ -180,7 +180,7 @@ class PageService implements SingletonInterface
         if (0 !== $languageUid) {
             $pageOverlay = $this->getPageRepository()->getPageOverlay($pageUid, $languageUid);
         }
-        $translationAvailable = (0 !== count($pageOverlay));
+        $translationAvailable = (0 !== \count($pageOverlay));
 
         return
             (true === $hideIfNotTranslated && (0 !== $languageUid) && false === $translationAvailable) ||
@@ -253,13 +253,13 @@ class PageService implements SingletonInterface
             return true;
         }
 
-        $groups = explode(',', $page['fe_group']);
+        $groups = \explode(',', $page['fe_group']);
 
-        $showPageAtAnyLogin = (in_array(-2, $groups));
-        $hidePageAtAnyLogin = (in_array(-1, $groups));
-        $userIsLoggedIn = (is_array($GLOBALS['TSFE']->fe_user->user));
+        $showPageAtAnyLogin = (\in_array(-2, $groups));
+        $hidePageAtAnyLogin = (\in_array(-1, $groups));
+        $userIsLoggedIn = (\is_array($GLOBALS['TSFE']->fe_user->user));
         $userGroups = $GLOBALS['TSFE']->fe_user->groupData['uid'];
-        $userIsInGrantedGroups = (0 < count(array_intersect($userGroups, $groups)));
+        $userIsInGrantedGroups = (0 < \count(\array_intersect($userGroups, $groups)));
 
         if ((false === $userIsLoggedIn && true === $hidePageAtAnyLogin) ||
             (true === $userIsLoggedIn && true === $showPageAtAnyLogin) ||
@@ -347,12 +347,12 @@ class PageService implements SingletonInterface
             case 2:
                 // mode: random subpage of selected or current page
                 $menu = $this->getMenu($page['shortcut'] > 0 ? $page['shortcut'] : $originalPageUid);
-                $targetPage = (0 < count($menu)) ? $menu[array_rand($menu)] : $page;
+                $targetPage = (0 < \count($menu)) ? $menu[\array_rand($menu)] : $page;
                 break;
             case 1:
                 // mode: first subpage of selected or current page
                 $menu = $this->getMenu($page['shortcut'] > 0 ? $page['shortcut'] : $originalPageUid);
-                $targetPage = (0 < count($menu)) ? reset($menu) : $page;
+                $targetPage = (0 < \count($menu)) ? \reset($menu) : $page;
                 break;
             case 0:
             default:

--- a/Classes/Traits/ArrayConsumingViewHelperTrait.php
+++ b/Classes/Traits/ArrayConsumingViewHelperTrait.php
@@ -90,14 +90,14 @@ trait ArrayConsumingViewHelperTrait
     protected static function arrayFromArrayOrTraversableOrCSVStatic($candidate, $useKeys = true)
     {
         if (true === $candidate instanceof \Traversable) {
-            return iterator_to_array($candidate, $useKeys);
+            return \iterator_to_array($candidate, $useKeys);
         } elseif (true === $candidate instanceof QueryResultInterface) {
             /** @var QueryResultInterface $candidate */
             return $candidate->toArray();
         }
-        if (true === is_string($candidate)) {
+        if (true === \is_string($candidate)) {
             return GeneralUtility::trimExplode(',', $candidate, true);
-        } elseif (true === is_array($candidate)) {
+        } elseif (true === \is_array($candidate)) {
             return $candidate;
         }
         ErrorUtility::throwViewHelperException('Unsupported input type; cannot convert to array!');
@@ -130,6 +130,6 @@ trait ArrayConsumingViewHelperTrait
      */
     protected static function assertIsArrayOrIterator($subject)
     {
-        return (boolean) (true === is_array($subject) || true === $subject instanceof \Traversable);
+        return (boolean) (true === \is_array($subject) || true === $subject instanceof \Traversable);
     }
 }

--- a/Classes/Traits/SlideViewHelperTrait.php
+++ b/Classes/Traits/SlideViewHelperTrait.php
@@ -130,10 +130,10 @@ trait SlideViewHelperTrait
             }
             $rootLine = $this->getPageService()->getRootLine($pageUid, null);
             if (-1 !== $slide) {
-                $rootLine = array_slice($rootLine, 0, $slide);
+                $rootLine = \array_slice($rootLine, 0, $slide);
             }
             if ($reverse) {
-                $rootLine = array_reverse($rootLine);
+                $rootLine = \array_reverse($rootLine);
             }
             foreach ($rootLine as $page) {
                 $storagePageUids[] = (integer) $page['uid'];
@@ -142,17 +142,17 @@ trait SlideViewHelperTrait
         // select records, respecting slide and slideCollect.
         $records = [];
         do {
-            $storagePageUid = array_shift($storagePageUids);
+            $storagePageUid = \array_shift($storagePageUids);
             $limitRemaining = null;
             if (null !== $limit) {
-                $limitRemaining = $limit - count($records);
+                $limitRemaining = $limit - \count($records);
                 if (0 >= $limitRemaining) {
                     break;
                 }
             }
             $recordsFromPageUid = $this->getSlideRecordsFromPage($storagePageUid, $limitRemaining);
-            if (0 < count($recordsFromPageUid)) {
-                $records = array_merge($records, $recordsFromPageUid);
+            if (0 < \count($recordsFromPageUid)) {
+                $records = \array_merge($records, $recordsFromPageUid);
                 if (0 === $slideCollect) {
                     // stop collecting because argument said so and we've gotten at least one record now.
                     break;

--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -48,7 +48,7 @@ trait SourceSetViewHelperTrait
         foreach ($srcsets as $key => $width) {
             $srcsetVariant = $this->getImgResource($src, $width, $format, $quality, $treatIdAsReference, null, $crop);
 
-            $srcsetVariantSrc = rawurldecode($srcsetVariant[3]);
+            $srcsetVariantSrc = \rawurldecode($srcsetVariant[3]);
             $srcsetVariantSrc = static::preprocessSourceUri(GeneralUtility::rawUrlEncodeFP($srcsetVariantSrc), $this->arguments);
 
             $imageSources[$srcsetVariant[0]] = [
@@ -59,7 +59,7 @@ trait SourceSetViewHelperTrait
             $srcsetVariants[$srcsetVariant[0]] = $srcsetVariantSrc . ' ' . $srcsetVariant[0] . 'w';
         }
 
-        $tag->addAttribute('srcset', implode(',', $srcsetVariants));
+        $tag->addAttribute('srcset', \implode(',', $srcsetVariants));
 
         if ('BE' === TYPO3_MODE) {
             FrontendSimulationUtility::resetFrontendEnvironment($tsfeBackup);
@@ -91,13 +91,13 @@ trait SourceSetViewHelperTrait
         if (false === empty($format)) {
             $setup['ext'] = $format;
         }
-        if (0 < intval($quality)) {
+        if (0 < \intval($quality)) {
             $quality = MathUtility::forceIntegerInRange($quality, 10, 100, 75);
             $setup['params'] .= ' -quality ' . $quality;
         }
 
-        if ('BE' === TYPO3_MODE && '../' === substr($src, 0, 3)) {
-            $src = substr($src, 3);
+        if ('BE' === TYPO3_MODE && '../' === \substr($src, 0, 3)) {
+            $src = \substr($src, 3);
         }
         return $this->contentObject->getImgResource($src, $setup);
     }
@@ -112,8 +112,8 @@ trait SourceSetViewHelperTrait
     {
         $srcsets = $this->arguments['srcset'];
         if (true === $srcsets instanceof \Traversable) {
-            $srcsets = iterator_to_array($srcsets);
-        } elseif (true === is_string($srcsets)) {
+            $srcsets = \iterator_to_array($srcsets);
+        } elseif (true === \is_string($srcsets)) {
             $srcsets = GeneralUtility::trimExplode(',', $srcsets, true);
         } else {
             $srcsets = (array) $srcsets;

--- a/Classes/Traits/TagViewHelperTrait.php
+++ b/Classes/Traits/TagViewHelperTrait.php
@@ -114,7 +114,7 @@ trait TagViewHelperTrait
         array $attributes = [],
         array $nonEmptyAttributes = ['id', 'class']
     ) {
-        $trimmedContent = trim((string) $content);
+        $trimmedContent = \trim((string) $content);
         $forceClosingTag = (boolean) $this->arguments['forceClosingTag'];
         if (true === empty($trimmedContent) && true === (boolean) $this->arguments['hideIfEmpty']) {
             return '';

--- a/Classes/Utility/CoreUtility.php
+++ b/Classes/Utility/CoreUtility.php
@@ -25,7 +25,7 @@ class CoreUtility
      */
     public static function getLanguageFlagIconPath()
     {
-        if (version_compare(self::getCurrentCoreVersion(), 9.0, '<')) {
+        if (\version_compare(self::getCurrentCoreVersion(), 9.0, '<')) {
             return ExtensionManagementUtility::extPath('core') . 'Resources/Public/Icons/Flags/PNG/';
         }
         return ExtensionManagementUtility::extPath('core') . 'Resources/Public/Icons/Flags/';
@@ -39,6 +39,6 @@ class CoreUtility
      */
     public static function getCurrentCoreVersion()
     {
-        return substr(ExtensionManagementUtility::getExtensionVersion('core'), 0, 3);
+        return \substr(ExtensionManagementUtility::getExtensionVersion('core'), 0, 3);
     }
 }

--- a/Classes/Utility/ErrorUtility.php
+++ b/Classes/Utility/ErrorUtility.php
@@ -21,7 +21,7 @@ class ErrorUtility
      */
     public static function throwViewHelperException($message = null, $code = null)
     {
-        if (version_compare(TYPO3_version, '8.0', '>=')) {
+        if (\version_compare(TYPO3_version, '8.0', '>=')) {
             throw new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception($message, $code);
         }
         throw new \TYPO3\CMS\Fluid\Core\ViewHelper\Exception($message, $code);

--- a/Classes/Utility/FrontendSimulationUtility.php
+++ b/Classes/Utility/FrontendSimulationUtility.php
@@ -34,16 +34,16 @@ class FrontendSimulationUtility
         $tsfeBackup = isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
         $GLOBALS['TSFE'] = new \stdClass();
         // preparing csConvObj
-        if (false === is_object($GLOBALS['TSFE']->csConvObj)) {
-            if (true === is_object($GLOBALS['LANG'])) {
+        if (false === \is_object($GLOBALS['TSFE']->csConvObj)) {
+            if (true === \is_object($GLOBALS['LANG'])) {
                 $GLOBALS['TSFE']->csConvObj = $GLOBALS['LANG']->csConvObj;
             } else {
                 $GLOBALS['TSFE']->csConvObj = GeneralUtility::makeInstance(CharsetConverter::class);
             }
         }
         // preparing renderCharset
-        if (false === is_object($GLOBALS['TSFE']->renderCharset)) {
-            if (true === is_object($GLOBALS['LANG'])) {
+        if (false === \is_object($GLOBALS['TSFE']->renderCharset)) {
+            if (true === \is_object($GLOBALS['LANG'])) {
                 $GLOBALS['TSFE']->renderCharset = $GLOBALS['LANG']->charSet;
             } else {
                 $GLOBALS['TSFE']->renderCharset = 'utf-8';

--- a/Classes/Utility/ViewHelperUtility.php
+++ b/Classes/Utility/ViewHelperUtility.php
@@ -26,7 +26,7 @@ class ViewHelperUtility
      */
     public static function getVariableProviderFromRenderingContext(RenderingContextInterface $renderingContext)
     {
-        if (method_exists($renderingContext, 'getVariableProvider')) {
+        if (\method_exists($renderingContext, 'getVariableProvider')) {
             return $renderingContext->getVariableProvider();
         }
         return $renderingContext->getTemplateVariableContainer();

--- a/Classes/View/UncacheTemplateView.php
+++ b/Classes/View/UncacheTemplateView.php
@@ -75,7 +75,7 @@ class UncacheTemplateView extends TemplateView
     {
         $partial = $conf['partial'];
         $section = $conf['section'];
-        $arguments = true === is_array($conf['arguments']) ? $conf['arguments'] : [];
+        $arguments = true === \is_array($conf['arguments']) ? $conf['arguments'] : [];
         /** @var ControllerContext $controllerContext */
         $controllerContext = $conf['controllerContext'];
         if (true === empty($partial)) {
@@ -99,12 +99,12 @@ class UncacheTemplateView extends TemplateView
     ) {
         $renderingContext->setControllerContext($controllerContext);
         $this->setRenderingContext($renderingContext);
-        if (method_exists($renderingContext, 'getTemplateParser')) {
+        if (\method_exists($renderingContext, 'getTemplateParser')) {
             $this->templateParser = $renderingContext->getTemplateParser();
         } else {
             $this->templateParser = TemplateParserBuilder::build();
         }
-        if (method_exists($renderingContext, 'getTemplateCompiler')) {
+        if (\method_exists($renderingContext, 'getTemplateCompiler')) {
             $this->templateCompiler = $renderingContext->getTemplateCompiler();
         } else {
             $this->templateCompiler = $this->objectManager->get(TemplateCompiler::class);
@@ -127,12 +127,12 @@ class UncacheTemplateView extends TemplateView
         $section = null,
         array $arguments = []
     ) {
-        array_push(
+        \array_push(
             $this->renderingStack,
             ['type' => self::RENDERING_TEMPLATE, 'parsedTemplate' => null, 'renderingContext' => $renderingContext]
         );
         $rendered = $this->renderPartial($partial, $section, $arguments);
-        array_pop($this->renderingStack);
+        \array_pop($this->renderingStack);
         return $rendered;
     }
 }

--- a/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
+++ b/Classes/ViewHelpers/Asset/AbstractAssetViewHelper.php
@@ -272,7 +272,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
         } else {
             $path = GeneralUtility::getFileAbsFileName($this->arguments['path']);
         }
-        $content = file_get_contents($path);
+        $content = \file_get_contents($path);
         return $content;
     }
 
@@ -318,7 +318,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
                 DebuggerUtility::var_dump($debugInformation);
                 return '';
             } else {
-                return var_export($debugInformation, true);
+                return \var_export($debugInformation, true);
             }
         }
     }
@@ -361,7 +361,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
         if (isset($assetSettings['name']) && !empty($assetSettings['name'])) {
             $name = $assetSettings['name'];
         } else {
-            $name = md5(serialize($assetSettings));
+            $name = \md5(\serialize($assetSettings));
         }
         return $name;
     }
@@ -403,7 +403,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
     public function getVariables()
     {
         $assetSettings = $this->getAssetSettings();
-        if (isset($assetSettings['variables']) && is_array($assetSettings['variables'])) {
+        if (isset($assetSettings['variables']) && \is_array($assetSettings['variables'])) {
             return $assetSettings['variables'];
         }
         return [];
@@ -433,7 +433,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
             }
         }
         $settings = self::$settingsCache;
-        if (is_array($this->localSettings)) {
+        if (\is_array($this->localSettings)) {
             ArrayUtility::mergeRecursiveWithOverrule($settings, $this->localSettings);
         }
         return $settings;
@@ -444,7 +444,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
      */
     public function setSettings($settings)
     {
-        if (is_array($settings) || $settings instanceof \ArrayAccess) {
+        if (\is_array($settings) || $settings instanceof \ArrayAccess) {
             $this->localSettings = $settings;
         }
     }
@@ -454,7 +454,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
      */
     public function getAssetSettings()
     {
-        if (is_array($this->assetSettingsCache)) {
+        if (\is_array($this->assetSettingsCache)) {
             return $this->assetSettingsCache;
         }
         // Note: name and group are taken directly from arguments; if they are changed through
@@ -464,13 +464,13 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
         $settings = $this->getSettings();
         $assetSettings = $this->arguments;
         $assetSettings['type'] = $this->getType();
-        if (isset($settings['asset']) && true === is_array($settings['asset'])) {
+        if (isset($settings['asset']) && true === \is_array($settings['asset'])) {
             $assetSettings = $this->mergeArrays($assetSettings, $settings['asset']);
         }
-        if (isset($settings['assetGroup'][$groupName]) && is_array($settings['assetGroup'][$groupName])) {
+        if (isset($settings['assetGroup'][$groupName]) && \is_array($settings['assetGroup'][$groupName])) {
             $assetSettings = $this->mergeArrays($assetSettings, $settings['assetGroup'][$groupName]);
         }
-        if (isset($settings['asset'][$name]) && is_array($settings['asset'][$name])) {
+        if (isset($settings['asset'][$name]) && \is_array($settings['asset'][$name])) {
             $assetSettings = $this->mergeArrays($assetSettings, $settings['asset'][$name]);
         }
         if (!empty($assetSettings['path']) && !$assetSettings['external']) {
@@ -490,7 +490,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
     public function getDebugInformation()
     {
         return [
-            'class' => get_class($this),
+            'class' => \get_class($this),
             'settings' => $this->getAssetSettings()
         ];
     }
@@ -560,7 +560,7 @@ abstract class AbstractAssetViewHelper extends AbstractViewHelper implements Ass
         $groupName = $this->arguments['group'];
         $settings = $this->getSettings();
         $dependencies = $this->getDependencies();
-        array_push($dependencies, $this->getName());
+        \array_push($dependencies, $this->getName());
         foreach ($dependencies as $name) {
             if (isset($settings['asset'][$name]['remove']) && $settings['asset'][$name]['remove'] > 0) {
                 return true;

--- a/Classes/ViewHelpers/Asset/PrefetchViewHelper.php
+++ b/Classes/ViewHelpers/Asset/PrefetchViewHelper.php
@@ -107,7 +107,7 @@ class PrefetchViewHelper extends AbstractAssetViewHelper
     public function build()
     {
         $domains = $this->arguments['domains'];
-        if (false === is_array($domains)) {
+        if (false === \is_array($domains)) {
             $domains = GeneralUtility::trimExplode(',', $domains, true);
         }
         $headerCode = '';

--- a/Classes/ViewHelpers/CallViewHelper.php
+++ b/Classes/ViewHelpers/CallViewHelper.php
@@ -66,18 +66,18 @@ class CallViewHelper extends AbstractViewHelper implements CompilableInterface
         $object = $renderChildrenClosure();
         $method = $arguments['method'];
         $methodArguments = $arguments['arguments'];
-        if (false === is_object($object)) {
+        if (false === \is_object($object)) {
             throw new \RuntimeException(
                 'Using v:call requires an object either as "object" attribute, tag content or inline argument',
                 1356849652
             );
         }
-        if (false === method_exists($object, $method)) {
+        if (false === \method_exists($object, $method)) {
             throw new \RuntimeException(
-                'Method "' . $method . '" does not exist on object of type ' . get_class($object),
+                'Method "' . $method . '" does not exist on object of type ' . \get_class($object),
                 1356834755
             );
         }
-        return call_user_func_array([$object, $method], $methodArguments);
+        return \call_user_func_array([$object, $method], $methodArguments);
     }
 }

--- a/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
@@ -40,6 +40,6 @@ class IsCliViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return defined('TYPO3_climode');
+        return \defined('TYPO3_climode');
     }
 }

--- a/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Form/HasValidatorViewHelper.php
@@ -76,18 +76,18 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper
         $validatorName = isset($arguments['validatorName']) ? $arguments['validatorName'] : null;
         $object = isset($arguments['object']) ? $arguments['object'] : null;
 
-        $className = get_class($object);
-        if (false !== strpos($property, '.')) {
-            $pathSegments = explode('.', $property);
+        $className = \get_class($object);
+        if (false !== \strpos($property, '.')) {
+            $pathSegments = \explode('.', $property);
             foreach ($pathSegments as $property) {
-                if (true === ctype_digit($property)) {
+                if (true === \ctype_digit($property)) {
                     continue;
                 }
                 $annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, 'var');
-                $possibleClassName = array_pop($annotations);
-                if (false !== strpos($possibleClassName, '<')) {
-                    $className = array_pop(explode('<', trim($possibleClassName, '>')));
-                } elseif (true === class_exists($possibleClassName)) {
+                $possibleClassName = \array_pop($annotations);
+                if (false !== \strpos($possibleClassName, '<')) {
+                    $className = \array_pop(\explode('<', \trim($possibleClassName, '>')));
+                } elseif (true === \class_exists($possibleClassName)) {
                     $className = $possibleClassName;
                 }
             }
@@ -95,13 +95,13 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper
 
         // If we are on TYPO3 9.3 or above, the old validator ID is no longer possible to use and we must use the new one.
         $fluidCoreVersion = ExtensionManagementUtility::getExtensionVersion('fluid');
-        if (version_compare($fluidCoreVersion, 9.3, '>=')) {
+        if (\version_compare($fluidCoreVersion, 9.3, '>=')) {
             $annotationName = 'Extbase\\Validate';
         } else {
             $annotationName = 'validate';
         }
         $annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, $annotationName);
-        if (empty($annotations) && $annotationName === 'validate' && version_compare($fluidCoreVersion, 9.1, '>=')) {
+        if (empty($annotations) && $annotationName === 'validate' && \version_compare($fluidCoreVersion, 9.1, '>=')) {
             // We tried looking for the legacy validator name but found none. Retry with the new way. We have to do this
             // as a retry, because we cannot assume that any site using TYPO3 9.1+ will also be using the modern
             // annotations. Hence we cannot change the validator name until we've also looked for the legacy ones (which
@@ -109,6 +109,6 @@ class HasValidatorViewHelper extends AbstractConditionViewHelper
             $annotationName = 'Extbase\\Validate';
             $annotations = self::$staticReflectionService->getPropertyTagValues($className, $property, $annotationName);
         }
-        return (count($annotations) && (!$validatorName || in_array($validatorName, $annotations)));
+        return (\count($annotations) && (!$validatorName || \in_array($validatorName, $annotations)));
     }
 }

--- a/Classes/ViewHelpers/Condition/Iterator/ContainsViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Iterator/ContainsViewHelper.php
@@ -63,7 +63,7 @@ class ContainsViewHelper extends AbstractConditionViewHelper
         }
         $haystack = $arguments['haystack'];
         $asArray = [];
-        if (true === is_array($haystack)) {
+        if (true === \is_array($haystack)) {
             $asArray = $haystack;
         } elseif (true === $haystack instanceof LazyObjectStorage) {
             /** @var $haystack LazyObjectStorage */
@@ -74,8 +74,8 @@ class ContainsViewHelper extends AbstractConditionViewHelper
         } elseif (true === $haystack instanceof QueryResult) {
             /** @var $haystack QueryResult */
             $asArray = $haystack->toArray();
-        } elseif (true === is_string($haystack)) {
-            $asArray = str_split($haystack);
+        } elseif (true === \is_string($haystack)) {
+            $asArray = \str_split($haystack);
         }
         return (true === isset($asArray[$index]) ? $asArray[$index] : false);
     }
@@ -88,7 +88,7 @@ class ContainsViewHelper extends AbstractConditionViewHelper
      */
     protected static function assertHaystackHasNeedle($haystack, $needle, $arguments)
     {
-        if (true === is_array($haystack)) {
+        if (true === \is_array($haystack)) {
             return self::assertHaystackIsArrayAndHasNeedle($haystack, $needle, $arguments);
         } elseif ($haystack instanceof LazyObjectStorage) {
             return self::assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
@@ -96,8 +96,8 @@ class ContainsViewHelper extends AbstractConditionViewHelper
             return self::assertHaystackIsObjectStorageAndHasNeedle($haystack, $needle);
         } elseif ($haystack instanceof QueryResult) {
             return self::assertHaystackIsQueryResultAndHasNeedle($haystack, $needle);
-        } elseif (true === is_string($haystack)) {
-            return strpos($haystack, $needle);
+        } elseif (true === \is_string($haystack)) {
+            return \strpos($haystack, $needle);
         }
         return false;
     }
@@ -153,9 +153,9 @@ class ContainsViewHelper extends AbstractConditionViewHelper
     {
         if (false === $needle instanceof DomainObjectInterface) {
             if (true === (boolean) $arguments['considerKeys']) {
-                $result = (boolean) (false !== array_search($needle, $haystack) || true === isset($haystack[$needle]));
+                $result = (boolean) (false !== \array_search($needle, $haystack) || true === isset($haystack[$needle]));
             } else {
-                $result = array_search($needle, $haystack);
+                $result = \array_search($needle, $haystack);
             }
             return $result;
         } else {
@@ -177,6 +177,6 @@ class ContainsViewHelper extends AbstractConditionViewHelper
      */
     protected static function assertHaystackIsStringAndHasNeedle($haystack, $needle)
     {
-        return strpos($haystack, $needle);
+        return \strpos($haystack, $needle);
     }
 }

--- a/Classes/ViewHelpers/Condition/Page/HasSubpagesViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/HasSubpagesViewHelper.php
@@ -77,6 +77,6 @@ class HasSubpagesViewHelper extends AbstractConditionViewHelper
 
         $menu = self::$pageService->getMenu($pageUid, [], $includeHiddenInMenu, false, $includeAccessProtected);
 
-        return (0 < count($menu));
+        return (0 < \count($menu));
     }
 }

--- a/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
@@ -40,7 +40,7 @@ class IsChildPageViewHelper extends AbstractConditionViewHelper
         $pageUid = $arguments['pageUid'];
         $respectSiteRoot = $arguments['respectSiteRoot'];
 
-        if (null === $pageUid || true === empty($pageUid) || 0 === intval($pageUid)) {
+        if (null === $pageUid || true === empty($pageUid) || 0 === \intval($pageUid)) {
             $pageUid = $GLOBALS['TSFE']->id;
         }
         $pageSelect = new PageRepository();

--- a/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsLanguageViewHelper.php
@@ -44,8 +44,8 @@ class IsLanguageViewHelper extends AbstractConditionViewHelper
         $defaultTitle = $arguments['defaultTitle'];
 
         $currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
-        if (true === is_numeric($language)) {
-            $languageUid = intval($language);
+        if (true === \is_numeric($language)) {
+            $languageUid = \intval($language);
         } else {
             /** @var QueryBuilder $queryBuilder */
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
@@ -62,7 +62,7 @@ class IsLanguageViewHelper extends AbstractConditionViewHelper
                 ->fetch();
 
             if (false !== $row) {
-                $languageUid = intval($row['uid']);
+                $languageUid = \intval($row['uid']);
             } else {
                 if ((string) $language === $defaultTitle) {
                     $languageUid = $currentLanguageUid;

--- a/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/ContainsViewHelper.php
@@ -34,6 +34,6 @@ class ContainsViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return false !== strpos($arguments['haystack'], $arguments['needle']);
+        return false !== \strpos($arguments['haystack'], $arguments['needle']);
     }
 }

--- a/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsLowercaseViewHelper.php
@@ -36,9 +36,9 @@ class IsLowercaseViewHelper extends AbstractConditionViewHelper
     protected static function evaluateCondition($arguments = null)
     {
         if (true === $arguments['fullString']) {
-            $result = ctype_lower($arguments['string']);
+            $result = \ctype_lower($arguments['string']);
         } else {
-            $result = ctype_lower(substr($arguments['string'], 0, 1));
+            $result = \ctype_lower(\substr($arguments['string'], 0, 1));
         }
         return true === $result;
     }

--- a/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsNumericViewHelper.php
@@ -33,6 +33,6 @@ class IsNumericViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_numeric($arguments['value']);
+        return true === \is_numeric($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
+++ b/Classes/ViewHelpers/Condition/String/IsUppercaseViewHelper.php
@@ -36,9 +36,9 @@ class IsUppercaseViewHelper extends AbstractConditionViewHelper
     protected static function evaluateCondition($arguments = null)
     {
         if (true === $arguments['fullString']) {
-            $result = ctype_upper($arguments['string']);
+            $result = \ctype_upper($arguments['string']);
         } else {
-            $result = ctype_upper(substr($arguments['string'], 0, 1));
+            $result = \ctype_upper(\substr($arguments['string'], 0, 1));
         }
         return true === $result;
     }

--- a/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsArrayViewHelper.php
@@ -33,6 +33,6 @@ class IsArrayViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return (isset($arguments['value']) && (true === is_array($arguments['value'])));
+        return (isset($arguments['value']) && (true === \is_array($arguments['value'])));
     }
 }

--- a/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsBooleanViewHelper.php
@@ -36,6 +36,6 @@ class IsBooleanViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_bool($arguments['value']);
+        return true === \is_bool($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsFloatViewHelper.php
@@ -33,6 +33,6 @@ class IsFloatViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_float($arguments['value']);
+        return true === \is_float($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsIntegerViewHelper.php
@@ -33,6 +33,6 @@ class IsIntegerViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_integer($arguments['value']);
+        return true === \is_integer($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsObjectViewHelper.php
@@ -33,6 +33,6 @@ class IsObjectViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_object($arguments['value']);
+        return true === \is_object($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Type/IsStringViewHelper.php
@@ -33,6 +33,6 @@ class IsStringViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return true === is_string($arguments['value']);
+        return true === \is_string($arguments['value']);
     }
 }

--- a/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
@@ -73,7 +73,7 @@ class IssetViewHelper extends AbstractConditionViewHelper
     protected static function evaluateCondition($arguments = null)
     {
         $renderingContext = static::$staticRenderingContext;
-        $variableProvider = method_exists($renderingContext, 'getVariableProvider') ? $renderingContext->getVariableProvider() : $renderingContext->getTemplateVariableContainer();
+        $variableProvider = \method_exists($renderingContext, 'getVariableProvider') ? $renderingContext->getVariableProvider() : $renderingContext->getTemplateVariableContainer();
         return $variableProvider->exists($arguments['name']);
     }
 

--- a/Classes/ViewHelpers/ConstViewHelper.php
+++ b/Classes/ViewHelpers/ConstViewHelper.php
@@ -51,6 +51,6 @@ class ConstViewHelper extends AbstractViewHelper implements CompilableInterface
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return constant($renderChildrenClosure());
+        return \constant($renderChildrenClosure());
     }
 }

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -122,7 +122,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
     {
         $order = $this->arguments['order'];
         if (false === empty($order)) {
-            $sortDirection = strtoupper(trim($this->arguments['sortDirection']));
+            $sortDirection = \strtoupper(\trim($this->arguments['sortDirection']));
             if ('ASC' !== $sortDirection && 'DESC' !== $sortDirection) {
                 $sortDirection = 'ASC';
             }
@@ -130,11 +130,11 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         }
 
         $contentUids = $this->arguments['contentUids'];
-        if (true === is_array($contentUids) && !empty($contentUids)) {
+        if (true === \is_array($contentUids) && !empty($contentUids)) {
             return $GLOBALS['TSFE']->cObj->getRecords(
                 'tt_content',
                 [
-                    'uidInList' => implode(',', $contentUids),
+                    'uidInList' => \implode(',', $contentUids),
                     'orderBy' => $order,
                     'max' => $limit,
                     // Note: pidInList must not use $pageUid which defaults to current PID. Use argument-passed pageUid!
@@ -146,8 +146,8 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         }
 
         $conditions = '1=1';
-        if (is_numeric($this->arguments['column'])) {
-            $conditions = sprintf('colPos = %d', (integer) $this->arguments['column']);
+        if (\is_numeric($this->arguments['column'])) {
+            $conditions = \sprintf('colPos = %d', (integer) $this->arguments['column']);
         }
         if (true === (boolean) $this->arguments['sectionIndexOnly']) {
             $conditions .= ' AND sectionIndex = 1';
@@ -200,7 +200,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         }
         $elements = [];
         foreach ($rows as $row) {
-            array_push($elements, static::renderRecord($row));
+            \array_push($elements, static::renderRecord($row));
         }
         if (false === empty($this->arguments['loadRegister'])) {
             $this->contentObject->cObjGetSingle('RESTORE_REGISTER', '');
@@ -254,7 +254,7 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         $queryBuilder = (new ConnectionPool())->getConnectionForTable('tt_content')->createQueryBuilder();
         $queryBuilder->select($fields)->from('tt_content')->where($condition);
         if ($order) {
-            $orderings = explode(' ', $order);
+            $orderings = \explode(' ', $order);
             $queryBuilder->orderBy($orderings[0], $orderings[1]);
         }
         if ($limit) {

--- a/Classes/ViewHelpers/Content/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Content/InfoViewHelper.php
@@ -111,7 +111,7 @@ class InfoViewHelper extends AbstractViewHelper
 
         if (false === $record && false === isset($record)) {
             throw new \Exception(
-                sprintf('Either record with uid %d or field %s do not exist.', $contentUid, $selectFields),
+                \sprintf('Either record with uid %d or field %s do not exist.', $contentUid, $selectFields),
                 1358679983
             );
         }

--- a/Classes/ViewHelpers/Content/Random/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Content/Random/RenderViewHelper.php
@@ -44,10 +44,10 @@ class RenderViewHelper extends AbstractContentViewHelper
         // so all the content records that end up unused do not get rendered.
         $contentRecords = $this->getContentRecords();
         if (false === empty($contentRecords)) {
-            shuffle($contentRecords);
-            $contentRecords = array_slice($contentRecords, 0, $limit);
+            \shuffle($contentRecords);
+            $contentRecords = \array_slice($contentRecords, 0, $limit);
             if (true === (boolean) $this->arguments['render']) {
-                $contentRecords = implode(LF, $contentRecords);
+                $contentRecords = \implode(LF, $contentRecords);
             }
         }
         return $contentRecords;

--- a/Classes/ViewHelpers/Content/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Content/RenderViewHelper.php
@@ -48,7 +48,7 @@ class RenderViewHelper extends AbstractContentViewHelper
 
         $content = $this->getContentRecords();
         if (false === $this->hasArgument('as')) {
-            return implode(LF, $content);
+            return \implode(LF, $content);
         }
 
         return $this->renderChildrenWithVariableOrReturnInput($content);

--- a/Classes/ViewHelpers/Count/BytesViewHelper.php
+++ b/Classes/ViewHelpers/Count/BytesViewHelper.php
@@ -60,6 +60,6 @@ class BytesViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return mb_strlen($renderChildrenClosure(), $arguments['encoding']);
+        return \mb_strlen($renderChildrenClosure(), $arguments['encoding']);
     }
 }

--- a/Classes/ViewHelpers/Count/LinesViewHelper.php
+++ b/Classes/ViewHelpers/Count/LinesViewHelper.php
@@ -63,6 +63,6 @@ class LinesViewHelper extends AbstractViewHelper
         if ((string) $value === '') {
             return 0;
         }
-        return mb_substr_count($value, PHP_EOL) + 1;
+        return \mb_substr_count($value, PHP_EOL) + 1;
     }
 }

--- a/Classes/ViewHelpers/Count/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Count/SubstringViewHelper.php
@@ -60,7 +60,7 @@ class SubstringViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return mb_substr_count(
+        return \mb_substr_count(
             $renderChildrenClosure(), $arguments['string']
         );
     }

--- a/Classes/ViewHelpers/Count/WordsViewHelper.php
+++ b/Classes/ViewHelpers/Count/WordsViewHelper.php
@@ -59,11 +59,11 @@ class WordsViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return count(
-            preg_split(
+        return \count(
+            \preg_split(
                 '~[^\p{L}\p{N}\']+~u',
-                strip_tags(
-                    str_replace(
+                \strip_tags(
+                    \str_replace(
                         '><',
                         '> <',
                         $renderChildrenClosure()

--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -101,11 +101,11 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
             $givenArguments = $viewHelperNode->getArguments();
             $viewHelperReflection = new \ReflectionClass($viewHelper);
             $viewHelperDescription = $viewHelperReflection->getDocComment();
-            $viewHelperDescription = htmlentities($viewHelperDescription);
+            $viewHelperDescription = \htmlentities($viewHelperDescription);
             $viewHelperDescription = '[CLASS DOC]' . LF . $viewHelperDescription . LF;
             $renderMethodDescription = $viewHelperReflection->getMethod('render')->getDocComment();
-            $renderMethodDescription = htmlentities($renderMethodDescription);
-            $renderMethodDescription = implode(LF, array_map('trim', explode(LF, $renderMethodDescription)));
+            $renderMethodDescription = \htmlentities($renderMethodDescription);
+            $renderMethodDescription = \implode(LF, \array_map('trim', \explode(LF, $renderMethodDescription)));
             $renderMethodDescription = '[RENDER METHOD DOC]' . LF . $renderMethodDescription . LF;
             $argumentDefinitions = [];
             foreach ($arguments as $argument) {
@@ -118,20 +118,20 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
                 DebuggerUtility::var_dump($givenArguments, '[CURRENT ARGUMENTS]', 4, true, false, true),
                 $renderMethodDescription
             ];
-            array_push($nodes, implode(LF, $sections));
+            \array_push($nodes, \implode(LF, $sections));
         }
-        if (0 < count($this->childObjectAccessorNodes)) {
-            array_push($nodes, '[VARIABLE ACCESSORS]');
+        if (0 < \count($this->childObjectAccessorNodes)) {
+            \array_push($nodes, '[VARIABLE ACCESSORS]');
             $templateVariables = $this->templateVariableContainer->getAll();
             foreach ($this->childObjectAccessorNodes as $objectAccessorNode) {
                 $path = $objectAccessorNode->getObjectPath();
-                $segments = explode('.', $path);
+                $segments = \explode('.', $path);
                 try {
-                    $value = ObjectAccess::getProperty($templateVariables, array_shift($segments));
+                    $value = ObjectAccess::getProperty($templateVariables, \array_shift($segments));
                     foreach ($segments as $segment) {
                         $value = ObjectAccess::getProperty($value, $segment);
                     }
-                    $type = gettype($value);
+                    $type = \gettype($value);
                 } catch (PropertyNotAccessibleException $error) {
                     $value = null;
                     $type = 'UNDEFINED/INACCESSIBLE';
@@ -140,13 +140,13 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
                     'Path: {' . $path . '}',
                     'Value type: ' . $type,
                 ];
-                if (true === is_object($value)) {
+                if (true === \is_object($value)) {
                     $sections[] = 'Accessible properties on {' . $path . '}:';
                     $gettable = ObjectAccess::getGettablePropertyNames($value);
                     unset($gettable[0]);
                     foreach ($gettable as $gettableProperty) {
                         $sections[] = '   {' . $path . '.' . $gettableProperty . '} (' .
-                            gettype(ObjectAccess::getProperty($value, $gettableProperty)) . ')';
+                            \gettype(ObjectAccess::getProperty($value, $gettableProperty)) . ')';
                     }
                 } elseif (null !== $value) {
                     $sections[] = DebuggerUtility::var_dump(
@@ -158,10 +158,10 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
                         true
                     );
                 }
-                array_push($nodes, implode(LF, $sections));
+                \array_push($nodes, \implode(LF, $sections));
             }
         }
-        return '<pre>' . implode(LF . LF, $nodes) . '</pre>';
+        return '<pre>' . \implode(LF . LF, $nodes) . '</pre>';
     }
 
     /**
@@ -174,10 +174,10 @@ class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInter
     {
         foreach ($childNodes as $childNode) {
             if (true === $childNode instanceof LegacyFluidViewHelperNode || $childNode instanceof StandaloneFluidViewHelperNode) {
-                array_push($this->childViewHelperNodes, $childNode);
+                \array_push($this->childViewHelperNodes, $childNode);
             }
             if (true === $childNode instanceof LegacyFluidObjectAccessorNode || $childNode instanceof StandaloneFluidObjectAccessorNode) {
-                array_push($this->childObjectAccessorNodes, $childNode);
+                \array_push($this->childObjectAccessorNodes, $childNode);
             }
         }
     }

--- a/Classes/ViewHelpers/Form/FieldNameViewHelper.php
+++ b/Classes/ViewHelpers/Form/FieldNameViewHelper.php
@@ -63,7 +63,7 @@ class FieldNameViewHelper extends AbstractViewHelper
         if ($this->isObjectAccessorMode()) {
             $formObjectName = $this->viewHelperVariableContainer->get(FormViewHelper::class, 'formObjectName');
             if (!empty($formObjectName)) {
-                $propertySegments = explode('.', $this->arguments['property']);
+                $propertySegments = \explode('.', $this->arguments['property']);
                 $propertyPath = '';
                 foreach ($propertySegments as $segment) {
                     $propertyPath .= '[' . $segment . ']';
@@ -85,9 +85,9 @@ class FieldNameViewHelper extends AbstractViewHelper
         if ('' === $fieldNamePrefix) {
             return $name;
         }
-        $fieldNameSegments = explode('[', $name, 2);
+        $fieldNameSegments = \explode('[', $name, 2);
         $name = $fieldNamePrefix . '[' . $fieldNameSegments[0] . ']';
-        if (1 < count($fieldNameSegments)) {
+        if (1 < \count($fieldNameSegments)) {
             $name .= '[' . $fieldNameSegments[1];
         }
         if ($this->viewHelperVariableContainer->exists(FormViewHelper::class, 'formFieldNames')) {

--- a/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/Select/OptionViewHelper.php
@@ -55,10 +55,10 @@ class OptionViewHelper extends AbstractFormFieldViewHelper
             $selected = 'selected';
         } elseif (true === $this->viewHelperVariableContainer->exists(SelectViewHelper::class, 'value')) {
             $value = $this->viewHelperVariableContainer->get(SelectViewHelper::class, 'value');
-            if (false === is_object($this->arguments['value']) && false === is_array($this->arguments['value'])) {
-                if (true === is_array($value)) {
-                    $selected = true === in_array($this->arguments['value'], $value) ? 'selected' : '';
-                } else if (true === ($value instanceof ObjectStorage) && true === is_numeric($this->arguments['value'])) {
+            if (false === \is_object($this->arguments['value']) && false === \is_array($this->arguments['value'])) {
+                if (true === \is_array($value)) {
+                    $selected = true === \in_array($this->arguments['value'], $value) ? 'selected' : '';
+                } else if (true === ($value instanceof ObjectStorage) && true === \is_numeric($this->arguments['value'])) {
                     // Requires that the option values are UIDs of objects in ObjectStorage
                     foreach ($value as $object) {
                         if($object->getUid() === (integer) $this->arguments['value']) {

--- a/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -126,7 +126,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
         // as often as there are elements in the box
         if (true === (boolean) $this->arguments['multiple']) {
             $content .= $this->renderHiddenFieldForEmptyValue();
-            $length = count($options);
+            $length = \count($options);
             for ($i = 0; $i < $length; $i++) {
                 $this->registerFieldNameForFormTokenGeneration($name);
             }
@@ -180,7 +180,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
 
         foreach ($options as $value => $label) {
             $isSelected = $this->isSelected($value);
-            $output .= $this->renderOptionTag($value, $label, $isSelected) . chr(10);
+            $output .= $this->renderOptionTag($value, $label, $isSelected) . \chr(10);
         }
         return $output;
     }
@@ -193,50 +193,50 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
      */
     protected function getOptions()
     {
-        if (!is_array($this->arguments['options']) && !$this->arguments['options'] instanceof \Traversable) {
+        if (!\is_array($this->arguments['options']) && !$this->arguments['options'] instanceof \Traversable) {
             return [];
         }
         $options = [];
         $optionsArgument = $this->arguments['options'];
         foreach ($optionsArgument as $key => $value) {
-            if (is_object($value)) {
+            if (\is_object($value)) {
                 if (isset($this->arguments['optionValueField']) && !empty($this->arguments['optionValueField'])) {
                     $key = ObjectAccess::getProperty($value, $this->arguments['optionValueField']);
-                    if (true === is_object($key)) {
-                        if (true === method_exists($key, '__toString')) {
+                    if (true === \is_object($key)) {
+                        if (true === \method_exists($key, '__toString')) {
                             $key = (string) $key;
                         } else {
                             ErrorUtility::throwViewHelperException(
-                                'Identifying value for object of class "' . get_class($value) . '" was an object.',
+                                'Identifying value for object of class "' . \get_class($value) . '" was an object.',
                                 1247827428
                             );
                         }
                     }
                 } elseif (null !== $this->persistenceManager->getBackend()->getIdentifierByObject($value)) {
                     $key = $this->persistenceManager->getBackend()->getIdentifierByObject($value);
-                } elseif (true === method_exists($value, '__toString')) {
+                } elseif (true === \method_exists($value, '__toString')) {
                     $key = (string) $value;
                 } else {
                     ErrorUtility::throwViewHelperException(
-                        'No identifying value for object of class "' . get_class($value) . '" found.',
+                        'No identifying value for object of class "' . \get_class($value) . '" found.',
                         1247826696
                     );
                 }
 
                 if (isset($this->arguments['optionLabelField']) && !empty($this->arguments['optionLabelField'])) {
                     $value = ObjectAccess::getProperty($value, $this->arguments['optionLabelField']);
-                    if (true === is_object($value)) {
-                        if (true === method_exists($value, '__toString')) {
+                    if (true === \is_object($value)) {
+                        if (true === \method_exists($value, '__toString')) {
                             $value = (string) $value;
                         } else {
                             ErrorUtility::throwViewHelperException(
-                                'Label value for object of class "' . get_class($value) . '" was an object without ' .
+                                'Label value for object of class "' . \get_class($value) . '" was an object without ' .
                                 'a __toString() method.',
                                 1247827553
                             );
                         }
                     }
-                } elseif (true === method_exists($value, '__toString')) {
+                } elseif (true === \method_exists($value, '__toString')) {
                     $value = (string) $value;
                 } elseif (null !== $this->persistenceManager->getBackend()->getIdentifierByObject($value)) {
                     $value = $this->persistenceManager->getBackend()->getIdentifierByObject($value);
@@ -245,7 +245,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
             $options[$key] = $value;
         }
         if (isset($this->arguments['sortByOptionLabel']) && !empty($this->arguments['sortByOptionLabel'])) {
-            asort($options);
+            \asort($options);
         }
         return $options;
     }
@@ -265,7 +265,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
         if (true === isset($this->arguments['multiple']) && false === empty($this->arguments['multiple'])) {
             if (null === $selectedValue && true === (boolean) $this->arguments['selectAllByDefault']) {
                 return true;
-            } elseif (true === is_array($selectedValue) && true === in_array($value, $selectedValue)) {
+            } elseif (true === \is_array($selectedValue) && true === \in_array($value, $selectedValue)) {
                 return true;
             }
         }
@@ -283,8 +283,8 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
         if (!isset($this->arguments['optionValueField']) || empty($this->arguments['optionValueField'])) {
             return $value;
         }
-        if (!is_array($value) && !$value instanceof \Iterator) {
-            if (is_object($value)) {
+        if (!\is_array($value) && !$value instanceof \Iterator) {
+            if (\is_object($value)) {
                 return ObjectAccess::getProperty($value, $this->arguments['optionValueField']);
             } else {
                 return $value;
@@ -292,7 +292,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
         }
         $selectedValues = [];
         foreach ($value as $selectedValueElement) {
-            if (is_object($selectedValueElement)) {
+            if (\is_object($selectedValueElement)) {
                 $selectedValues[] = ObjectAccess::getProperty(
                     $selectedValueElement,
                     $this->arguments['optionValueField']
@@ -314,11 +314,11 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
      */
     protected function renderOptionTag($value, $label, $isSelected)
     {
-        $output = '<option value="' . htmlspecialchars($value) . '"';
+        $output = '<option value="' . \htmlspecialchars($value) . '"';
         if (true === (boolean) $isSelected) {
             $output .= ' selected="selected"';
         }
-        $output .= '>' . htmlspecialchars($label) . '</option>';
+        $output .= '>' . \htmlspecialchars($label) . '</option>';
 
         return $output;
     }

--- a/Classes/ViewHelpers/Format/CaseViewHelper.php
+++ b/Classes/ViewHelpers/Format/CaseViewHelper.php
@@ -65,7 +65,7 @@ class CaseViewHelper extends AbstractViewHelper
                 $string = $GLOBALS['TSFE']->csConvObj->conv_case($charset, $string, 'toUpper');
                 break;
             case self::CASE_UCWORDS:
-                $string = ucwords($string);
+                $string = \ucwords($string);
                 break;
             case self::CASE_UCFIRST:
                 $string = $GLOBALS['TSFE']->csConvObj->convCaseFirst($charset, $string, 'toUpper');

--- a/Classes/ViewHelpers/Format/DateRangeViewHelper.php
+++ b/Classes/ViewHelpers/Format/DateRangeViewHelper.php
@@ -170,7 +170,7 @@ class DateRangeViewHelper extends AbstractViewHelper
         $return = $arguments['return'];
         if (null === $return) {
             $spaceGlue = (boolean) $arguments['spaceGlue'];
-            $glue = strval($arguments['glue']);
+            $glue = \strval($arguments['glue']);
             $startFormat = $arguments['format'];
             $endFormat = $arguments['format'];
             if (null !== $arguments['startFormat'] && false === empty($arguments['startFormat'])) {
@@ -186,18 +186,18 @@ class DateRangeViewHelper extends AbstractViewHelper
             $output .= static::formatDate($endDateTime, $endFormat);
         } elseif ('DateTime' === $return) {
             $output = $endDateTime;
-        } elseif (true === is_string($return)) {
-            if (false === strpos($return, '%')) {
+        } elseif (true === \is_string($return)) {
+            if (false === \strpos($return, '%')) {
                 $return = '%' . $return;
             }
             $output = $interval->format($return);
-        } elseif (true === is_array($return)) {
+        } elseif (true === \is_array($return)) {
             $output = [];
             foreach ($return as $format) {
-                if (false === strpos($format, '%')) {
+                if (false === \strpos($format, '%')) {
                     $format = '%' . $format;
                 }
-                array_push($output, $interval->format($format));
+                \array_push($output, $interval->format($format));
             }
         }
         return $output;
@@ -211,12 +211,12 @@ class DateRangeViewHelper extends AbstractViewHelper
     {
         if (false === $date instanceof \DateTime) {
             try {
-                if (true === is_integer($date)) {
+                if (true === \is_integer($date)) {
                     $date = new \DateTime('@' . $date);
                 } else {
                     $date = new \DateTime($date);
                 }
-                $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+                $date->setTimezone(new \DateTimeZone(\date_default_timezone_get()));
             } catch (\Exception $exception) {
                 ErrorUtility::throwViewHelperException('"' . $date . '" could not be parsed by \DateTime constructor.', 1369573112);
             }
@@ -231,8 +231,8 @@ class DateRangeViewHelper extends AbstractViewHelper
      */
     protected static function formatDate($date, $format = 'Y-m-d')
     {
-        if (false !== strpos($format, '%')) {
-            return strftime($format, $date->format('U'));
+        if (false !== \strpos($format, '%')) {
+            return \strftime($format, $date->format('U'));
         } else {
             return $date->format($format);
         }

--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -127,16 +127,16 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateCharacters($content, $characters, $caseSensitive)
     {
-        if (true === is_array($characters)) {
+        if (true === \is_array($characters)) {
             $subjects = $characters;
         } else {
-            $subjects = preg_split('//u', $characters, null, PREG_SPLIT_NO_EMPTY);
+            $subjects = \preg_split('//u', $characters, null, PREG_SPLIT_NO_EMPTY);
         }
         foreach ($subjects as $subject) {
             if (true === $caseSensitive) {
-                $content = str_replace($subject, '', $content);
+                $content = \str_replace($subject, '', $content);
             } else {
-                $content = str_ireplace($subject, '', $content);
+                $content = \str_ireplace($subject, '', $content);
             }
         }
         return $content;
@@ -150,16 +150,16 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateStrings($content, $strings, $caseSensitive)
     {
-        if (true === is_array($strings)) {
+        if (true === \is_array($strings)) {
             $subjects = $strings;
         } else {
-            $subjects = explode(',', $strings);
+            $subjects = \explode(',', $strings);
         }
         foreach ($subjects as $subject) {
             if (true === $caseSensitive) {
-                $content = str_replace($subject, '', $content);
+                $content = \str_replace($subject, '', $content);
             } else {
-                $content = str_ireplace($subject, '', $content);
+                $content = \str_ireplace($subject, '', $content);
             }
         }
         return $content;
@@ -171,7 +171,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateWhitespace($content)
     {
-        $content = preg_replace('/\s+/', '', $content);
+        $content = \preg_replace('/\s+/', '', $content);
         return $content;
     }
 
@@ -181,7 +181,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateWhitespaceBetweenHtmlTags($content)
     {
-        $content = trim(preg_replace('/>\s+</', '><', $content));
+        $content = \trim(\preg_replace('/>\s+</', '><', $content));
         return $content;
     }
 
@@ -191,7 +191,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateTabs($content)
     {
-        $content = str_replace("\t", '', $content);
+        $content = \str_replace("\t", '', $content);
         return $content;
     }
 
@@ -201,7 +201,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateUnixBreaks($content)
     {
-        $content = str_replace("\n", '', $content);
+        $content = \str_replace("\n", '', $content);
         return $content;
     }
 
@@ -211,7 +211,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateWindowsCarriageReturns($content)
     {
-        $content = str_replace("\r", '', $content);
+        $content = \str_replace("\r", '', $content);
         return $content;
     }
 
@@ -221,7 +221,7 @@ class EliminateViewHelper extends AbstractViewHelper
      */
     protected static function eliminateDigits($content)
     {
-        $content = preg_replace('#[0-9]#', '', $content);
+        $content = \preg_replace('#[0-9]#', '', $content);
         return $content;
     }
 
@@ -233,9 +233,9 @@ class EliminateViewHelper extends AbstractViewHelper
     protected static function eliminateLetters($content, $caseSensitive)
     {
         if (true === $caseSensitive) {
-            $content = preg_replace('#[a-z]#', '', $content);
+            $content = \preg_replace('#[a-z]#', '', $content);
         } else {
-            $content = preg_replace('/[a-z]/i', '', $content);
+            $content = \preg_replace('/[a-z]/i', '', $content);
         }
         return $content;
     }
@@ -248,7 +248,7 @@ class EliminateViewHelper extends AbstractViewHelper
     protected static function eliminateNonAscii($content, $caseSensitive)
     {
         $caseSensitiveIndicator = true === $caseSensitive ? 'i' : '';
-        $content = preg_replace('/[^(\x20-\x7F)]*/' . $caseSensitiveIndicator, '', $content);
+        $content = \preg_replace('/[^(\x20-\x7F)]*/' . $caseSensitiveIndicator, '', $content);
         return $content;
     }
 }

--- a/Classes/ViewHelpers/Format/HashViewHelper.php
+++ b/Classes/ViewHelpers/Format/HashViewHelper.php
@@ -48,7 +48,7 @@ class HashViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ) {
         $content = $renderChildrenClosure();
-        $content = hash($arguments['algorithm'], $content, false);
+        $content = \hash($arguments['algorithm'], $content, false);
         return $content;
     }
 }

--- a/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
@@ -42,9 +42,9 @@ class DecodeViewHelper extends AbstractViewHelper
         if (true === empty($json)) {
             return null;
         }
-        $value = json_decode($json, true);
+        $value = \json_decode($json, true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (JSON_ERROR_NONE !== \json_last_error()) {
             ErrorUtility::throwViewHelperException('The provided argument is invalid JSON.', 1358440054);
         }
 

--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -115,7 +115,7 @@ class EncodeViewHelper extends AbstractViewHelper
     {
         if (true === $value instanceof \Traversable) {
             // Note: also converts ObjectStorage to \Vendor\Extname\Domain\Model\ObjectType[] which are each converted
-            $value = iterator_to_array($value, $useTraversableKeys);
+            $value = \iterator_to_array($value, $useTraversableKeys);
         } elseif (true === $value instanceof DomainObjectInterface) {
             // Convert to associative array,
             $value = static::recursiveDomainObjectToArray($value, $preventRecursion, $recursionMarker);
@@ -124,12 +124,12 @@ class EncodeViewHelper extends AbstractViewHelper
         }
 
         // process output of conversion, catching specially supported object types such as DomainObject and DateTime
-        if (true === is_array($value)) {
+        if (true === \is_array($value)) {
             $value = static::recursiveArrayOfDomainObjectsToArray($value, $preventRecursion, $recursionMarker);
             $value = static::recursiveDateTimeToUnixtimeMiliseconds($value, $dateTimeFormat);
         }
-        $json = json_encode($value, JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS | JSON_HEX_TAG);
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        $json = \json_encode($value, JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS | JSON_HEX_TAG);
+        if (JSON_ERROR_NONE !== \json_last_error()) {
             ErrorUtility::throwViewHelperException('The provided argument cannot be converted into JSON.', 1358440181);
         }
         return $json;
@@ -152,7 +152,7 @@ class EncodeViewHelper extends AbstractViewHelper
         foreach ($array as $key => $possibleDateTime) {
             if (true === $possibleDateTime instanceof \DateTime) {
                 $array[$key] = static::dateTimeToUnixtimeMiliseconds($possibleDateTime, $dateTimeFormat);
-            } elseif (true === is_array($possibleDateTime)) {
+            } elseif (true === \is_array($possibleDateTime)) {
                 $array[$key] = static::recursiveDateTimeToUnixtimeMiliseconds($array[$key], $dateTimeFormat);
             }
         }
@@ -171,7 +171,7 @@ class EncodeViewHelper extends AbstractViewHelper
     protected static function dateTimeToUnixtimeMiliseconds(\DateTime $dateTime, $dateTimeFormat)
     {
         if (null === $dateTimeFormat) {
-            return intval($dateTime->format('U')) * 1000;
+            return \intval($dateTime->format('U')) * 1000;
         }
         return $dateTime->format($dateTimeFormat);
     }
@@ -199,7 +199,7 @@ class EncodeViewHelper extends AbstractViewHelper
                     $recursionMarker
                 );
             } elseif (true === $possibleDomainObject instanceof \Traversable) {
-                $traversableAsArray = iterator_to_array($possibleDomainObject);
+                $traversableAsArray = \iterator_to_array($possibleDomainObject);
                 $domainObjects[$key] = static::recursiveArrayOfDomainObjectsToArray(
                     $traversableAsArray,
                     $preventRecursion,
@@ -225,8 +225,8 @@ class EncodeViewHelper extends AbstractViewHelper
         $preventRecursion,
         $recursionMarker
     ) {
-        $hash = spl_object_hash($domainObject);
-        if (true === $preventRecursion && true === in_array($hash, static::$encounteredClasses)) {
+        $hash = \spl_object_hash($domainObject);
+        if (true === $preventRecursion && true === \in_array($hash, static::$encounteredClasses)) {
             return $recursionMarker;
         }
         $converted = ObjectAccess::getGettableProperties($domainObject);

--- a/Classes/ViewHelpers/Format/MarkdownViewHelper.php
+++ b/Classes/ViewHelpers/Format/MarkdownViewHelper.php
@@ -71,14 +71,14 @@ class MarkdownViewHelper extends AbstractViewHelper
             return null;
         }
 
-        $cacheIdentifier = sha1($text);
+        $cacheIdentifier = \sha1($text);
         $fromCache = static::getCache()->get($cacheIdentifier);
         if (!empty($fromCache)) {
             return $fromCache;
         }
 
         $markdownExecutablePath = CommandUtility::getCommand('markdown');
-        if (false === is_executable($markdownExecutablePath)) {
+        if (false === \is_executable($markdownExecutablePath)) {
             ErrorUtility::throwViewHelperException(
                 'Use of Markdown requires the "markdown" shell utility to be installed and accessible; this binary ' .
                 'could not be found in any of your configured paths available to this script',
@@ -86,10 +86,10 @@ class MarkdownViewHelper extends AbstractViewHelper
             );
         }
         if (true === (boolean) $trim) {
-            $text = trim($text);
+            $text = \trim($text);
         }
         if (true === (boolean) $htmlentities) {
-            $text = htmlentities($text);
+            $text = \htmlentities($text);
         }
         $transformed = static::transform($text, $markdownExecutablePath);
         static::getCache()->set($cacheIdentifier, $transformed);
@@ -109,24 +109,24 @@ class MarkdownViewHelper extends AbstractViewHelper
             2 => ['pipe', 'a']
         ];
 
-        $process = proc_open($markdownExecutablePath, $descriptorspec, $pipes, null, $GLOBALS['_ENV']);
+        $process = \proc_open($markdownExecutablePath, $descriptorspec, $pipes, null, $GLOBALS['_ENV']);
 
-        stream_set_blocking($pipes[0], 1);
-        stream_set_blocking($pipes[1], 1);
-        stream_set_blocking($pipes[2], 1);
+        \stream_set_blocking($pipes[0], 1);
+        \stream_set_blocking($pipes[1], 1);
+        \stream_set_blocking($pipes[2], 1);
 
-        fwrite($pipes[0], $text);
-        fclose($pipes[0]);
+        \fwrite($pipes[0], $text);
+        \fclose($pipes[0]);
 
-        $transformed = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
+        $transformed = \stream_get_contents($pipes[1]);
+        \fclose($pipes[1]);
 
-        $errors = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
+        $errors = \stream_get_contents($pipes[2]);
+        \fclose($pipes[2]);
 
-        $exitCode = proc_close($process);
+        $exitCode = \proc_close($process);
 
-        if ('' !== trim($errors)) {
+        if ('' !== \trim($errors)) {
             ErrorUtility::throwViewHelperException(
                 'There was an error while executing ' . $markdownExecutablePath . '. The return code was ' .
                 $exitCode . ' and the message reads: ' . $errors,

--- a/Classes/ViewHelpers/Format/Placeholder/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Format/Placeholder/ImageViewHelper.php
@@ -56,9 +56,9 @@ class ImageViewHelper extends AbstractTagBasedViewHelper
             $this->arguments['textColor'],
         ];
         if (false === empty($text)) {
-            array_push($url, '&text=' . urlencode($text));
+            \array_push($url, '&text=' . \urlencode($text));
         }
-        $imageUrl = implode('/', $url);
+        $imageUrl = \implode('/', $url);
         $this->tag->forceClosingTag(false);
         $this->tag->addAttribute('src', $imageUrl);
         $this->tag->addAttribute('alt', $imageUrl);

--- a/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
+++ b/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
@@ -59,30 +59,30 @@ class LipsumViewHelper extends AbstractViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $lipsum = $arguments['lipsum'];
-        if (mb_strlen($lipsum) === 0) {
+        if (\mb_strlen($lipsum) === 0) {
             $lipsum = static::getDefaultLoremIpsum();
         }
-        if ((mb_strlen($lipsum) < 255 && !preg_match('/[^a-z0-9_\.\:\/]/i', $lipsum)) || 0 === mb_strpos($lipsum, 'EXT:')) {
+        if ((\mb_strlen($lipsum) < 255 && !\preg_match('/[^a-z0-9_\.\:\/]/i', $lipsum)) || 0 === \mb_strpos($lipsum, 'EXT:')) {
             // argument is most likely a file reference.
             $sourceFile = GeneralUtility::getFileAbsFileName($lipsum);
-            if (file_exists($sourceFile)) {
-                $lipsum = file_get_contents($sourceFile);
+            if (\file_exists($sourceFile)) {
+                $lipsum = \file_get_contents($sourceFile);
             } else {
                 return 'Vhs LipsumViewHelper was asked to load Lorem Ipsum from a file which does not exist. ' .
                     'The file was: ' . $sourceFile;
             }
         }
-        $lipsum = preg_replace('/[\\r\\n]{1,}/i', "\n", $lipsum);
-        $paragraphs = explode("\n", $lipsum);
-        $paragraphs = array_slice($paragraphs, 0, intval($arguments['paragraphs']));
+        $lipsum = \preg_replace('/[\\r\\n]{1,}/i', "\n", $lipsum);
+        $paragraphs = \explode("\n", $lipsum);
+        $paragraphs = \array_slice($paragraphs, 0, \intval($arguments['paragraphs']));
         foreach ($paragraphs as $index => $paragraph) {
             $length = $arguments['wordsPerParagraph']
-                + rand(0 - intval($arguments['skew']), intval($arguments['skew']));
-            $words = explode(' ', $paragraph);
-            $paragraphs[$index] = implode(' ', array_slice($words, 0, $length));
+                + \rand(0 - \intval($arguments['skew']), \intval($arguments['skew']));
+            $words = \explode(' ', $paragraph);
+            $paragraphs[$index] = \implode(' ', \array_slice($words, 0, $length));
         }
 
-        $lipsum = implode("\n", $paragraphs);
+        $lipsum = \implode("\n", $paragraphs);
         if ($arguments['html']) {
             $tsParserPath = $arguments['parseFuncTSPath'] ? '< ' . $arguments['parseFuncTSPath'] : null;
             $lipsum = static::getContentObject()->parseFunc($lipsum, [], $tsParserPath);
@@ -155,8 +155,8 @@ EqsH8BqIBVNokKRmb2lT1YdZNpwNiMFNvzg3al2OAoUHoN6MsueG0z5Ui2vbeIuLjKpFPT9TenUd9OVD
 x6M5TL9+9eRSN6k7qIfMQASX3oQXVGMtmPSfLjuBzGGeNjszJMznOLW8FUMbkptifPaZV13sSQyF0qOdN9Rk+hobN164Wdc6m4V8RrHTGxXQpN3EXiZfUJ
 DMIQpga2uYYtOVQwtd838NhauhXzLF9AYQu16hr9u1C42SO8/kznuFkuu8wtkKoFbuoDxm3Cvn8OMziHcxkfZKgc+egBghffP+bZb9GrsmjORQPza31VR4
 fKlBugvORmsyOJaRIQ8yH3I1EG2Y/+/6jqtrg4/xnazRv4v3i04aA==';
-        $uncompressed = gzuncompress(base64_decode($lipsum));
-        $safeLipsum = htmlentities(strip_tags($uncompressed));
+        $uncompressed = \gzuncompress(\base64_decode($lipsum));
+        $safeLipsum = \htmlentities(\strip_tags($uncompressed));
         return $safeLipsum;
     }
 

--- a/Classes/ViewHelpers/Format/PlaintextViewHelper.php
+++ b/Classes/ViewHelpers/Format/PlaintextViewHelper.php
@@ -44,9 +44,9 @@ class PlaintextViewHelper extends AbstractViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $content = $renderChildrenClosure();
-        $content = trim($content);
-        $lines = explode("\n", $content);
-        $lines = array_map('trim', $lines);
-        return implode(LF, $lines);
+        $content = \trim($content);
+        $lines = \explode("\n", $content);
+        $lines = \array_map('trim', $lines);
+        return \implode(LF, $lines);
     }
 }

--- a/Classes/ViewHelpers/Format/PregReplaceViewHelper.php
+++ b/Classes/ViewHelpers/Format/PregReplaceViewHelper.php
@@ -46,7 +46,7 @@ class PregReplaceViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ) {
         $subject = isset($arguments['as']) ? $arguments['subject'] : ($arguments['subject'] ?? $renderChildrenClosure());
-        $value = preg_replace($arguments['pattern'], $arguments['replacement'], $subject);
+        $value = \preg_replace($arguments['pattern'], $arguments['replacement'], $subject);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $value,
             $arguments['as'],

--- a/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
@@ -146,15 +146,15 @@ class SanitizeStringViewHelper extends AbstractViewHelper
 
         $characterMap = static::$characterMap;
         $customMap = $arguments['customMap'];
-        if (true === is_array($customMap) && 0 < count($customMap)) {
-            $characterMap = array_merge($characterMap, $customMap);
+        if (true === \is_array($customMap) && 0 < \count($customMap)) {
+            $characterMap = \array_merge($characterMap, $customMap);
         }
-        $specialCharsSearch = array_keys($characterMap);
-        $specialCharsReplace = array_values($characterMap);
-        $string = str_replace($specialCharsSearch, $specialCharsReplace, $string);
-        $string = strtolower($string);
+        $specialCharsSearch = \array_keys($characterMap);
+        $specialCharsReplace = \array_values($characterMap);
+        $string = \str_replace($specialCharsSearch, $specialCharsReplace, $string);
+        $string = \strtolower($string);
         $pattern = '/([^a-z0-9\-]){1,}/';
-        $string = preg_replace($pattern, '-', $string);
-        return trim($string, '-');
+        $string = \preg_replace($pattern, '-', $string);
+        return \trim($string, '-');
     }
 }

--- a/Classes/ViewHelpers/Format/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SubstringViewHelper.php
@@ -45,8 +45,8 @@ class SubstringViewHelper extends AbstractViewHelper
         $start = (integer) $arguments['start'];
         $length = $arguments['length'];
         if (null !== $length) {
-            return mb_substr($content, $start, $length);
+            return \mb_substr($content, $start, $length);
         }
-        return mb_substr($content, $start);
+        return \mb_substr($content, $start);
     }
 }

--- a/Classes/ViewHelpers/Format/TidyViewHelper.php
+++ b/Classes/ViewHelpers/Format/TidyViewHelper.php
@@ -40,7 +40,7 @@ class TidyViewHelper extends AbstractViewHelper
     {
         $content = $renderChildrenClosure();
         $encoding = $arguments['encoding'];
-        if (true === class_exists('tidy')) {
+        if (true === \class_exists('tidy')) {
             $tidy = tidy_parse_string($content, [], $encoding);
             $tidy->cleanRepair();
             return (string) $tidy;

--- a/Classes/ViewHelpers/Format/TrimViewHelper.php
+++ b/Classes/ViewHelpers/Format/TrimViewHelper.php
@@ -42,9 +42,9 @@ class TrimViewHelper extends AbstractViewHelper
         $characters = $arguments['characters'];
         $content = $renderChildrenClosure();
         if (false === empty($characters)) {
-            $content = trim($content, $characters);
+            $content = \trim($content, $characters);
         } else {
-            $content = trim($content);
+            $content = \trim($content);
         }
         return $content;
     }

--- a/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
@@ -35,6 +35,6 @@ class DecodeViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return rawurldecode($renderChildrenClosure());
+        return \rawurldecode($renderChildrenClosure());
     }
 }

--- a/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
@@ -35,6 +35,6 @@ class EncodeViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return rawurlencode($renderChildrenClosure());
+        return \rawurlencode($renderChildrenClosure());
     }
 }

--- a/Classes/ViewHelpers/Format/WordWrapViewHelper.php
+++ b/Classes/ViewHelpers/Format/WordWrapViewHelper.php
@@ -50,19 +50,19 @@ class WordWrapViewHelper extends AbstractViewHelper
         $limit = (integer) $arguments['limit'];
         $break = $arguments['break'];
         $glue = $arguments['glue'];
-        $subject = preg_replace('/ +/', ' ', $subject);
-        $subject = str_replace(["\r\n", "\r"], PHP_EOL, $subject);
-        $subject = wordwrap($subject, $limit, $break, false);
+        $subject = \preg_replace('/ +/', ' ', $subject);
+        $subject = \str_replace(["\r\n", "\r"], PHP_EOL, $subject);
+        $subject = \wordwrap($subject, $limit, $break, false);
         $output = '';
-        foreach (explode($break, $subject) as $line) {
-            if (mb_strlen($line) <= $limit) {
+        foreach (\explode($break, $subject) as $line) {
+            if (\mb_strlen($line) <= $limit) {
                 $output .= $line . $glue;
                 continue;
             }
             $temp = '';
-            while (mb_strlen($line) > $limit) {
-                $temp .= mb_substr($line, 0, $limit - 1);
-                $line = mb_substr($line, $limit - 1);
+            while (\mb_strlen($line) > $limit) {
+                $temp .= \mb_substr($line, 0, $limit - 1);
+                $line = \mb_substr($line, $limit - 1);
             }
             if (false === empty($temp)) {
                 $output .= $temp . $glue . $line . $glue;

--- a/Classes/ViewHelpers/IfViewHelper.php
+++ b/Classes/ViewHelpers/IfViewHelper.php
@@ -96,15 +96,15 @@ class IfViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateStack(array $stack)
     {
-        $stackCount = count($stack);
+        $stackCount = \count($stack);
 
         if (0 === $stackCount) {
             return false;
         } elseif (1 === $stackCount) {
-            return BooleanNode::convertToBoolean(reset($stack));
+            return BooleanNode::convertToBoolean(\reset($stack));
         } elseif (3 === $stackCount) {
-            list ($leftSide, $operator, $rightSide) = array_values($stack);
-            if (true === is_string($operator) && true === isset(self::$comparisonOperators[$operator])) {
+            list ($leftSide, $operator, $rightSide) = \array_values($stack);
+            if (true === \is_string($operator) && true === isset(self::$comparisonOperators[$operator])) {
                 $operator = self::$comparisonOperators[$operator];
                 return BooleanNode::evaluateComparator($operator, $leftSide, $rightSide);
             }
@@ -115,7 +115,7 @@ class IfViewHelper extends AbstractConditionViewHelper
         $operatorIndex = false;
 
         foreach ($stack as $index => $element) {
-            if (true === is_string($element) && true === isset(self::$logicalOperators[$element])) {
+            if (true === \is_string($element) && true === isset(self::$logicalOperators[$element])) {
                 $currentOperator = self::$logicalOperators[$element];
                 $currentOperatorPrecedence = self::$operatorPrecedence[$currentOperator];
                 if ($currentOperatorPrecedence <= $operatorPrecedence) {
@@ -133,7 +133,7 @@ class IfViewHelper extends AbstractConditionViewHelper
             );
         }
 
-        $operatorIndex = array_search($operatorIndex, array_keys($stack));
+        $operatorIndex = \array_search($operatorIndex, \array_keys($stack));
         if (0 === $operatorIndex || $operatorIndex + 1 >= $stackCount) {
             throw new \RuntimeException(
                 'The stack may not contain a logical operator at the first or last element.',
@@ -141,8 +141,8 @@ class IfViewHelper extends AbstractConditionViewHelper
             );
         }
 
-        $leftSide = array_slice($stack, 0, $operatorIndex);
-        $rightSide = array_slice($stack, $operatorIndex + 1);
+        $leftSide = \array_slice($stack, 0, $operatorIndex);
+        $rightSide = \array_slice($stack, $operatorIndex + 1);
 
         return self::evaluateLogicalOperator($leftSide, $operator, $rightSide);
     }
@@ -174,9 +174,9 @@ class IfViewHelper extends AbstractConditionViewHelper
      */
     protected static function prepareSideForEvaluation(array $side)
     {
-        if (1 === count($side)) {
-            $element = reset($side);
-            if (true === is_array($element)) {
+        if (1 === \count($side)) {
+            $element = \reset($side);
+            if (true === \is_array($element)) {
                 return $element;
             }
         }

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -81,18 +81,18 @@ class ChunkViewHelper extends AbstractViewHelper implements CompilableInterface
             return $output;
         }
         if (true === (boolean) $fixed) {
-            $subjectSize = count($subject);
+            $subjectSize = \count($subject);
             if (0 < $subjectSize) {
-                $chunkSize = ceil($subjectSize / $count);
-                $output = array_chunk($subject, $chunkSize, $preserveKeys);
+                $chunkSize = \ceil($subjectSize / $count);
+                $output = \array_chunk($subject, $chunkSize, $preserveKeys);
             }
             // Fill the resulting array with empty items to get the desired element count
-            $elementCount = count($output);
+            $elementCount = \count($output);
             if ($elementCount < $count) {
-                $output += array_fill($elementCount, $count - $elementCount, null);
+                $output += \array_fill($elementCount, $count - $elementCount, null);
             }
         } else {
-            $output = array_chunk($subject, $count, $preserveKeys);
+            $output = \array_chunk($subject, $count, $preserveKeys);
         }
 
         return static::renderChildrenWithVariableOrReturnInputStatic(

--- a/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
@@ -120,7 +120,7 @@ class ColumnViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $subject = !empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure();
-        $output = array_column($subject, $arguments['columnKey'], $arguments['indexKey']);
+        $output = \array_column($subject, $arguments['columnKey'], $arguments['indexKey']);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/DiffViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/DiffViewHelper.php
@@ -60,6 +60,6 @@ class DiffViewHelper extends AbstractViewHelper implements CompilableInterface
         $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
         $b = static::arrayFromArrayOrTraversableOrCSVStatic($arguments['b']);
 
-        return array_diff($a, $b);
+        return \array_diff($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
@@ -77,7 +77,7 @@ class ExplodeViewHelper extends AbstractViewHelper implements CompilableInterfac
         $content = !empty($arguments['as']) ? $arguments['content'] : ($arguments['content'] ?? $renderChildrenClosure());
         $glue = $arguments['glue'];
         $limit = isset($arguments['limit']) ? $arguments['limit'] : PHP_INT_MAX;
-        $output = explode($glue, $content, $limit);
+        $output = \explode($glue, $content, $limit);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
@@ -134,7 +134,7 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
         }
 
         if (true === (boolean) $single) {
-            return reset($result);
+            return \reset($result);
         }
 
         return $result;
@@ -150,8 +150,8 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
      */
     protected static function extractByKey($iterator, $key)
     {
-        if (false === is_array($iterator) && false === $iterator instanceof \Traversable) {
-            throw new \Exception('Traversable object or array expected but received ' . gettype($iterator), 1361532490);
+        if (false === \is_array($iterator) && false === $iterator instanceof \Traversable) {
+            throw new \Exception('Traversable object or array expected but received ' . \gettype($iterator), 1361532490);
         }
 
         $result = ObjectAccess::getPropertyPath($iterator, $key);
@@ -169,8 +169,8 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
      */
     protected static function recursivelyExtractKey($iterator, $key)
     {
-        if (false === is_array($iterator) && false === $iterator instanceof \Traversable) {
-            throw new \Exception('Traversable object or array expected but received ' . gettype($iterator), 1515498714);
+        if (false === \is_array($iterator) && false === $iterator instanceof \Traversable) {
+            throw new \Exception('Traversable object or array expected but received ' . \gettype($iterator), 1515498714);
         }
 
         $content = [];
@@ -180,7 +180,7 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
             $result = ObjectAccess::getPropertyPath($v, $key);
             if (null !== $result) {
                 $content[] = $result;
-            } elseif (true === is_array($v) || true === $v instanceof \Traversable) {
+            } elseif (true === \is_array($v) || true === $v instanceof \Traversable) {
                 $content[] = static::recursivelyExtractKey($v, $key);
             }
         }
@@ -204,7 +204,7 @@ class ExtractViewHelper extends AbstractViewHelper implements CompilableInterfac
         }
 
         foreach ($content as $sub) {
-            if (true === is_array($sub)) {
+            if (true === \is_array($sub)) {
                 $flattened = static::flattenArray($sub, $flattened);
             } else {
                 $flattened[] = $sub;

--- a/Classes/ViewHelpers/Iterator/FilterViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FilterViewHelper.php
@@ -86,14 +86,14 @@ class FilterViewHelper extends AbstractViewHelper implements CompilableInterface
         $invert = (boolean) $arguments['invert'];
         $nullFilter = (boolean) $arguments['nullFilter'];
 
-        if (null === $subject || (false === is_array($subject) && false === $subject instanceof \Traversable)) {
+        if (null === $subject || (false === \is_array($subject) && false === $subject instanceof \Traversable)) {
             return [];
         }
         if ((false === (boolean) $nullFilter && null === $filter) || '' === $filter) {
             return $subject;
         }
         if (true === $subject instanceof \Traversable) {
-            $subject = iterator_to_array($subject);
+            $subject = \iterator_to_array($subject);
         }
         $items = [];
         $invertFlag = !$invert;
@@ -102,7 +102,7 @@ class FilterViewHelper extends AbstractViewHelper implements CompilableInterface
                 $items[$key] = $item;
             }
         }
-        return true === $preserveKeys ? $items : array_values($items);
+        return true === $preserveKeys ? $items : \array_values($items);
     }
 
     /**
@@ -118,11 +118,11 @@ class FilterViewHelper extends AbstractViewHelper implements CompilableInterface
      */
     protected static function filter($item, $filter, $propertyName)
     {
-        if (false === empty($propertyName) && (true === is_object($item) || true === is_array($item))) {
+        if (false === empty($propertyName) && (true === \is_object($item) || true === \is_array($item))) {
             $value = ObjectAccess::getPropertyPath($item, $propertyName);
         } else {
             $value = $item;
         }
-        return is_array($filter) ? in_array($value, $filter) : ($value == $filter);
+        return \is_array($filter) ? \in_array($value, $filter) : ($value == $filter);
     }
 }

--- a/Classes/ViewHelpers/Iterator/FirstViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FirstViewHelper.php
@@ -55,10 +55,10 @@ class FirstViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $haystack = $renderChildrenClosure();
-        if (false === is_array($haystack) && false === $haystack instanceof \Iterator && null !== $haystack) {
+        if (false === \is_array($haystack) && false === $haystack instanceof \Iterator && null !== $haystack) {
             ErrorUtility::throwViewHelperException(
                 'Invalid argument supplied to Iterator/FirstViewHelper - expected array, Iterator or NULL but got ' .
-                gettype($haystack),
+                \gettype($haystack),
                 1351958398
             );
         }

--- a/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
@@ -69,7 +69,7 @@ class ImplodeViewHelper extends AbstractViewHelper implements CompilableInterfac
     ) {
         $content = !empty($arguments['as']) ? $arguments['content'] : ($arguments['content'] ?? $renderChildrenClosure());
         $glue = $arguments['glue'];
-        $output = implode($glue, $content);
+        $output = \implode($glue, $content);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
@@ -61,6 +61,6 @@ class IntersectViewHelper extends AbstractViewHelper implements CompilableInterf
         $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
         $b = static::arrayFromArrayOrTraversableOrCSVStatic($arguments['b']);
 
-        return array_intersect($a, $b);
+        return \array_intersect($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Iterator/KeysViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/KeysViewHelper.php
@@ -55,7 +55,7 @@ class KeysViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         return static::renderChildrenWithVariableOrReturnInputStatic(
-            array_keys(static::arrayFromArrayOrTraversableOrCSVStatic(isset($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure())),
+            \array_keys(static::arrayFromArrayOrTraversableOrCSVStatic(isset($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure())),
             $arguments['as'],
             $renderingContext,
             $renderChildrenClosure

--- a/Classes/ViewHelpers/Iterator/LastViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LastViewHelper.php
@@ -53,6 +53,6 @@ class LastViewHelper extends AbstractViewHelper implements CompilableInterface
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return array_pop(static::arrayFromArrayOrTraversableOrCSVStatic($renderChildrenClosure()));
+        return \array_pop(static::arrayFromArrayOrTraversableOrCSVStatic($renderChildrenClosure()));
     }
 }

--- a/Classes/ViewHelpers/Iterator/PopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PopViewHelper.php
@@ -55,7 +55,7 @@ class PopViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         return static::renderChildrenWithVariableOrReturnInputStatic(
-            array_pop(static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure())),
+            \array_pop(static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure())),
             $arguments['as'],
             $renderingContext,
             $renderChildrenClosure

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -65,7 +65,7 @@ class RandomViewHelper extends AbstractViewHelper implements CompilableInterface
             return null;
         }
         return static::renderChildrenWithVariableOrReturnInputStatic(
-            $subject[array_rand($subject)],
+            $subject[\array_rand($subject)],
             $arguments['as'],
             $renderingContext,
             $renderChildrenClosure

--- a/Classes/ViewHelpers/Iterator/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RangeViewHelper.php
@@ -69,7 +69,7 @@ class RangeViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         return static::renderChildrenWithVariableOrReturnInputStatic(
-            range($arguments['low'], $arguments['high'], $arguments['step']),
+            \range($arguments['low'], $arguments['high'], $arguments['step']),
             $arguments['as'],
             $renderingContext,
             $renderChildrenClosure

--- a/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
@@ -66,7 +66,7 @@ class ReverseViewHelper extends AbstractViewHelper implements CompilableInterfac
         RenderingContextInterface $renderingContext
     ) {
         $array = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure());
-        $array = array_reverse($array, true);
+        $array = \array_reverse($array, true);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $array,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
@@ -57,7 +57,7 @@ class ShiftViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $subject = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure());
-        $output = array_shift($subject);
+        $output = \array_shift($subject);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/SliceViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SliceViewHelper.php
@@ -60,7 +60,7 @@ class SliceViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $haystack = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['haystack'] : $renderChildrenClosure());
-        $output = array_slice($haystack, $arguments['start'], $arguments['length'], (boolean) $arguments['preserveKeys']);
+        $output = \array_slice($haystack, $arguments['start'], $arguments['length'], (boolean) $arguments['preserveKeys']);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -115,14 +115,14 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
     ) {
         $subject = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure());
         $sorted = null;
-        if (true === is_array($subject)) {
+        if (true === \is_array($subject)) {
             $sorted = static::sortArray($subject, $arguments);
         } else {
             if (true === $subject instanceof ObjectStorage || true === $subject instanceof LazyObjectStorage) {
                 $sorted = static::sortObjectStorage($subject, $arguments);
             } elseif (true === $subject instanceof \Iterator) {
                 /** @var \Iterator $subject */
-                $array = iterator_to_array($subject, true);
+                $array = \iterator_to_array($subject, true);
                 $sorted = static::sortArray($array, $arguments);
             } elseif (true === $subject instanceof QueryResultInterface) {
                 /** @var QueryResultInterface $subject */
@@ -133,7 +133,7 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
                 // fatal error.
                 ErrorUtility::throwViewHelperException(
                     'Unsortable variable type passed to Iterator/SortViewHelper. Expected any of Array, QueryResult, ' .
-                    ' ObjectStorage or Iterator implementation but got ' . gettype($subject),
+                    ' ObjectStorage or Iterator implementation but got ' . \gettype($subject),
                     1351958941
                 );
             }
@@ -167,19 +167,19 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
             $sorted[$index] = $object;
         }
         if ('ASC' === $arguments['order']) {
-            ksort($sorted, static::getSortFlags($arguments));
+            \ksort($sorted, static::getSortFlags($arguments));
         } elseif ('RAND' === $arguments['order']) {
-            $sortedKeys = array_keys($sorted);
-            shuffle($sortedKeys);
+            $sortedKeys = \array_keys($sorted);
+            \shuffle($sortedKeys);
             $backup = $sorted;
             $sorted = [];
             foreach ($sortedKeys as $sortedKey) {
                 $sorted[$sortedKey] = $backup[$sortedKey];
             }
         } elseif ('SHUFFLE' === $arguments['order']) {
-            shuffle($sorted);
+            \shuffle($sorted);
         } else {
-            krsort($sorted, static::getSortFlags($arguments));
+            \krsort($sorted, static::getSortFlags($arguments));
         }
         return $sorted;
     }
@@ -223,8 +223,8 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
             $value = (integer) $value->format('U');
         } elseif (true === $value instanceof ObjectStorage || true === $value instanceof LazyObjectStorage) {
             $value = $value->count();
-        } elseif (is_array($value)) {
-            $value = count($value);
+        } elseif (\is_array($value)) {
+            $value = \count($value);
         }
         return $value;
     }
@@ -242,14 +242,14 @@ class SortViewHelper extends AbstractViewHelper implements CompilableInterface
         $constants = static::arrayFromArrayOrTraversableOrCSVStatic($arguments['sortFlags']);
         $flags = 0;
         foreach ($constants as $constant) {
-            if (false === in_array($constant, static::$allowedSortFlags)) {
+            if (false === \in_array($constant, static::$allowedSortFlags)) {
                 ErrorUtility::throwViewHelperException(
                     'The constant "' . $constant . '" you\'re trying to use as a sortFlag is not allowed. Allowed ' .
-                    'constants are: ' . implode(', ', static::$allowedSortFlags) . '.',
+                    'constants are: ' . \implode(', ', static::$allowedSortFlags) . '.',
                     1404220538
                 );
             }
-            $flags = $flags | constant(trim($constant));
+            $flags = $flags | \constant(\trim($constant));
         }
         return $flags;
     }

--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -59,6 +59,6 @@ class SplitViewHelper extends AbstractViewHelper implements CompilableInterface
             // argument is zero for some reason. PHP would throw a warning; Fluid would logically just return empty.
             return [];
         }
-        return str_split(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure(), $arguments['length']);
+        return \str_split(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure(), $arguments['length']);
     }
 }

--- a/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
@@ -98,7 +98,7 @@ class UniqueViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $array = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure());
-        $array = array_unique($array);
+        $array = \array_unique($array);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $array,
             $arguments['as'],

--- a/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
@@ -74,7 +74,7 @@ class ValuesViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $subject = static::arrayFromArrayOrTraversableOrCSVStatic(!empty($arguments['as']) ? $arguments['subject'] : $renderChildrenClosure());
-        $output = array_values($subject);
+        $output = \array_values($subject);
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $output,
             $arguments['as'],

--- a/Classes/ViewHelpers/LViewHelper.php
+++ b/Classes/ViewHelpers/LViewHelper.php
@@ -89,11 +89,11 @@ class LViewHelper extends AbstractViewHelper implements CompilableInterface
         $value = LocalizationUtility::translate($id, $extensionName, $translationArguments);
         if (true === empty($value)) {
             $value = $default;
-            if (true === is_array($translationArguments)) {
-                $value = vsprintf($value, $translationArguments);
+            if (true === \is_array($translationArguments)) {
+                $value = \vsprintf($value, $translationArguments);
             }
         } elseif (true === $htmlEscape) {
-            $value = htmlspecialchars($value);
+            $value = \htmlspecialchars($value);
         }
         return $value;
     }

--- a/Classes/ViewHelpers/Link/TypolinkViewHelper.php
+++ b/Classes/ViewHelpers/Link/TypolinkViewHelper.php
@@ -73,7 +73,7 @@ class TypolinkViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ) {
         GeneralUtility::deprecationLog(
-            sprintf(
+            \sprintf(
                 'Deprecated TypoLinkViewHelper from VHS was used. Please use %s instead.',
                 FluidTypolinkViewHelper::class
             )

--- a/Classes/ViewHelpers/Math/AverageViewHelper.php
+++ b/Classes/ViewHelpers/Math/AverageViewHelper.php
@@ -49,7 +49,7 @@ class AverageViewHelper extends AbstractMultipleMathViewHelper
         if (true === $aIsIterable) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             if ($b === null) {
-                return array_sum($a) / count($a);
+                return \array_sum($a) / \count($a);
             }
             if ($bIsIterable) {
                 $b = static::arrayFromArrayOrTraversableOrCSVStatic($b);

--- a/Classes/ViewHelpers/Math/CeilViewHelper.php
+++ b/Classes/ViewHelpers/Math/CeilViewHelper.php
@@ -28,8 +28,8 @@ class CeilViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map('ceil', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+            return \array_map('ceil', static::arrayFromArrayOrTraversableOrCSVStatic($a));
         }
-        return ceil($a);
+        return \ceil($a);
     }
 }

--- a/Classes/ViewHelpers/Math/CubeViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubeViewHelper.php
@@ -26,8 +26,8 @@ class CubeViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map([static::class, 'calculateAction'], $a);
+            return \array_map([static::class, 'calculateAction'], $a);
         }
-        return pow($a, 3);
+        return \pow($a, 3);
     }
 }

--- a/Classes/ViewHelpers/Math/CubicRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubicRootViewHelper.php
@@ -26,8 +26,8 @@ class CubicRootViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map([static::class, 'calculateAction'], static::arrayFromArrayOrTraversableOrCSVStatic($a));
+            return \array_map([static::class, 'calculateAction'], static::arrayFromArrayOrTraversableOrCSVStatic($a));
         }
-        return pow($a, 1 / 3);
+        return \pow($a, 1 / 3);
     }
 }

--- a/Classes/ViewHelpers/Math/DivisionViewHelper.php
+++ b/Classes/ViewHelpers/Math/DivisionViewHelper.php
@@ -35,8 +35,8 @@ class DivisionViewHelper extends AbstractMultipleMathViewHelper
         $bIsIterable = static::assertIsArrayOrIterator($b);
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            $sum = array_sum($a);
-            $distribution = count($a);
+            $sum = \array_sum($a);
+            $distribution = \count($a);
             return $sum / $distribution;
         } elseif (true === $aIsIterable && $b !== null) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);

--- a/Classes/ViewHelpers/Math/FloorViewHelper.php
+++ b/Classes/ViewHelpers/Math/FloorViewHelper.php
@@ -28,8 +28,8 @@ class FloorViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map('floor', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+            return \array_map('floor', static::arrayFromArrayOrTraversableOrCSVStatic($a));
         }
-        return floor($a);
+        return \floor($a);
     }
 }

--- a/Classes/ViewHelpers/Math/MaximumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MaximumViewHelper.php
@@ -43,11 +43,11 @@ class MaximumViewHelper extends AbstractMultipleMathViewHelper
         $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            return max($a);
+            return \max($a);
         }
         if ($b === null && (boolean) $arguments['fail']) {
             ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
-        return max($a, $b);
+        return \max($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Math/MedianViewHelper.php
+++ b/Classes/ViewHelpers/Math/MedianViewHelper.php
@@ -33,8 +33,8 @@ class MedianViewHelper extends AbstractSingleMathViewHelper
         $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            sort($a, SORT_NUMERIC);
-            $size = count($a);
+            \sort($a, SORT_NUMERIC);
+            $size = \count($a);
             $midpoint = $size / 2;
             if (1 === $size % 2) {
                 /*
@@ -44,8 +44,8 @@ class MedianViewHelper extends AbstractSingleMathViewHelper
 				 */
                 return $a[(integer) $midpoint];
             }
-            $candidates = array_slice($a, floor($midpoint) - 1, 2);
-            return array_sum($candidates) / 2;
+            $candidates = \array_slice($a, \floor($midpoint) - 1, 2);
+            return \array_sum($candidates) / 2;
         }
         return $a;
     }

--- a/Classes/ViewHelpers/Math/MinimumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MinimumViewHelper.php
@@ -43,11 +43,11 @@ class MinimumViewHelper extends AbstractMultipleMathViewHelper
         $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            return min($a);
+            return \min($a);
         }
         if ($b === null && (boolean) $arguments['fail']) {
             ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
-        return min($a, $b);
+        return \min($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Math/PowerViewHelper.php
+++ b/Classes/ViewHelpers/Math/PowerViewHelper.php
@@ -26,6 +26,6 @@ class PowerViewHelper extends AbstractMultipleMathViewHelper
      */
     protected static function calculateAction($a, $b)
     {
-        return pow($a, $b);
+        return \pow($a, $b);
     }
 }

--- a/Classes/ViewHelpers/Math/ProductViewHelper.php
+++ b/Classes/ViewHelpers/Math/ProductViewHelper.php
@@ -38,7 +38,7 @@ class ProductViewHelper extends AbstractMultipleMathViewHelper
         $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            return array_product($a);
+            return \array_product($a);
         }
         if ($b === null && (boolean) $arguments['fail']) {
             ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);

--- a/Classes/ViewHelpers/Math/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Math/RangeViewHelper.php
@@ -30,6 +30,6 @@ class RangeViewHelper extends AbstractSingleMathViewHelper
      */
     protected static function calculateAction($a)
     {
-        return [min($a), max($a)];
+        return [\min($a), \max($a)];
     }
 }

--- a/Classes/ViewHelpers/Math/RoundViewHelper.php
+++ b/Classes/ViewHelpers/Math/RoundViewHelper.php
@@ -44,6 +44,6 @@ class RoundViewHelper extends AbstractSingleMathViewHelper
             }
             return $a;
         }
-        return round($a, $arguments['decimals']);
+        return \round($a, $arguments['decimals']);
     }
 }

--- a/Classes/ViewHelpers/Math/SquareRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareRootViewHelper.php
@@ -26,8 +26,8 @@ class SquareRootViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map('sqrt', static::arrayFromArrayOrTraversableOrCSVStatic($a));
+            return \array_map('sqrt', static::arrayFromArrayOrTraversableOrCSVStatic($a));
         }
-        return sqrt($a);
+        return \sqrt($a);
     }
 }

--- a/Classes/ViewHelpers/Math/SquareViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareViewHelper.php
@@ -26,11 +26,11 @@ class SquareViewHelper extends AbstractSingleMathViewHelper
     protected static function calculateAction($a)
     {
         if (static::assertIsArrayOrIterator($a)) {
-            return array_map(
+            return \array_map(
                 [static::class, 'calculateAction'],
                 static::arrayFromArrayOrTraversableOrCSVStatic($a)
             );
         }
-        return pow($a, 2);
+        return \pow($a, 2);
     }
 }

--- a/Classes/ViewHelpers/Math/SubtractViewHelper.php
+++ b/Classes/ViewHelpers/Math/SubtractViewHelper.php
@@ -46,7 +46,7 @@ class SubtractViewHelper extends AbstractMultipleMathViewHelper
         $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-            return -array_sum($a);
+            return -\array_sum($a);
         }
         if ($b === null && (boolean) $arguments['fail']) {
             ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);

--- a/Classes/ViewHelpers/Math/SumViewHelper.php
+++ b/Classes/ViewHelpers/Math/SumViewHelper.php
@@ -51,7 +51,7 @@ class SumViewHelper extends AbstractMultipleMathViewHelper
         if (true === $aIsIterable) {
             if (null === $b) {
                 $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
-                return array_sum($a);
+                return \array_sum($a);
             }
             foreach ($a as $index => $value) {
                 $a[$index] = static::calculateAction($value, $b, $arguments);

--- a/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
@@ -58,11 +58,11 @@ abstract class AbstractMediaViewHelper extends AbstractTagBasedViewHelper
      */
     public static function preprocessSourceUri($src, array $arguments)
     {
-        $src = $GLOBALS['TSFE']->absRefPrefix . str_replace('%2F', '/', rawurlencode($src));
+        $src = $GLOBALS['TSFE']->absRefPrefix . \str_replace('%2F', '/', \rawurlencode($src));
         if (false === empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
             $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
         } elseif ('BE' === TYPO3_MODE || false === (boolean) $arguments['relative']) {
-            $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . ltrim($src, '/');
+            $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . \ltrim($src, '/');
         }
         return $src;
     }
@@ -79,8 +79,8 @@ abstract class AbstractMediaViewHelper extends AbstractTagBasedViewHelper
     {
         $src = $arguments['src'];
         if ($src instanceof \Traversable) {
-            $src = iterator_to_array($src);
-        } elseif (true === is_string($src)) {
+            $src = \iterator_to_array($src);
+        } elseif (true === \is_string($src)) {
             $src = GeneralUtility::trimExplode(',', $src, true);
         }
         return $src;

--- a/Classes/ViewHelpers/Media/AudioViewHelper.php
+++ b/Classes/ViewHelpers/Media/AudioViewHelper.php
@@ -128,20 +128,20 @@ class AudioViewHelper extends AbstractMediaViewHelper
     public function render()
     {
         $sources = static::getSourcesFromArgument($this->arguments);
-        if (0 === count($sources)) {
+        if (0 === \count($sources)) {
             throw new Exception('No audio sources provided.', 1359382189);
         }
 
         foreach ($sources as $source) {
-            if (is_string($source)) {
-                if (false !== strpos($source, '//')) {
+            if (\is_string($source)) {
+                if (false !== \strpos($source, '//')) {
                     $src = $source;
-                    $type = mb_substr($source, mb_strrpos($source, '.') + 1);
+                    $type = \mb_substr($source, \mb_strrpos($source, '.') + 1);
                 } else {
-                    $src = mb_substr(GeneralUtility::getFileAbsFileName($source), mb_strlen(PATH_site));
-                    $type = pathinfo($src, PATHINFO_EXTENSION);
+                    $src = \mb_substr(GeneralUtility::getFileAbsFileName($source), \mb_strlen(PATH_site));
+                    $type = \pathinfo($src, PATHINFO_EXTENSION);
                 }
-            } elseif (is_array($source)) {
+            } elseif (\is_array($source)) {
                 if (!isset($source['src'])) {
                     throw new Exception('Missing value for "src" in sources array.', 1359381250);
                 }
@@ -154,8 +154,8 @@ class AudioViewHelper extends AbstractMediaViewHelper
                 // skip invalid source
                 continue;
             }
-            $type = mb_strtolower($type);
-            if (!in_array($type, $this->validTypes)) {
+            $type = \mb_strtolower($type);
+            if (!\in_array($type, $this->validTypes)) {
                     throw new Exception('Invalid audio type "' . $type . '".', 1359381260);
             }
             $type = $this->mimeTypesMap[$type];
@@ -179,7 +179,7 @@ class AudioViewHelper extends AbstractMediaViewHelper
         if (true === (boolean) $this->arguments['muted']) {
             $tagAttributes['muted'] = 'muted';
         }
-        if (true === in_array($this->arguments['preload'], $this->validPreloadModes)) {
+        if (true === \in_array($this->arguments['preload'], $this->validPreloadModes)) {
             $tagAttributes['preload'] = 'preload';
         }
         if (null !== $this->arguments['poster']) {

--- a/Classes/ViewHelpers/Media/ExistsViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExistsViewHelper.php
@@ -43,9 +43,9 @@ class ExistsViewHelper extends AbstractConditionViewHelper
         $directory = $arguments['directory'];
         $evaluation = false;
         if (true === isset($arguments['file'])) {
-            $evaluation = ((file_exists($file) || file_exists(constant('PATH_site') . $file)) && is_file($file));
+            $evaluation = ((\file_exists($file) || \file_exists(\constant('PATH_site') . $file)) && \is_file($file));
         } elseif (true === isset($arguments['directory'])) {
-            $evaluation = (is_dir($directory) || is_dir(constant('PATH_site') . $directory));
+            $evaluation = (\is_dir($directory) || \is_dir(\constant('PATH_site') . $directory));
         }
         return $evaluation;
     }

--- a/Classes/ViewHelpers/Media/ExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExtensionViewHelper.php
@@ -57,14 +57,14 @@ class ExtensionViewHelper extends AbstractViewHelper
 
         $file = GeneralUtility::getFileAbsFileName($filePath);
 
-        $parts = explode('.', basename($file));
+        $parts = \explode('.', \basename($file));
 
         // file has no extension
-        if (1 === count($parts)) {
+        if (1 === \count($parts)) {
             return '';
         }
 
-        $extension = strtolower(array_pop($parts));
+        $extension = \strtolower(\array_pop($parts));
 
         return $extension;
     }

--- a/Classes/ViewHelpers/Media/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Media/GravatarViewHelper.php
@@ -77,8 +77,8 @@ class GravatarViewHelper extends AbstractTagBasedViewHelper
         $secure = (boolean) $this->arguments['secure'];
 
         $url = (true === $secure ? self::GRAVATAR_SECURE_BASEURL : self::GRAVATAR_BASEURL);
-        $url .= md5(strtolower(trim($email)));
-        $query = http_build_query(['s' => $size, 'd' => $imageSet, 'r' => $maximumRating]);
+        $url .= \md5(\strtolower(\trim($email)));
+        $query = \http_build_query(['s' => $size, 'd' => $imageSet, 'r' => $maximumRating]);
         $url .= (false === empty($query) ? '?' . $query : '');
         $this->tag->addAttribute('src', $url);
         $this->tag->forceClosingTag(true);

--- a/Classes/ViewHelpers/Media/Image/AbstractImageInfoViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageInfoViewHelper.php
@@ -86,7 +86,7 @@ abstract class AbstractImageInfoViewHelper extends AbstractViewHelper
             }
         }
 
-        if (is_object($src) && $src instanceof FileReference) {
+        if (\is_object($src) && $src instanceof FileReference) {
             $src = $src->getUid();
             $treatIdAsUid = false;
             $treatIdAsReference = true;
@@ -102,13 +102,13 @@ abstract class AbstractImageInfoViewHelper extends AbstractViewHelper
             }
         } else {
             $file = GeneralUtility::getFileAbsFileName($src);
-            if (false === file_exists($file) || true === is_dir($file)) {
+            if (false === \file_exists($file) || true === \is_dir($file)) {
                 throw new Exception(
                     'Cannot determine info for "' . $file . '". File does not exist or is a directory.',
                     1357066532
                 );
             }
-            $imageSize = getimagesize($file);
+            $imageSize = \getimagesize($file);
             $info = [
                 'width'  => $imageSize[0],
                 'height' => $imageSize[1],

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -141,13 +141,13 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         $treatIdAsReference = (boolean) $this->arguments['treatIdAsReference'];
         $crop = $this->arguments['crop'];
 
-        if (is_object($src) && $src instanceof FileReference) {
+        if (\is_object($src) && $src instanceof FileReference) {
             $src = $src->getUid();
             $treatIdAsReference = true;
         }
 
         if ($crop === null) {
-            $crop = (is_object($src) && $src instanceof FileReference) ? $src->_getProperty('crop') : null;
+            $crop = (\is_object($src) && $src instanceof FileReference) ? $src->_getProperty('crop') : null;
         }
 
         if ('BE' === TYPO3_MODE) {
@@ -171,32 +171,32 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
             $setup['params'] = '-quality ' . $quality;
         }
 
-        if (TYPO3_MODE === 'BE' && strpos($src, '../') === 0) {
-            $src = mb_substr($src, 3);
+        if (TYPO3_MODE === 'BE' && \strpos($src, '../') === 0) {
+            $src = \mb_substr($src, 3);
         }
         $this->imageInfo = $this->contentObject->getImgResource($src, $setup);
         $GLOBALS['TSFE']->lastImageInfo = $this->imageInfo;
 
-        if (false === is_array($this->imageInfo)) {
-            throw new Exception('Could not get image resource for "' . htmlspecialchars($src) . '".', 1253191060);
+        if (false === \is_array($this->imageInfo)) {
+            throw new Exception('Could not get image resource for "' . \htmlspecialchars($src) . '".', 1253191060);
         }
         if ($this->hasArgument('canvasWidth') && $this->hasArgument('canvasHeight')) {
             $canvasWidth = (integer) $this->arguments['canvasWidth'];
             $canvasHeight = (integer) $this->arguments['canvasHeight'];
-            $canvasColor = str_replace('#', '', $this->arguments['canvasColor']);
+            $canvasColor = \str_replace('#', '', $this->arguments['canvasColor']);
             $originalFilename = $this->imageInfo[3];
-            $originalExtension = mb_substr($originalFilename, -3);
-            $tempPath = (version_compare(TYPO3_version, 8.0, '>=')) ? 'typo3temp/assets/' : 'typo3temp/';
+            $originalExtension = \mb_substr($originalFilename, -3);
+            $tempPath = (\version_compare(TYPO3_version, 8.0, '>=')) ? 'typo3temp/assets/' : 'typo3temp/';
             $destinationFilename = $tempPath . 'vhs-canvas-' .
-                md5($originalFilename.$canvasColor.$canvasWidth.$canvasHeight) . '.' . $originalExtension;
+                \md5($originalFilename.$canvasColor.$canvasWidth.$canvasHeight) . '.' . $originalExtension;
             $destinationFilepath = GeneralUtility::getFileAbsFileName($destinationFilename);
             $transparency = '';
             if ($this->hasArgument('transparencyColor')) {
-                $transparencyColor = str_replace('#', '', $this->arguments['transparencyColor']);
+                $transparencyColor = \str_replace('#', '', $this->arguments['transparencyColor']);
                 $transparency = ' -transparent \'#' . $transparencyColor . '\'';
             }
-            if (!file_exists($destinationFilepath)) {
-                $arguments = sprintf(
+            if (!\file_exists($destinationFilepath)) {
+                $arguments = \sprintf(
                     '%s -background \'#%s\'%s -gravity center -extent %dx%d %s',
                     $originalFilename,
                     $canvasColor,
@@ -212,7 +212,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         }
 
         $GLOBALS['TSFE']->imagesOnPage[] = $this->imageInfo[3];
-        $this->mediaSource = rawurldecode($this->imageInfo[3]);
+        $this->mediaSource = \rawurldecode($this->imageInfo[3]);
         if (TYPO3_MODE === 'BE') {
             $this->resetFrontendEnvironment();
         }
@@ -229,8 +229,8 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     protected function simulateFrontendEnvironment()
     {
         $this->tsfeBackup = true === isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
-        $this->workingDirectoryBackup = getcwd();
-        chdir(constant('PATH_site'));
+        $this->workingDirectoryBackup = \getcwd();
+        \chdir(\constant('PATH_site'));
         $typoScriptSetup = $this->configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );
@@ -238,7 +238,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = 0;
         $template->init();
-        $template->getFileName_backPath = constant('PATH_site');
+        $template->getFileName_backPath = \constant('PATH_site');
         $GLOBALS['TSFE']->tmpl = $template;
         $GLOBALS['TSFE']->tmpl->setup = $typoScriptSetup;
         $GLOBALS['TSFE']->config = $typoScriptSetup;
@@ -254,6 +254,6 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     protected function resetFrontendEnvironment()
     {
         $GLOBALS['TSFE'] = $this->tsfeBackup;
-        chdir($this->workingDirectoryBackup);
+        \chdir($this->workingDirectoryBackup);
     }
 }

--- a/Classes/ViewHelpers/Media/PdfThumbnailViewHelper.php
+++ b/Classes/ViewHelpers/Media/PdfThumbnailViewHelper.php
@@ -72,7 +72,7 @@ class PdfThumbnailViewHelper extends ImageViewHelper
     public function render()
     {
         $src = GeneralUtility::getFileAbsFileName($this->arguments['src']);
-        if (false === file_exists($src)) {
+        if (false === \file_exists($src)) {
             return null;
         }
         $density = $this->arguments['density'];
@@ -80,16 +80,16 @@ class PdfThumbnailViewHelper extends ImageViewHelper
         $page = (integer) $this->arguments['page'];
         $background = $this->arguments['background'];
         $forceOverwrite = (boolean) $this->arguments['forceOverwrite'];
-        $filename = basename($src);
+        $filename = \basename($src);
         $pageArgument = $page > 0 ? $page - 1 : 0;
         if (isset($GLOBALS['TYPO3_CONF_VARS']['GFX']['colorspace'])) {
             $colorspace = $GLOBALS['TYPO3_CONF_VARS']['GFX']['colorspace'];
         } else {
             $colorspace = 'RGB';
         }
-        $tempPath = (version_compare(TYPO3_version, 8.0, '>=')) ? 'typo3temp/assets/' : 'typo3temp/';
+        $tempPath = (\version_compare(TYPO3_version, 8.0, '>=')) ? 'typo3temp/assets/' : 'typo3temp/';
         $path = GeneralUtility::getFileAbsFileName($tempPath . 'vhs-pdf-' . $filename . '-page' . $page . '.png');
-        if (false === file_exists($path) || true === $forceOverwrite) {
+        if (false === \file_exists($path) || true === $forceOverwrite) {
             $arguments = '-colorspace ' . $colorspace;
             if (0 < (integer) $density) {
                 $arguments .= ' -density ' . $density;

--- a/Classes/ViewHelpers/Media/PictureViewHelper.php
+++ b/Classes/ViewHelpers/Media/PictureViewHelper.php
@@ -77,7 +77,7 @@ class PictureViewHelper extends AbstractTagBasedViewHelper
     {
         $src = $this->arguments['src'];
         $treatIdAsReference = (boolean) $this->arguments['treatIdAsReference'];
-        if (is_object($src) && $src instanceof FileReference) {
+        if (\is_object($src) && $src instanceof FileReference) {
             $src = $src->getUid();
             $treatIdAsReference = true;
         }

--- a/Classes/ViewHelpers/Media/SizeViewHelper.php
+++ b/Classes/ViewHelpers/Media/SizeViewHelper.php
@@ -58,14 +58,14 @@ class SizeViewHelper extends AbstractViewHelper
 
         $file = GeneralUtility::getFileAbsFileName($path);
 
-        if (false === file_exists($file) || true === is_dir($file)) {
+        if (false === \file_exists($file) || true === \is_dir($file)) {
             throw new Exception(
                 'Cannot determine size of "' . $file . '". File does not exist or is a directory.',
                 1356953963
             );
         }
 
-        $size = filesize($file);
+        $size = \filesize($file);
 
         if (false === $size) {
             throw new Exception('Cannot determine size of "' . $file . '".', 1356954032);

--- a/Classes/ViewHelpers/Media/SourceViewHelper.php
+++ b/Classes/ViewHelpers/Media/SourceViewHelper.php
@@ -129,13 +129,13 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
         if (false === empty($format)) {
             $setup['ext'] = $format;
         }
-        if (0 < intval($quality)) {
+        if (0 < \intval($quality)) {
             $quality = MathUtility::forceIntegerInRange($quality, 10, 100, 75);
             $setup['params'] .= ' -quality ' . $quality;
         }
 
-        if (is_string($imageSource) && 'BE' === TYPO3_MODE && '../' === mb_substr($imageSource, 0, 3)) {
-            $imageSource = mb_substr($imageSource, 3);
+        if (\is_string($imageSource) && 'BE' === TYPO3_MODE && '../' === \mb_substr($imageSource, 0, 3)) {
+            $imageSource = \mb_substr($imageSource, 3);
         }
         $result = $this->contentObject->getImgResource($imageSource, $setup);
 
@@ -143,7 +143,7 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
             FrontendSimulationUtility::resetFrontendEnvironment($tsfeBackup);
         }
 
-        $src = $this->preprocessSourceUri(rawurldecode($result[3]));
+        $src = $this->preprocessSourceUri(\rawurldecode($result[3]));
 
         if (null === $this->arguments['media']) {
             $this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_DEFAULT_SOURCE, $src);
@@ -168,11 +168,11 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
             $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
         } elseif ('BE' === TYPO3_MODE || false === (boolean) $this->arguments['relative']) {
             if (GeneralUtility::isValidUrl($src)) {
-                $src = ltrim($src, '/');
+                $src = \ltrim($src, '/');
             } elseif (TYPO3_MODE === 'FE') {
-                $src = $GLOBALS['TSFE']->absRefPrefix . ltrim($src, '/');
+                $src = $GLOBALS['TSFE']->absRefPrefix . \ltrim($src, '/');
             } else {
-                $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . ltrim($src, '/');
+                $src = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . \ltrim($src, '/');
             }
         }
         return $src;

--- a/Classes/ViewHelpers/Media/SpotifyViewHelper.php
+++ b/Classes/ViewHelpers/Media/SpotifyViewHelper.php
@@ -79,13 +79,13 @@ class SpotifyViewHelper extends AbstractTagBasedViewHelper
         $width      = (integer) $this->arguments['width'];
         $height     = (integer) $this->arguments['height'];
 
-        if (true === in_array($this->arguments['theme'], ['black', 'white'])) {
+        if (true === \in_array($this->arguments['theme'], ['black', 'white'])) {
             $theme = $this->arguments['theme'];
         } else {
             $theme = 'black';
         }
 
-        if (true === in_array($this->arguments['view'], ['coverart', 'list'])) {
+        if (true === \in_array($this->arguments['view'], ['coverart', 'list'])) {
             $view = $this->arguments['view'];
         } else {
             $view = 'list';

--- a/Classes/ViewHelpers/Media/VideoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VideoViewHelper.php
@@ -122,19 +122,19 @@ class VideoViewHelper extends AbstractMediaViewHelper
     public function render()
     {
         $sources = static::getSourcesFromArgument($this->arguments);
-        if (0 === count($sources)) {
+        if (0 === \count($sources)) {
             throw new Exception('No video sources provided.', 1359382189);
         }
         foreach ($sources as $source) {
-            if (true === is_string($source)) {
-                if (false !== strpos($source, '//')) {
+            if (true === \is_string($source)) {
+                if (false !== \strpos($source, '//')) {
                     $src = $source;
-                    $type = mb_substr($source, mb_strrpos($source, '.') + 1);
+                    $type = \mb_substr($source, \mb_strrpos($source, '.') + 1);
                 } else {
-                    $src = mb_substr(GeneralUtility::getFileAbsFileName($source), mb_strlen(PATH_site));
-                    $type = pathinfo($src, PATHINFO_EXTENSION);
+                    $src = \mb_substr(GeneralUtility::getFileAbsFileName($source), \mb_strlen(PATH_site));
+                    $type = \pathinfo($src, PATHINFO_EXTENSION);
                 }
-            } elseif (true === is_array($source)) {
+            } elseif (true === \is_array($source)) {
                 if (false === isset($source['src'])) {
                     throw new Exception('Missing value for "src" in sources array.', 1359381250);
                 }
@@ -147,7 +147,7 @@ class VideoViewHelper extends AbstractMediaViewHelper
                 // skip invalid source
                 continue;
             }
-            if (false === in_array(strtolower($type), $this->validTypes)) {
+            if (false === \in_array(\strtolower($type), $this->validTypes)) {
                     throw new Exception('Invalid video type "' . $type . '".', 1359381260);
             }
             $type = $this->mimeTypesMap[$type];
@@ -171,7 +171,7 @@ class VideoViewHelper extends AbstractMediaViewHelper
         if (true === (boolean) $this->arguments['muted']) {
             $tagAttributes['muted'] = 'muted';
         }
-        if (true === in_array($this->arguments['preload'], $this->validPreloadModes)) {
+        if (true === \in_array($this->arguments['preload'], $this->validPreloadModes)) {
             $tagAttributes['preload'] = $this->arguments['preload'];
         }
         if (null !== $this->arguments['poster']) {

--- a/Classes/ViewHelpers/Media/VimeoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VimeoViewHelper.php
@@ -112,14 +112,14 @@ class VimeoViewHelper extends AbstractTagBasedViewHelper
             'title='     . (integer) $this->arguments['title'],
             'byline='    . (integer) $this->arguments['byline'],
             'portrait='  . (integer) $this->arguments['portrait'],
-            'color='     . str_replace('#', '', $this->arguments['color']),
+            'color='     . \str_replace('#', '', $this->arguments['color']),
             'autoplay='  . (integer) $this->arguments['autoplay'],
             'loop='      . (integer) $this->arguments['loop'],
             'api='       . (integer) $this->arguments['api'],
             'player_id=' . $this->arguments['playerId'],
         ];
 
-        $src .= implode('&', $queryParams);
+        $src .= \implode('&', $queryParams);
 
         $this->tag->forceClosingTag(true);
         $this->tag->addAttribute('src', $src);

--- a/Classes/ViewHelpers/Media/YoutubeViewHelper.php
+++ b/Classes/ViewHelpers/Media/YoutubeViewHelper.php
@@ -207,7 +207,7 @@ class YoutubeViewHelper extends AbstractTagBasedViewHelper
         }
 
         if (false === empty($params)) {
-            $src .= $seperator . implode('&', $params);
+            $src .= $seperator . \implode('&', $params);
         }
 
         return $src;

--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -249,7 +249,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
     public function renderContent(array $menu)
     {
         $deferredRendering = (boolean) $this->arguments['deferred'];
-        if (0 === count($menu) && false === $deferredRendering) {
+        if (0 === \count($menu) && false === $deferredRendering) {
             return null;
         }
         if (true === $deferredRendering) {
@@ -270,7 +270,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             $this->unsetDeferredVariableStorage();
         } else {
             $content = $this->renderChildren();
-            if (0 < mb_strlen(trim($content))) {
+            if (0 < \mb_strlen(\trim($content))) {
                 $output = $content;
             } elseif ((boolean) $this->arguments['hideIfEmpty'] === true) {
                 $output = '';
@@ -296,12 +296,12 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
         $showCurrent = (boolean) $this->arguments['showCurrent'];
         $expandAll = (boolean) $this->arguments['expandAll'];
         $itemsRendered = 0;
-        $numberOfItems = count($menu);
+        $numberOfItems = \count($menu);
         foreach ($menu as $page) {
             if ($page['current'] && !$showCurrent) {
                 continue;
             }
-            $class = (trim($page['class']) !== '') ? ' class="' . trim($page['class']) . '"' : '';
+            $class = (\trim($page['class']) !== '') ? ' class="' . \trim($page['class']) . '"' : '';
             $elementId = ($this->arguments['substElementUid']) ? ' id="elem_' . $page['uid'] . '"' : '';
             if (!$this->isNonWrappingMode()) {
                 $html[] = '<' . $tagName . $elementId . $class . '>';
@@ -310,7 +310,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             if (($page['active'] || $expandAll) && $page['hasSubPages'] && $level < $levels) {
                 $subPages = $this->getMenu($page['uid']);
                 $subMenu = $this->parseMenu($subPages);
-                if (0 < count($subMenu)) {
+                if (0 < \count($subMenu)) {
                     $renderedSubMenu = $this->autoRender($subMenu, $level + 1);
                     $parentTagId = $this->tag->getAttribute('id');
                     if (!empty($parentTagId)) {
@@ -343,7 +343,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             }
         }
 
-        return implode(LF, $html);
+        return \implode(LF, $html);
     }
 
     /**
@@ -359,25 +359,25 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
         $linkActive = (boolean) $this->arguments['linkActive'];
         $includeAnchorTitle = (boolean) $this->arguments['includeAnchorTitle'];
         $target = (!empty($page['target'])) ? ' target="' . $page['target'] . '"' : '';
-        $class = (trim($page['class']) !== '') ? ' class="' . trim($page['class']) . '"' : '';
+        $class = (\trim($page['class']) !== '') ? ' class="' . \trim($page['class']) . '"' : '';
         if ($isSpacer || ($isCurrent && !$linkCurrent) || ($isActive && !$linkActive)) {
-            $html = htmlspecialchars($page['linktext']);
+            $html = \htmlspecialchars($page['linktext']);
         } elseif ($includeAnchorTitle) {
-            $html = sprintf(
+            $html = \sprintf(
                 '<a href="%s" title="%s"%s%s>%s</a>',
                 $page['link'],
-                htmlspecialchars($page['title']),
+                \htmlspecialchars($page['title']),
                 $class,
                 $target,
-                htmlspecialchars($page['linktext'])
+                \htmlspecialchars($page['linktext'])
             );
         } else {
-            $html = sprintf(
+            $html = \sprintf(
                 '<a href="%s"%s%s>%s</a>',
                 $page['link'],
                 $class,
                 $target,
-                htmlspecialchars($page['linktext'])
+                \htmlspecialchars($page['linktext'])
             );
         }
 
@@ -395,7 +395,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
         if (null === $pageUid) {
             if (null !== $entryLevel) {
                 if ($entryLevel < 0) {
-                    $entryLevel = count($rootLineData) - 1 + $entryLevel;
+                    $entryLevel = \count($rootLineData) - 1 + $entryLevel;
                 }
                 $pageUid = $rootLineData[$entryLevel]['uid'];
             } else {
@@ -438,7 +438,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
     public function parseMenu(array $pages)
     {
         $count = 0;
-        $total = count($pages);
+        $total = \count($pages);
         $processedPages = [];
         foreach ($pages as $index => $page) {
             $count++;
@@ -472,7 +472,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
                 $pages[$index]['current'] = true;
                 $class[] = $this->arguments['classCurrent'];
             }
-            if (0 < count($this->getMenu($originalPageUid))) {
+            if (0 < \count($this->getMenu($originalPageUid))) {
                 $pages[$index]['hasSubPages'] = true;
                 //TODO: Remove deprecated argument in next major version
                 $class[] = $this->arguments[
@@ -485,7 +485,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             if ($count === $total) {
                 $class[] = $this->arguments['classLast'];
             }
-            $pages[$index]['class'] = implode(' ', $class);
+            $pages[$index]['class'] = \implode(' ', $class);
             $pages[$index]['linktext'] = $this->getItemTitle($pages[$index]);
             $forceAbsoluteUrl = $this->arguments['forceAbsoluteUrl'];
             $pages[$index]['link'] = $this->pageService->getItemLink($page, $forceAbsoluteUrl);
@@ -577,7 +577,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function restoreVariables()
     {
-        if (0 < count($this->backupValues)) {
+        if (0 < \count($this->backupValues)) {
             foreach ($this->backupValues as $var => $value) {
                 if (false === $this->templateVariableContainer->exists($var)) {
                     $this->templateVariableContainer->add($var, $value);
@@ -629,7 +629,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function getArguments()
     {
-        if (false === is_array($this->arguments)) {
+        if (false === \is_array($this->arguments)) {
             return $this->arguments->toArray();
         }
         return $this->arguments;
@@ -661,7 +661,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function isNonWrappingMode()
     {
-        return (boolean) ('a' === strtolower($this->arguments['tagNameChildren']));
+        return (boolean) ('a' === \strtolower($this->arguments['tagNameChildren']));
     }
 
     /**
@@ -676,13 +676,13 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
             $pages = $this->arguments['pages'];
         }
         if (true === $pages instanceof \Traversable) {
-            $pages = iterator_to_array($pages);
-        } elseif (true === is_string($pages)) {
+            $pages = \iterator_to_array($pages);
+        } elseif (true === \is_string($pages)) {
             $pages = GeneralUtility::trimExplode(',', $pages, true);
-        } elseif (true === is_int($pages)) {
+        } elseif (true === \is_int($pages)) {
             $pages = (array) $pages;
         }
-        if (false === is_array($pages)) {
+        if (false === \is_array($pages)) {
             return [];
         }
 

--- a/Classes/ViewHelpers/Menu/BrowseViewHelper.php
+++ b/Classes/ViewHelpers/Menu/BrowseViewHelper.php
@@ -93,8 +93,8 @@ class BrowseViewHelper extends AbstractMenuViewHelper
         if (empty($menuData)) {
             return !empty($this->arguments['as']) ? $this->renderChildren() : '';
         }
-        $pageUids = array_keys($menuData);
-        $uidCount = count($pageUids);
+        $pageUids = \array_keys($menuData);
+        $uidCount = \count($pageUids);
         $firstUid = $pageUids[0];
         $lastUid = $pageUids[$uidCount - 1];
         $nextUid = null;

--- a/Classes/ViewHelpers/Menu/DirectoryViewHelper.php
+++ b/Classes/ViewHelpers/Menu/DirectoryViewHelper.php
@@ -45,12 +45,12 @@ class DirectoryViewHelper extends AbstractMenuViewHelper
     public function render()
     {
         $pages = $this->processPagesArgument();
-        if (0 === count($pages)) {
+        if (0 === \count($pages)) {
             return null;
         }
         $menuData = [];
         foreach ($pages as $pageUid) {
-            $menuData = array_merge($menuData, $this->getMenu($pageUid));
+            $menuData = \array_merge($menuData, $this->getMenu($pageUid));
         }
         $menu = $this->parseMenu($menuData);
         $this->backupVariables();

--- a/Classes/ViewHelpers/Menu/ListViewHelper.php
+++ b/Classes/ViewHelpers/Menu/ListViewHelper.php
@@ -44,7 +44,7 @@ class ListViewHelper extends AbstractMenuViewHelper
     public function render()
     {
         $pages = $this->processPagesArgument();
-        if (0 === count($pages)) {
+        if (0 === \count($pages)) {
             return null;
         }
         $showAccessProtected = (boolean) $this->arguments['showAccessProtected'];

--- a/Classes/ViewHelpers/Once/AbstractOnceViewHelper.php
+++ b/Classes/ViewHelpers/Once/AbstractOnceViewHelper.php
@@ -111,7 +111,7 @@ abstract class AbstractOnceViewHelper extends AbstractConditionViewHelper
     {
         $identifier = static::getIdentifier($arguments);
         if (false === isset(self::$identifiers[$identifier])) {
-            self::$identifiers[$identifier] = time();
+            self::$identifiers[$identifier] = \time();
         }
     }
 
@@ -122,7 +122,7 @@ abstract class AbstractOnceViewHelper extends AbstractConditionViewHelper
     protected static function removeIfExpired(array $arguments)
     {
         $id = static::getIdentifier($arguments);
-        if (isset(self::$identifiers[$id]) && self::$identifiers[$id] <= time() - $arguments['ttl']) {
+        if (isset(self::$identifiers[$id]) && self::$identifiers[$id] <= \time() - $arguments['ttl']) {
             unset(self::$identifiers[$id]);
         }
     }

--- a/Classes/ViewHelpers/Once/CookieViewHelper.php
+++ b/Classes/ViewHelpers/Once/CookieViewHelper.php
@@ -33,7 +33,7 @@ class CookieViewHelper extends AbstractOnceViewHelper
     {
         $identifier = static::getIdentifier($arguments);
         $domain = $arguments['lockToDomain'] ? $_SERVER['HTTP_HOST'] : null;
-        setcookie($identifier, '1', time() + $arguments['ttl'], null, $domain);
+        \setcookie($identifier, '1', \time() + $arguments['ttl'], null, $domain);
     }
 
     /**
@@ -67,6 +67,6 @@ class CookieViewHelper extends AbstractOnceViewHelper
     {
         $identifier = static::getIdentifier($arguments);
         unset($_SESSION[$identifier], $_COOKIE[$identifier]);
-        setcookie($identifier, null, time() - 1);
+        \setcookie($identifier, null, \time() - 1);
     }
 }

--- a/Classes/ViewHelpers/Once/InstanceViewHelper.php
+++ b/Classes/ViewHelpers/Once/InstanceViewHelper.php
@@ -37,7 +37,7 @@ class InstanceViewHelper extends AbstractOnceViewHelper
             return $arguments['identifier'];
         }
         $request = static::$currentRenderingContext->getControllerContext()->getRequest();
-        $identifier = implode('_', [
+        $identifier = \implode('_', [
             $request->getControllerActionName(),
             $request->getControllerName(),
             $request->getPluginName(),
@@ -53,7 +53,7 @@ class InstanceViewHelper extends AbstractOnceViewHelper
     protected static function storeIdentifier(array $arguments)
     {
         $identifier = static::getIdentifier($arguments);
-        if (false === is_array($GLOBALS[static::class])) {
+        if (false === \is_array($GLOBALS[static::class])) {
             $GLOBALS[static::class] = [];
         }
         $GLOBALS[static::class][$identifier] = true;

--- a/Classes/ViewHelpers/Once/SessionViewHelper.php
+++ b/Classes/ViewHelpers/Once/SessionViewHelper.php
@@ -35,8 +35,8 @@ class SessionViewHelper extends AbstractOnceViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        if ('' === session_id()) {
-            session_start();
+        if ('' === \session_id()) {
+            \session_start();
         }
         return parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
     }
@@ -49,10 +49,10 @@ class SessionViewHelper extends AbstractOnceViewHelper
     {
         $identifier = static::getIdentifier($arguments);
         $index = static::class;
-        if (false === is_array($_SESSION[$index])) {
+        if (false === \is_array($_SESSION[$index])) {
             $_SESSION[$index] = [];
         }
-        $_SESSION[$index][$identifier] = time();
+        $_SESSION[$index][$identifier] = \time();
     }
 
     /**
@@ -75,7 +75,7 @@ class SessionViewHelper extends AbstractOnceViewHelper
         $id = static::getIdentifier($arguments);
         $index = static::class;
         $existsInSession = (boolean) (true === isset($_SESSION[$index]) && true === isset($_SESSION[$index][$id]));
-        if (true === $existsInSession && time() - $arguments['ttl'] >= $_SESSION[$index][$id]) {
+        if (true === $existsInSession && \time() - $arguments['ttl'] >= $_SESSION[$index][$id]) {
             unset($_SESSION[$index][$id]);
         }
     }

--- a/Classes/ViewHelpers/OrViewHelper.php
+++ b/Classes/ViewHelpers/OrViewHelper.php
@@ -62,21 +62,21 @@ class OrViewHelper extends AbstractViewHelper
     {
         $alternative = $arguments['alternative'];
         $arguments = (array) $arguments['arguments'];
-        if (0 === count($arguments)) {
+        if (0 === \count($arguments)) {
             $arguments = null;
         }
-        if (0 === strpos($alternative, 'LLL:EXT:')) {
+        if (0 === \strpos($alternative, 'LLL:EXT:')) {
             $alternative = LocalizationUtility::translate($alternative, null, $arguments);
-        } elseif (0 === strpos($alternative, 'LLL:')) {
+        } elseif (0 === \strpos($alternative, 'LLL:')) {
             $extensionName = $arguments['extensionName'];
             if (null === $extensionName) {
                 $extensionName = $renderingContext->getControllerContext()->getRequest()->getControllerExtensionName();
             }
-            $translated = LocalizationUtility::translate(substr($alternative, 4), $extensionName ?: 'core', $arguments);
+            $translated = LocalizationUtility::translate(\substr($alternative, 4), $extensionName ?: 'core', $arguments);
             if (null !== $translated) {
                 $alternative = $translated;
             }
         }
-        return null !== $arguments && false === empty($alternative) ? vsprintf($alternative, $arguments) : $alternative;
+        return null !== $arguments && false === empty($alternative) ? \vsprintf($alternative, $arguments) : $alternative;
     }
 }

--- a/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
+++ b/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
@@ -34,7 +34,7 @@ class AbsoluteUrlViewHelper extends AbstractViewHelper implements CompilableInte
         RenderingContextInterface $renderingContext
     ) {
         $url = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
-        if (0 !== strpos($url, GeneralUtility::getIndpEnv('TYPO3_SITE_URL'))) {
+        if (0 !== \strpos($url, GeneralUtility::getIndpEnv('TYPO3_SITE_URL'))) {
             $url = GeneralUtility::getIndpEnv('TYPO3_SITE_URL') . $url;
         }
         return $url;

--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -53,8 +53,8 @@ class BreadCrumbViewHelper extends AbstractMenuViewHelper
         $entryLevel = $this->arguments['entryLevel'];
         $endLevel = $this->arguments['endLevel'];
         $rawRootLineData = $this->pageService->getRootLine($pageUid);
-        $rawRootLineData = array_reverse($rawRootLineData);
-        $rawRootLineData = array_slice($rawRootLineData, $entryLevel, $endLevel);
+        $rawRootLineData = \array_reverse($rawRootLineData);
+        $rawRootLineData = \array_slice($rawRootLineData, $entryLevel, $endLevel);
         $rootLineData = [];
         $showHidden = (boolean) $this->arguments['showHiddenInMenu'];
         foreach ($rawRootLineData as $record) {
@@ -67,11 +67,11 @@ class BreadCrumbViewHelper extends AbstractMenuViewHelper
             }
 
             if ((true === $showHidden && true === $isHidden || false === $isHidden) && true === $isAllowedDoktype) {
-                array_push($rootLineData, $record);
+                \array_push($rootLineData, $record);
             }
         }
         $rootLine = $this->parseMenu($rootLineData);
-        if (0 === count($rootLine)) {
+        if (0 === \count($rootLine)) {
             return null;
         }
         $this->backupVariables();

--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -94,8 +94,8 @@ class AlternateViewHelper extends AbstractViewHelper
 
         $languages = $this->arguments['languages'];
         if (true === $languages instanceof \Traversable) {
-            $languages = iterator_to_array($languages);
-        } elseif (true === is_string($languages)) {
+            $languages = \iterator_to_array($languages);
+        } elseif (true === \is_string($languages)) {
             $languages = GeneralUtility::trimExplode(',', $languages, true);
         } else {
             $languages = (array) $languages;
@@ -141,7 +141,7 @@ class AlternateViewHelper extends AbstractViewHelper
         }
 
         if (false === $usePageRenderer) {
-            return trim($output);
+            return \trim($output);
         }
 
         return null;

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -62,7 +62,7 @@ class CanonicalViewHelper extends AbstractTagBasedViewHelper
         }
 
         $queryStringMethod = $this->arguments['queryStringMethod'];
-        if (!in_array($queryStringMethod, ['GET', 'POST', 'GET,POST'], true)) {
+        if (!\in_array($queryStringMethod, ['GET', 'POST', 'GET,POST'], true)) {
             throw new \InvalidArgumentException(
                 'The parameter "queryStringMethods" must be one of "GET", "POST" or "GET,POST".',
                 1475337546

--- a/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
@@ -86,7 +86,7 @@ class TitleViewHelper extends AbstractViewHelper
         } else {
             $title = $renderChildrenClosure();
         }
-        $title = trim(preg_replace('/\s+/', $arguments['whitespaceString'], $title), $arguments['whitespaceString']);
+        $title = \trim(\preg_replace('/\s+/', $arguments['whitespaceString'], $title), $arguments['whitespaceString']);
         static::getPageRenderer()->setTitle($title);
         if (true === $arguments['setIndexedDocTitle']) {
             $GLOBALS['TSFE']->indexedDocTitle = $title;

--- a/Classes/ViewHelpers/Page/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Page/InfoViewHelper.php
@@ -64,7 +64,7 @@ class InfoViewHelper extends AbstractViewHelper implements CompilableInterface
     ) {
         if (!isset($GLOBALS['TSFE']) || !$GLOBALS['TSFE']->sys_page instanceof PageRepository) {
             ErrorUtility::throwViewHelperException(
-                sprintf('ViewHelper %s does not work in backend context without a simulated frontend.', static::class),
+                \sprintf('ViewHelper %s does not work in backend context without a simulated frontend.', static::class),
                 1489931508
             );
         }
@@ -77,7 +77,7 @@ class InfoViewHelper extends AbstractViewHelper implements CompilableInterface
         $content = null;
         if (true === empty($field)) {
             $content = $page;
-        } elseif (true === is_array($page) && true === isset($page[$field])) {
+        } elseif (true === \is_array($page) && true === isset($page[$field])) {
             $content = $page[$field];
         }
 

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -116,7 +116,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
      */
     public function render()
     {
-        if (false === is_object($GLOBALS['TSFE']->sys_page)) {
+        if (false === \is_object($GLOBALS['TSFE']->sys_page)) {
             return null;
         }
         $this->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
@@ -127,7 +127,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         $this->templateVariableContainer->add($this->arguments['as'], $this->languageMenu);
         $content = $this->renderChildren();
         $this->templateVariableContainer->remove($this->arguments['as']);
-        if (0 === mb_strlen(trim($content))) {
+        if (0 === \mb_strlen(\trim($content))) {
             $content = $this->autoRender();
         }
         return $content;
@@ -141,7 +141,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
     protected function autoRender()
     {
         $content = $this->getLanguageMenu();
-        $content = trim($content);
+        $content = \trim($content);
         if (false === empty($content)) {
             $this->tag->setContent($content);
             $content = $this->tag->render();
@@ -158,7 +158,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
     {
         $tagName = $this->arguments['tagNameChildren'];
         $html = [];
-        $itemCount = count($this->languageMenu);
+        $itemCount = \count($this->languageMenu);
         foreach ($this->languageMenu as $index => $var) {
             $class = '';
             $classes = [];
@@ -173,17 +173,17 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
             } elseif (($itemCount - 1) === $index) {
                 $classes[] = 'last';
             }
-            if (0 < count($classes)) {
-                $class = ' class="' . implode(' ', $classes) . '" ';
+            if (0 < \count($classes)) {
+                $class = ' class="' . \implode(' ', $classes) . '" ';
             }
             if (true === (boolean) $var['current'] && false === (boolean) $this->arguments['linkCurrent']) {
                 $html[] = '<' . $tagName . $class . '>' . $this->getLayout($var) . '</' . $tagName . '>';
             } else {
-                $html[] = '<' . $tagName . $class . '><a href="' . htmlspecialchars($var['url']) . '">' .
+                $html[] = '<' . $tagName . $class . '><a href="' . \htmlspecialchars($var['url']) . '">' .
                     $this->getLayout($var) . '</a></' . $tagName . '>';
             }
         }
-        return implode(LF, $html);
+        return \implode(LF, $html);
     }
 
     /**
@@ -195,13 +195,13 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
     protected function getLanguageFlagSrc($iso)
     {
         if ('' !== $this->arguments['flagPath']) {
-            $path = trim($this->arguments['flagPath']);
+            $path = \trim($this->arguments['flagPath']);
         } else {
             $path = CoreUtility::getLanguageFlagIconPath();
         }
 
-        $imgType = trim($this->arguments['flagImageType']);
-        return $path . strtoupper($iso) . '.' . $imgType;
+        $imgType = \trim($this->arguments['flagImageType']);
+        return $path . \strtoupper($iso) . '.' . $imgType;
     }
 
     /**
@@ -212,7 +212,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
      */
     protected function getLayout(array $language)
     {
-        $flagImage = false !== stripos($this->arguments['layout'], 'flag') ? $this->getFlagImage($language) : '';
+        $flagImage = false !== \stripos($this->arguments['layout'], 'flag') ? $this->getFlagImage($language) : '';
         $label = $language['label'];
         switch ($this->arguments['layout']) {
             case 'flag':
@@ -278,10 +278,10 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         $select = 'uid,title,flag';
         $from = 'sys_language';
         $limitLanguages = static::arrayFromArrayOrTraversableOrCSVStatic($this->arguments['languages'] ?? []);
-        $limitLanguages = array_filter($limitLanguages);
+        $limitLanguages = \array_filter($limitLanguages);
 
         if (!empty($limitLanguages)) {
-            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => -1, 'uidInList' => implode(',', $limitLanguages)]);
+            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => -1, 'uidInList' => \implode(',', $limitLanguages)]);
         } else {
             $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => 'root']);
         }
@@ -314,13 +314,13 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         }
 
         // Select all language overlay records on the current page. Each represents a possibility for a language.
-        $table = version_compare(TYPO3_branch, '9.5', '<') ? 'pages_language_overlay' : 'pages';
+        $table = \version_compare(TYPO3_branch, '9.5', '<') ? 'pages_language_overlay' : 'pages';
         $sysLang = $GLOBALS['TSFE']->cObj->getRecords($table, ['selectFields' => 'sys_language_uid', 'pidInList' => $this->getPageUid(), 'languageField' => 0]);
-        $languageUids = array_column($sysLang, 'sys_language_uid');
+        $languageUids = \array_column($sysLang, 'sys_language_uid');
 
         foreach ($languageMenu as $key => $value) {
             $current = $GLOBALS['TSFE']->sys_language_uid === (integer) $key ? 1 : 0;
-            $inactive = in_array($key, $languageUids) || (integer) $key === $this->defaultLangUid ? 0 : 1;
+            $inactive = \in_array($key, $languageUids) || (integer) $key === $this->defaultLangUid ? 0 : 1;
             $url = $this->getLanguageUrl($key);
             if (true === empty($url)) {
                 $url = GeneralUtility::getIndpEnv('REQUEST_URI');
@@ -345,7 +345,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
      */
     protected function getLanguageUrl($uid)
     {
-        $excludedVars = trim((string) $this->arguments['excludeQueryVars']);
+        $excludedVars = \trim((string) $this->arguments['excludeQueryVars']);
         $config = [
             'parameter' => $this->getPageUid(),
             'returnLast' => 'url',
@@ -357,7 +357,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
                 'exclude' => 'id,L,cHash' . ($excludedVars ? ',' . $excludedVars : '')
             ]
         ];
-        if (true === is_array($this->arguments['configuration'])) {
+        if (true === \is_array($this->arguments['configuration'])) {
             $config = $this->mergeArrays($config, $this->arguments['configuration']);
         }
         return $this->cObj->typoLink('', $config);

--- a/Classes/ViewHelpers/Page/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageViewHelper.php
@@ -68,14 +68,14 @@ class LanguageViewHelper extends AbstractViewHelper implements CompilableInterfa
 
         $languages = $arguments['languages'];
         if (true === $languages instanceof \Traversable) {
-            $languages = iterator_to_array($languages);
-        } elseif (true === is_string($languages)) {
+            $languages = \iterator_to_array($languages);
+        } elseif (true === \is_string($languages)) {
             $languages = GeneralUtility::trimExplode(',', $languages, true);
         } else {
             $languages = (array) $languages;
         }
 
-        $pageUid = intval($arguments['pageUid']);
+        $pageUid = \intval($arguments['pageUid']);
         $normalWhenNoLanguage = $arguments['normalWhenNoLanguage'];
 
         if (0 === $pageUid) {

--- a/Classes/ViewHelpers/Page/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/LinkViewHelper.php
@@ -145,7 +145,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
         // Check if link wizard link
         $pageUid = $this->arguments['pageUid'];
         $additionalParameters = (array) $this->arguments['additionalParams'];
-        if (false === is_numeric($pageUid)) {
+        if (false === \is_numeric($pageUid)) {
             $linkConfig = GeneralUtility::unQuoteFilenames($pageUid, true);
             if (true === isset($linkConfig[0])) {
                 $pageUid = $linkConfig[0];
@@ -160,7 +160,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
                 $this->tag->addAttribute('title', $linkConfig[3]);
             }
             if (true === isset($linkConfig[4]) && '-' !== $linkConfig[4]) {
-                $additionalParametersString = trim($linkConfig[4], '&');
+                $additionalParametersString = \trim($linkConfig[4], '&');
                 $additionalParametersArray = GeneralUtility::trimExplode('&', $additionalParametersString);
                 foreach ($additionalParametersArray as $parameter) {
                     list($key, $value) = GeneralUtility::trimExplode('=', $parameter);
@@ -228,7 +228,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
         if ($showAccessProtected && $this->pageService->isAccessGranted($page)) {
             $class[] = $this->arguments['classAccessGranted'];
         }
-        $additionalCssClasses = implode(' ', $class);
+        $additionalCssClasses = \implode(' ', $class);
 
         $uriBuilder = $this->renderingContext->getControllerContext()->getUriBuilder();
         $uri = $uriBuilder->reset()
@@ -243,7 +243,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
             ->setArgumentsToBeExcludedFromQueryString((array) $this->arguments['argumentsToBeExcludedFromQueryString'])
             ->build();
         $this->tag->addAttribute('href', $uri);
-        $classes = trim($this->arguments['class'] . ' ' . $additionalCssClasses);
+        $classes = \trim($this->arguments['class'] . ' ' . $additionalCssClasses);
         if (!empty($classes)) {
             $this->tag->addAttribute('class', $classes);
         } else {

--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -71,7 +71,7 @@ class FalViewHelper extends ResourcesFalViewHelper
             }
             /** @var PageRepository $pageRepository */
             $localisation = $pageRepository->getPageOverlay($record, $this->getCurrentLanguageUid());
-            if (is_array($localisation)) {
+            if (\is_array($localisation)) {
                 $record = $localisation;
             }
         }
@@ -100,8 +100,8 @@ class FalViewHelper extends ResourcesFalViewHelper
         // method on this class. Calling $this->getResources() would yield wrong result
         // for the purpose of this method.
         $resources = parent::getResources($pageRecord);
-        if (null !== $limit && count($resources) > $limit) {
-            $resources = array_slice($resources, 0, $limit);
+        if (null !== $limit && \count($resources) > $limit) {
+            $resources = \array_slice($resources, 0, $limit);
         }
         return $resources;
     }

--- a/Classes/ViewHelpers/Random/NumberViewHelper.php
+++ b/Classes/ViewHelpers/Random/NumberViewHelper.php
@@ -79,14 +79,14 @@ class NumberViewHelper extends AbstractViewHelper implements CompilableInterface
         $maximum = $arguments['maximum'];
         $minimumDecimals = $arguments['minimumDecimals'];
         $maximumDecimals = $arguments['maximumDecimals'];
-        $natural = rand($minimum, $maximum);
+        $natural = \rand($minimum, $maximum);
         if (0 === (integer) $minimumDecimals && 0 === (integer) $maximumDecimals) {
             return $natural;
         }
-        $decimals = array_fill(0, rand($minimumDecimals, $maximumDecimals), 0);
-        $decimals = array_map(function () {
-            return rand(0, 9);
+        $decimals = \array_fill(0, \rand($minimumDecimals, $maximumDecimals), 0);
+        $decimals = \array_map(function () {
+            return \rand(0, 9);
         }, $decimals);
-        return floatval($natural . '.' . implode('', $decimals));
+        return \floatval($natural . '.' . \implode('', $decimals));
     }
 }

--- a/Classes/ViewHelpers/Random/StringViewHelper.php
+++ b/Classes/ViewHelpers/Random/StringViewHelper.php
@@ -59,13 +59,13 @@ class StringViewHelper extends AbstractViewHelper implements CompilableInterface
         $maximumLength = (integer) $arguments['maximumLength'];
         $characters = $arguments['characters'];
         if ($minimumLength != $maximumLength) {
-            $length = rand($minimumLength, $maximumLength);
+            $length = \rand($minimumLength, $maximumLength);
         } else {
             $length = $length !== null ? $length : $minimumLength;
         }
         $string = '';
         for ($i = 0; $i < $length; $i++) {
-            $randomIndex = mt_rand(0, mb_strlen($characters) - 1);
+            $randomIndex = \mt_rand(0, \mb_strlen($characters) - 1);
             $string .= $characters{$randomIndex};
         }
         return $string;

--- a/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
+++ b/Classes/ViewHelpers/Render/AbstractRenderViewHelper.php
@@ -93,7 +93,7 @@ abstract class AbstractRenderViewHelper extends AbstractViewHelper
         $namespaces = [];
         foreach ((array) $arguments['namespaces'] as $namespaceIdentifier => $namespace) {
             $addedOverriddenNamespace = '{namespace ' . $namespaceIdentifier . '=' . $namespace . '}';
-            array_push($namespaces, $addedOverriddenNamespace);
+            \array_push($namespaces, $addedOverriddenNamespace);
         }
         return $namespaces;
     }
@@ -105,7 +105,7 @@ abstract class AbstractRenderViewHelper extends AbstractViewHelper
     protected static function getPreparedClonedView(RenderingContextInterface $renderingContext)
     {
         $view = static::getPreparedView();
-        if (method_exists($renderingContext, 'getControllerContext')) {
+        if (\method_exists($renderingContext, 'getControllerContext')) {
             $controllerContext = clone $renderingContext->getControllerContext();
             $view->setControllerContext($controllerContext);
             $view->setFormat($controllerContext->getRequest()->getFormat());

--- a/Classes/ViewHelpers/Render/AsciiViewHelper.php
+++ b/Classes/ViewHelpers/Render/AsciiViewHelper.php
@@ -70,13 +70,13 @@ class AsciiViewHelper extends AbstractViewHelper implements CompilableInterface
         RenderingContextInterface $renderingContext
     ) {
         $ascii = $renderChildrenClosure();
-        if (true === is_numeric($ascii)) {
-            return chr((integer) $ascii);
+        if (true === \is_numeric($ascii)) {
+            return \chr((integer) $ascii);
         }
-        if (true === is_array($ascii) || true === $ascii instanceof \Traversable) {
+        if (true === \is_array($ascii) || true === $ascii instanceof \Traversable) {
             $string = '';
             foreach ($ascii as $characterNumber) {
-                $string .= chr($characterNumber);
+                $string .= \chr($characterNumber);
             }
             return $string;
         }

--- a/Classes/ViewHelpers/Render/CacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/CacheViewHelper.php
@@ -82,10 +82,10 @@ class CacheViewHelper extends AbstractRenderViewHelper implements CompilableInte
         RenderingContextInterface $renderingContext
     ) {
         $identity = $arguments['identity'];
-        if (false === ctype_alnum(preg_replace('/[\-_]/i', '', $identity))) {
+        if (false === \ctype_alnum(\preg_replace('/[\-_]/i', '', $identity))) {
             if (true === $identity instanceof DomainObjectInterface) {
-                $identity = get_class($identity) . self::ID_SEPARATOR . $identity->getUid();
-            } elseif (true === method_exists($identity, '__toString')) {
+                $identity = \get_class($identity) . self::ID_SEPARATOR . $identity->getUid();
+            } elseif (true === \method_exists($identity, '__toString')) {
                 $identity = (string) $identity;
             } else {
                 throw new \RuntimeException(
@@ -96,7 +96,7 @@ class CacheViewHelper extends AbstractRenderViewHelper implements CompilableInte
         }
 
         // Hash the cache-key to circumvent disallowed chars
-        $identity = sha1($identity);
+        $identity = \sha1($identity);
 
         if (true === static::has($identity)) {
             return static::retrieve($identity);

--- a/Classes/ViewHelpers/Render/InlineViewHelper.php
+++ b/Classes/ViewHelpers/Render/InlineViewHelper.php
@@ -57,9 +57,9 @@ class InlineViewHelper extends AbstractRenderViewHelper implements CompilableInt
     ) {
         $content = $renderChildrenClosure();
         $namespaces = static::getPreparedNamespaces($arguments);
-        $namespaceHeader = implode(LF, $namespaces);
+        $namespaceHeader = \implode(LF, $namespaces);
         foreach ($namespaces as $namespace) {
-            $content = str_replace($namespace, '', $content);
+            $content = \str_replace($namespace, '', $content);
         }
         $view = static::getPreparedClonedView($renderingContext);
         $view->setTemplateSource($namespaceHeader . $content);

--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -76,7 +76,7 @@ class RequestViewHelper extends AbstractRenderViewHelper implements CompilableIn
         $extensionName = $arguments['extensionName'];
         $pluginName = $arguments['pluginName'];
         $vendorName = $arguments['vendorName'];
-        $requestArguments = is_array($arguments['arguments']) ? $arguments['arguments'] : [];
+        $requestArguments = \is_array($arguments['arguments']) ? $arguments['arguments'] : [];
         $configurationManager = static::getConfigurationManager();
         $objectManager = static::getObjectManager();
         $contentObjectBackup = $configurationManager->getContentObject();
@@ -121,7 +121,7 @@ class RequestViewHelper extends AbstractRenderViewHelper implements CompilableIn
                 throw $error;
             }
             if (false === empty($arguments['onError'])) {
-                return sprintf($arguments['onError'], [$error->getMessage()], $error->getCode());
+                return \sprintf($arguments['onError'], [$error->getMessage()], $error->getCode());
             }
             return $error->getMessage() . ' (' . $error->getCode() . ')';
         }

--- a/Classes/ViewHelpers/Render/TemplateViewHelper.php
+++ b/Classes/ViewHelpers/Render/TemplateViewHelper.php
@@ -81,7 +81,7 @@ class TemplateViewHelper extends AbstractRenderViewHelper
         $file = GeneralUtility::getFileAbsFileName($file);
         $view = static::getPreparedView();
         $view->setTemplatePathAndFilename($file);
-        if (is_array($this->arguments['variables'])) {
+        if (\is_array($this->arguments['variables'])) {
             $view->assignMultiple($this->arguments['variables']);
         }
         $format = $this->arguments['format'];
@@ -89,12 +89,12 @@ class TemplateViewHelper extends AbstractRenderViewHelper
             $view->setFormat($format);
         }
         $paths = $this->arguments['paths'];
-        if (is_array($paths)) {
-            if (isset($paths['layoutRootPaths']) && is_array($paths['layoutRootPaths'])) {
+        if (\is_array($paths)) {
+            if (isset($paths['layoutRootPaths']) && \is_array($paths['layoutRootPaths'])) {
                 $layoutRootPaths = $this->processPathsArray($paths['layoutRootPaths']);
                 $view->setLayoutRootPaths($layoutRootPaths);
             }
-            if (isset($paths['partialRootPaths']) && is_array($paths['partialRootPaths'])) {
+            if (isset($paths['partialRootPaths']) && \is_array($paths['partialRootPaths'])) {
                 $partialRootPaths = $this->processPathsArray($paths['partialRootPaths']);
                 $view->setPartialRootPaths($partialRootPaths);
             }
@@ -110,7 +110,7 @@ class TemplateViewHelper extends AbstractRenderViewHelper
     {
         $pathsArray = [];
         foreach ($paths as $key => $path) {
-            $pathsArray[$key] = (0 === strpos($path, 'EXT:')) ? GeneralUtility::getFileAbsFileName($path) : $path;
+            $pathsArray[$key] = (0 === \strpos($path, 'EXT:')) ? GeneralUtility::getFileAbsFileName($path) : $path;
         }
 
         return $pathsArray;

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -56,7 +56,7 @@ class UncacheViewHelper extends AbstractViewHelper implements CompilableInterfac
     ) {
         $templateVariableContainer = $renderingContext->getTemplateVariableContainer();
         $partialArguments = $arguments['arguments'];
-        if (false === is_array($partialArguments)) {
+        if (false === \is_array($partialArguments)) {
             $partialArguments = [];
         }
         if (false === isset($partialArguments['settings']) && true === $templateVariableContainer->exists('settings')) {
@@ -73,7 +73,7 @@ class UncacheViewHelper extends AbstractViewHelper implements CompilableInterfac
 
         $GLOBALS['TSFE']->config['INTincScript'][$substKey] = [
             'type' => 'POSTUSERFUNC',
-            'cObj' => serialize($templateView),
+            'cObj' => \serialize($templateView),
             'postUserFunc' => 'render',
             'conf' => [
                 'partial' => $arguments['partial'],

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -149,9 +149,9 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
         foreach ($files as $file) {
             $imageInfo = $this->contentObject->getImgResource($file->getUid(), $setup);
 
-            if (false === is_array($imageInfo)) {
+            if (false === \is_array($imageInfo)) {
                 throw new Exception(
-                    'Could not get image resource for "' . htmlspecialchars($file->getCombinedIdentifier()) . '".',
+                    'Could not get image resource for "' . \htmlspecialchars($file->getCombinedIdentifier()) . '".',
                     1253191060
                 );
             }
@@ -162,7 +162,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
             if (true === GeneralUtility::isValidUrl($imageInfo[3])) {
                 $imageSource = $imageInfo[3];
             } else {
-                $imageSource = $GLOBALS['TSFE']->absRefPrefix . str_replace('%2F', '/', rawurlencode($imageInfo[3]));
+                $imageSource = $GLOBALS['TSFE']->absRefPrefix . \str_replace('%2F', '/', \rawurlencode($imageInfo[3]));
             }
 
             if (true === $onlyProperties) {
@@ -193,8 +193,8 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
     protected function simulateFrontendEnvironment()
     {
         $this->tsfeBackup = isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
-        $this->workingDirectoryBackup = getcwd();
-        chdir(constant('PATH_site'));
+        $this->workingDirectoryBackup = \getcwd();
+        \chdir(\constant('PATH_site'));
         $typoScriptSetup = $this->configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );
@@ -202,7 +202,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = 0;
         $template->init();
-        $template->getFileName_backPath = constant('PATH_site');
+        $template->getFileName_backPath = \constant('PATH_site');
         $GLOBALS['TSFE']->tmpl = $template;
         $GLOBALS['TSFE']->tmpl->setup = $typoScriptSetup;
         $GLOBALS['TSFE']->config = $typoScriptSetup;
@@ -217,7 +217,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
     protected function resetFrontendEnvironment()
     {
         $GLOBALS['TSFE'] = $this->tsfeBackup;
-        chdir($this->workingDirectoryBackup);
+        \chdir($this->workingDirectoryBackup);
     }
 
     /**

--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -112,7 +112,7 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
                 ->execute()
                 ->fetchAll();
 
-            $fileUids = array_unique(array_column($rows, 'uid_foreign'));
+            $fileUids = \array_unique(\array_column($rows, 'uid_foreign'));
 
             if (true === empty($identifier)) {
                 foreach ($fileUids as $fileUid) {
@@ -136,15 +136,15 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
         foreach ($identifier as $i) {
             try {
                 if (true === $treatIdAsUid) {
-                    $file = $resourceFactory->getFileObject(intval($i));
+                    $file = $resourceFactory->getFileObject(\intval($i));
                 } elseif (true === $treatIdAsReference) {
-                    $fileReference = $resourceFactory->getFileReferenceObject(intval($i));
+                    $fileReference = $resourceFactory->getFileReferenceObject(\intval($i));
                     $file = $fileReference->getOriginalFile();
                 } else {
                     $file = $resourceFactory->getFileObjectFromCombinedIdentifier($i);
                 }
 
-                if (true === isset($fileUids) && false === in_array($file->getUid(), $fileUids)) {
+                if (true === isset($fileUids) && false === \in_array($file->getUid(), $fileUids)) {
                     continue;
                 }
 
@@ -175,8 +175,8 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
         }
 
         if (true === $argument instanceof \Traversable) {
-            $argument = iterator_to_array($argument);
-        } elseif (true === is_string($argument)) {
+            $argument = \iterator_to_array($argument);
+        } elseif (true === \is_string($argument)) {
             $argument = GeneralUtility::trimExplode(',', $argument, true);
         } else {
             $argument = (array) $argument;
@@ -194,7 +194,7 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
      */
     private function getTablenameForSystemConfiguration()
     {
-        if (ExtensionManagementUtility::isLoaded('filemetadata') || version_compare(TYPO3_version, '8.0.0', '>=')) {
+        if (ExtensionManagementUtility::isLoaded('filemetadata') || \version_compare(TYPO3_version, '8.0.0', '>=')) {
             return 'sys_file_metadata';
         }
         return 'sys_file';

--- a/Classes/ViewHelpers/Resource/FileViewHelper.php
+++ b/Classes/ViewHelpers/Resource/FileViewHelper.php
@@ -43,8 +43,8 @@ class FileViewHelper extends AbstractResourceViewHelper
     public function render()
     {
         $files = (array) $this->getFiles($this->arguments['onlyProperties']);
-        if (1 === count($files)) {
-            $files = array_shift($files);
+        if (1 === \count($files)) {
+            $files = \array_shift($files);
         }
         return $this->renderChildrenWithVariableOrReturnInput($files);
     }

--- a/Classes/ViewHelpers/Resource/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/ImageViewHelper.php
@@ -111,7 +111,7 @@ class ImageViewHelper extends AbstractImageViewHelper
         }
         $as = $this->arguments['as'];
         if (true === empty($as)) {
-            return implode('', $tags);
+            return \implode('', $tags);
         }
         return $this->renderChildrenWithVariableOrReturnInput($info);
     }

--- a/Classes/ViewHelpers/Resource/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/LanguageViewHelper.php
@@ -117,7 +117,7 @@ class LanguageViewHelper extends AbstractViewHelper
         $path = $this->arguments['path'];
         $absoluteFileName = GeneralUtility::getFileAbsFileName($this->arguments['path']);
 
-        if (false === file_exists($absoluteFileName)) {
+        if (false === \file_exists($absoluteFileName)) {
             $extensionName = $this->getResolvedExtensionName();
             $extensionKey = GeneralUtility::camelCaseToLowerCaseUnderscored($extensionName);
             $absoluteFileName = ExtensionManagementUtility::extPath($extensionKey, $path);
@@ -155,7 +155,7 @@ class LanguageViewHelper extends AbstractViewHelper
      */
     protected function getLabelsFromTarget($labels)
     {
-        if (true === is_array($labels)) {
+        if (true === \is_array($labels)) {
             foreach ($labels as $labelKey => $label) {
                 $labels[$labelKey] = $label[0]['target'];
             }
@@ -193,7 +193,7 @@ class LanguageViewHelper extends AbstractViewHelper
 
         if ('FE' === TYPO3_MODE) {
             $language = $GLOBALS['TSFE']->lang;
-        } elseif (true === is_object($GLOBALS['LANG'])) {
+        } elseif (true === \is_object($GLOBALS['LANG'])) {
             $language = $GLOBALS['LANG']->lang;
         }
 

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -131,7 +131,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
             $table = $this->table;
         }
 
-        if (true === empty($table) || false === is_string($table)) {
+        if (true === empty($table) || false === \is_string($table)) {
             ErrorUtility::throwViewHelperException('The "table" argument must be specified and must be a string.', 1384611336);
         }
 
@@ -148,7 +148,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
             $field = $this->field;
         }
 
-        if (true === empty($field) || false === is_string($field)) {
+        if (true === empty($field) || false === \is_string($field)) {
             ErrorUtility::throwViewHelperException('The "field" argument must be specified and must be a string.', 1384611355);
         }
 
@@ -173,7 +173,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
 
         $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT, ':id');
 
-        return reset($queryBuilder
+        return \reset($queryBuilder
                 ->select('*')
                 ->from($table)
                 ->where(

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -101,7 +101,7 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
      */
     protected function getFileReferences($table, $field, $uidOrRecord)
     {
-        if (is_array($uidOrRecord)) {
+        if (\is_array($uidOrRecord)) {
             $record = $uidOrRecord;
         } else {
             $record = $this->getRecord($uidOrRecord);
@@ -205,7 +205,7 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
             $references = $ids;
 
             if (empty($references) === false) {
-                $referenceUids = array_keys($references);
+                $referenceUids = \array_keys($references);
                 $fileReferences = [];
                 if (empty($referenceUids) === false) {
                     foreach ($referenceUids as $referenceUid) {

--- a/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
+++ b/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
@@ -147,52 +147,52 @@ abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper
         $evaluationType = $this->arguments['evaluationType'];
         $evaluations = [];
         if (true === (boolean) $this->arguments['anyFrontendUser']) {
-            $evaluations['anyFrontendUser'] = intval($this->assertFrontendUserLoggedIn());
+            $evaluations['anyFrontendUser'] = \intval($this->assertFrontendUserLoggedIn());
         }
         if (true === (boolean) $this->arguments['anyFrontendUserGroup']) {
-            $evaluations['anyFrontendUserGroup'] = intval($this->assertFrontendUserGroupLoggedIn());
+            $evaluations['anyFrontendUserGroup'] = \intval($this->assertFrontendUserGroupLoggedIn());
         }
         if (true === isset($this->arguments['frontendUser'])) {
             $evaluations['frontendUser'] =
-                intval($this->assertFrontendUserLoggedIn($this->arguments['frontendUser']));
+                \intval($this->assertFrontendUserLoggedIn($this->arguments['frontendUser']));
         }
         if (true === isset($this->arguments['frontendUsers'])) {
             $evaluations['frontendUsers'] =
-                intval($this->assertFrontendUsersLoggedIn($this->arguments['frontendUsers']));
+                \intval($this->assertFrontendUsersLoggedIn($this->arguments['frontendUsers']));
         }
         if (true === isset($this->arguments['frontendUserGroup'])) {
             $evaluations['frontendUserGroup'] =
-                intval($this->assertFrontendUserGroupLoggedIn($this->arguments['frontendUserGroup']));
+                \intval($this->assertFrontendUserGroupLoggedIn($this->arguments['frontendUserGroup']));
         }
         if (true === isset($this->arguments['frontendUserGroups'])) {
             $evaluations['frontendUserGroups'] =
-                intval($this->assertFrontendUserGroupLoggedIn($this->arguments['frontendUserGroups']));
+                \intval($this->assertFrontendUserGroupLoggedIn($this->arguments['frontendUserGroups']));
         }
         if (true === (boolean) $this->arguments['anyBackendUser']) {
-            $evaluations['anyBackendUser'] = intval($this->assertBackendUserLoggedIn());
+            $evaluations['anyBackendUser'] = \intval($this->assertBackendUserLoggedIn());
         }
         if (true === (boolean) $this->arguments['anyBackendUserGroup']) {
-            $evaluations['anyBackendUserGroup'] = intval($this->assertBackendUserGroupLoggedIn());
+            $evaluations['anyBackendUserGroup'] = \intval($this->assertBackendUserGroupLoggedIn());
         }
         if (true === isset($this->arguments['backendUser'])) {
-            $evaluations['backendUser'] = intval($this->assertBackendUserLoggedIn($this->arguments['backendUser']));
+            $evaluations['backendUser'] = \intval($this->assertBackendUserLoggedIn($this->arguments['backendUser']));
         }
         if (true === isset($this->arguments['backendUsers'])) {
-            $evaluations['backendUsers'] = intval($this->assertBackendUserLoggedIn($this->arguments['backendUsers']));
+            $evaluations['backendUsers'] = \intval($this->assertBackendUserLoggedIn($this->arguments['backendUsers']));
         }
         if (true === isset($this->arguments['backendUserGroup'])) {
             $evaluations['backendUserGroup'] =
-                intval($this->assertBackendUserGroupLoggedIn($this->arguments['backendUserGroup']));
+                \intval($this->assertBackendUserGroupLoggedIn($this->arguments['backendUserGroup']));
         }
         if (true === isset($this->arguments['backendUserGroups'])) {
             $evaluations['backendUserGroups'] =
-                intval($this->assertBackendUserGroupLoggedIn($this->arguments['backendUserGroups']));
+                \intval($this->assertBackendUserGroupLoggedIn($this->arguments['backendUserGroups']));
         }
         if (true === (boolean) $this->arguments['admin']) {
-            $evaluations['admin'] = intval($this->assertAdminLoggedIn());
+            $evaluations['admin'] = \intval($this->assertAdminLoggedIn());
         }
-        $sum = array_sum($evaluations);
-        return (boolean) ('AND' === $evaluationType ? count($evaluations) === $sum : $sum > 0);
+        $sum = \array_sum($evaluations);
+        return (boolean) ('AND' === $evaluationType ? \count($evaluations) === $sum : $sum > 0);
     }
 
     /**
@@ -216,7 +216,7 @@ abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper
                 return false;
             }
         }
-        return (boolean) (true === is_object($currentFrontendUser));
+        return (boolean) (true === \is_object($currentFrontendUser));
     }
 
     /**
@@ -281,7 +281,7 @@ abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper
                 return false;
             }
         }
-        return (boolean) (true === is_array($currentBackendUser));
+        return (boolean) (true === \is_array($currentBackendUser));
     }
 
     /**
@@ -299,17 +299,17 @@ abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper
             return false;
         }
         $currentBackendUser = $this->getCurrentBackendUser();
-        $currentUserGroups = trim($currentBackendUser['usergroup'], ',');
-        $userGroups = false === empty($currentUserGroups) ? explode(',', $currentUserGroups) : [];
-        if (0 === count($userGroups)) {
+        $currentUserGroups = \trim($currentBackendUser['usergroup'], ',');
+        $userGroups = false === empty($currentUserGroups) ? \explode(',', $currentUserGroups) : [];
+        if (0 === \count($userGroups)) {
             return false;
         }
-        if (true === is_string($groups)) {
-            $groups = trim($groups, ',');
-            $groups = false === empty($groups) ? explode(',', $groups) : [];
+        if (true === \is_string($groups)) {
+            $groups = \trim($groups, ',');
+            $groups = false === empty($groups) ? \explode(',', $groups) : [];
         }
-        if (0 < count($groups)) {
-            return (boolean) (0 < count(array_intersect($userGroups, $groups)));
+        if (0 < \count($groups)) {
+            return (boolean) (0 < \count(\array_intersect($userGroups, $groups)));
         }
         return false;
     }

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -32,7 +32,7 @@ class DateTimeViewHelper extends AbstractViewHelper implements CompilableInterfa
      */
     protected static function getTimestamp()
     {
-        return time();
+        return \time();
     }
 
     /**

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -42,6 +42,6 @@ class TimestampViewHelper extends AbstractViewHelper implements CompilableInterf
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return time();
+        return \time();
     }
 }

--- a/Classes/ViewHelpers/System/UniqIdViewHelper.php
+++ b/Classes/ViewHelpers/System/UniqIdViewHelper.php
@@ -62,7 +62,7 @@ class UniqIdViewHelper extends AbstractViewHelper implements CompilableInterface
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $uniqueId = uniqid($arguments['prefix'], $arguments['moreEntropy']);
+        $uniqueId = \uniqid($arguments['prefix'], $arguments['moreEntropy']);
         return $uniqueId;
     }
 }

--- a/Classes/ViewHelpers/TagViewHelper.php
+++ b/Classes/ViewHelpers/TagViewHelper.php
@@ -41,8 +41,8 @@ class TagViewHelper extends AbstractTagBasedViewHelper
      */
     public function render()
     {
-        $this->arguments['class'] = trim((string) $this->arguments['class']);
-        $this->arguments['class'] = str_replace(',', ' ', $this->arguments['class']);
+        $this->arguments['class'] = \trim((string) $this->arguments['class']);
+        $this->arguments['class'] = \str_replace(',', ' ', $this->arguments['class']);
         $content = $this->renderChildren();
         return $this->renderTag($this->arguments['name'], $content);
     }

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -85,8 +85,8 @@ class GravatarViewHelper extends AbstractViewHelper implements CompilableInterfa
         $secure = (boolean) $arguments['secure'];
 
         $url = (true === $secure ? self::GRAVATAR_SECURE_BASEURL : self::GRAVATAR_BASEURL);
-        $url .= md5(strtolower(trim($email)));
-        $query = http_build_query(['s' => $size, 'd' => $imageSet, 'r' => $maximumRating]);
+        $url .= \md5(\strtolower(\trim($email)));
+        $query = \http_build_query(['s' => $size, 'd' => $imageSet, 'r' => $maximumRating]);
         $url .= (false === empty($query) ? '?' . $query : '');
 
         return $url;

--- a/Classes/ViewHelpers/Variable/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ConvertViewHelper.php
@@ -74,11 +74,11 @@ class ConvertViewHelper extends AbstractViewHelper implements CompilableInterfac
     ) {
         $value = $renderChildrenClosure();
         $type = $arguments['type'];
-        if (gettype($value) === $type) {
+        if (\gettype($value) === $type) {
             return $value;
         }
         if (null !== $value) {
-            if ('ObjectStorage' === $type && 'array' === gettype($value)) {
+            if ('ObjectStorage' === $type && 'array' === \gettype($value)) {
                 /** @var ObjectManager $objectManager */
                 $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
                 /** @var ObjectStorage $storage */
@@ -88,16 +88,16 @@ class ConvertViewHelper extends AbstractViewHelper implements CompilableInterfac
                 }
                 $value = $storage;
             } elseif ('array' === $type && true === $value instanceof \Traversable) {
-                $value = iterator_to_array($value, false);
+                $value = \iterator_to_array($value, false);
             } elseif ('array' === $type) {
                 $value = [$value];
             } else {
-                settype($value, $type);
+                \settype($value, $type);
             }
         } else {
             if (true === isset($arguments['default'])) {
                 $default = $arguments['default'];
-                if (gettype($default) !== $type) {
+                if (\gettype($default) !== $type) {
                     throw new \RuntimeException(
                         'Supplied argument "default" is not of the type "' . $type .'"',
                         1364542576

--- a/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
@@ -71,11 +71,11 @@ class ExtensionConfigurationViewHelper extends AbstractViewHelper implements Com
             $extensionKey = GeneralUtility::camelCaseToLowerCaseUnderscored($extensionName);
         }
 
-        if (!array_key_exists($extensionKey, $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'])) {
+        if (!\array_key_exists($extensionKey, $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'])) {
             return null;
-        } elseif (!array_key_exists($extensionKey, static::$configurations)) {
-            if (is_string($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey])) {
-                $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey]);
+        } elseif (!\array_key_exists($extensionKey, static::$configurations)) {
+            if (\is_string($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey])) {
+                $extConf = \unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey]);
             } else {
                 $extConf = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extensionKey];
             }

--- a/Classes/ViewHelpers/Variable/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/GetViewHelper.php
@@ -81,24 +81,24 @@ class GetViewHelper extends AbstractViewHelper implements CompilableInterface
         $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);
         $name = $arguments['name'];
         $useRawKeys = $arguments['useRawKeys'];
-        if (false === strpos($name, '.')) {
+        if (false === \strpos($name, '.')) {
             if (true === $variableProvider->exists($name)) {
                 return $variableProvider->get($name);
             }
         } else {
-            $segments = explode('.', $name);
-            $lastSegment = array_shift($segments);
+            $segments = \explode('.', $name);
+            $lastSegment = \array_shift($segments);
             $templateVariableRootName = $lastSegment;
             if (true === $variableProvider->exists($templateVariableRootName)) {
                 $templateVariableRoot = $variableProvider->get($templateVariableRootName);
                 if (true === $useRawKeys) {
-                    return ObjectAccess::getPropertyPath($templateVariableRoot, implode('.', $segments));
+                    return ObjectAccess::getPropertyPath($templateVariableRoot, \implode('.', $segments));
                 }
                 try {
                     $value = $templateVariableRoot;
                     foreach ($segments as $segment) {
-                        if (true === ctype_digit($segment)) {
-                            $segment = intval($segment);
+                        if (true === \ctype_digit($segment)) {
+                            $segment = \intval($segment);
                             $index = 0;
                             $found = false;
                                 // Note: this loop approach is not a stupid solution. If you doubt this,

--- a/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
+++ b/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
@@ -62,9 +62,9 @@ class PregMatchViewHelper extends AbstractViewHelper implements CompilableInterf
             $subject = $arguments['subject'];
         }
         if (true === (boolean) $arguments['global']) {
-            preg_match_all($arguments['pattern'], $subject, $matches, PREG_SET_ORDER);
+            \preg_match_all($arguments['pattern'], $subject, $matches, PREG_SET_ORDER);
         } else {
-            preg_match($arguments['pattern'], $subject, $matches);
+            \preg_match($arguments['pattern'], $subject, $matches);
         }
         return static::renderChildrenWithVariableOrReturnInputStatic(
             $matches,

--- a/Classes/ViewHelpers/Variable/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/SetViewHelper.php
@@ -86,15 +86,15 @@ class SetViewHelper extends AbstractViewHelper implements CompilableInterface
         $name = $arguments['name'];
         $value = $renderChildrenClosure();
         $variableProvider = ViewHelperUtility::getVariableProviderFromRenderingContext($renderingContext);
-        if (false === strpos($name, '.')) {
+        if (false === \strpos($name, '.')) {
             if (true === $variableProvider->exists($name)) {
                 $variableProvider->remove($name);
             }
             $variableProvider->add($name, $value);
-        } elseif (1 === mb_substr_count($name, '.')) {
-            $parts = explode('.', $name);
-            $objectName = array_shift($parts);
-            $path = implode('.', $parts);
+        } elseif (1 === \mb_substr_count($name, '.')) {
+            $parts = \explode('.', $name);
+            $objectName = \array_shift($parts);
+            $path = \implode('.', $parts);
             if (false === $variableProvider->exists($objectName)) {
                 return null;
             }

--- a/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
+++ b/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
@@ -91,12 +91,12 @@ class TyposcriptViewHelper extends AbstractViewHelper implements CompilableInter
         $all = static::getConfigurationManager()->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );
-        $segments = explode('.', $path);
+        $segments = \explode('.', $path);
         $value = $all;
         foreach ($segments as $path) {
             $value = (true === isset($value[$path . '.']) ? $value[$path . '.'] : $value[$path]);
         }
-        if (true === is_array($value)) {
+        if (true === \is_array($value)) {
             $value = GeneralUtility::removeDotsFromTS($value);
         }
         return $value;

--- a/Tests/Unit/AssetTest.php
+++ b/Tests/Unit/AssetTest.php
@@ -107,7 +107,7 @@ class AssetTest extends AbstractTestCase
         $asset = Asset::getInstance();
         $settableProperties = ObjectAccess::getSettablePropertyNames($asset);
         foreach ($settableProperties as $propertyName) {
-            $setter = 'set' . ucfirst($propertyName);
+            $setter = 'set' . \ucfirst($propertyName);
             $asset = $asset->$setter(null);
             $this->assertInstanceOf(Asset::class, $asset, 'The ' . $setter . ' method does not support chaining');
         }
@@ -144,7 +144,7 @@ class AssetTest extends AbstractTestCase
     public function assetsAddedByFilenameUsesFileBasenameAsAssetName()
     {
         $file = $this->getAbsoluteAssetFixturePath();
-        $expectedName = pathinfo($file, PATHINFO_FILENAME);
+        $expectedName = \pathinfo($file, PATHINFO_FILENAME);
         $asset = Asset::createFromFile($file);
         $this->assertSame($asset, $GLOBALS['VhsAssets'][$expectedName]);
         $this->assertEquals(
@@ -161,11 +161,11 @@ class AssetTest extends AbstractTestCase
     {
         $file = $this->getAbsoluteAssetFixturePath();
         $asset = Asset::createFromFile($file);
-        $expectedTrimmedContent = trim(file_get_contents($file));
-        $this->assertEquals($expectedTrimmedContent, trim($asset->build()));
-        $asset->setContent(file_get_contents($file));
+        $expectedTrimmedContent = \trim(\file_get_contents($file));
+        $this->assertEquals($expectedTrimmedContent, \trim($asset->build()));
+        $asset->setContent(\file_get_contents($file));
         $asset->setPath(null);
-        $this->assertEquals($expectedTrimmedContent, trim($asset->build()));
+        $this->assertEquals($expectedTrimmedContent, \trim($asset->build()));
     }
 
     /**
@@ -175,8 +175,8 @@ class AssetTest extends AbstractTestCase
     {
         $file = $this->getAbsoluteAssetFixturePath();
         $asset = Asset::createFromFile($file);
-        $expectedTrimmedContent = trim(file_get_contents($file));
-        $this->assertEquals($expectedTrimmedContent, trim($asset->getContent()));
+        $expectedTrimmedContent = \trim(\file_get_contents($file));
+        $this->assertEquals($expectedTrimmedContent, \trim($asset->getContent()));
     }
 
     /**
@@ -205,7 +205,7 @@ class AssetTest extends AbstractTestCase
         $gettableProperties = ObjectAccess::getGettablePropertyNames($asset);
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         foreach ($gettableProperties as $propertyName) {
-            if (false === property_exists(Asset::class, $propertyName)) {
+            if (false === \property_exists(Asset::class, $propertyName)) {
                 continue;
             }
             $propertyValue = ObjectAccess::getProperty($asset, $propertyName);
@@ -213,7 +213,7 @@ class AssetTest extends AbstractTestCase
             $propertyReflection = $objectManager->get(\ReflectionProperty::class, Asset::class, $propertyName);
             $docComment = $propertyReflection->getDocComment();
             $matches = [];
-            preg_match('/@var ([a-z\\\\0-9_]+)/i', $docComment, $matches);
+            \preg_match('/@var ([a-z\\\\0-9_]+)/i', $docComment, $matches);
             $expectedDataType = $matches[1];
             $constraint = new \PHPUnit_Framework_Constraint_IsType($expectedDataType);
             $this->assertThat($propertyValue, $constraint);
@@ -221,9 +221,9 @@ class AssetTest extends AbstractTestCase
         $constraint = new \PHPUnit_Framework_Constraint_IsType('array');
         $this->assertThat($asset->getDebugInformation(), $constraint);
         $this->assertThat($asset->getAssetSettings(), $constraint);
-        $this->assertGreaterThan(0, count($asset->getAssetSettings()));
+        $this->assertGreaterThan(0, \count($asset->getAssetSettings()));
         $this->assertThat($asset->getSettings(), $constraint);
-        $this->assertGreaterThan(0, count($asset->getSettings()));
+        $this->assertGreaterThan(0, \count($asset->getSettings()));
         $this->assertNotNull($asset->getContent());
     }
 
@@ -248,7 +248,7 @@ class AssetTest extends AbstractTestCase
     public function assertSupportsRawContent()
     {
         $file = $this->getAbsoluteAssetFixturePath();
-        $content = file_get_contents($file);
+        $content = \file_get_contents($file);
         $asset = Asset::createFromContent($content);
         $this->assertSame($content, $asset->getContent());
     }

--- a/Tests/Unit/Service/AssetServiceTest.php
+++ b/Tests/Unit/Service/AssetServiceTest.php
@@ -74,13 +74,13 @@ class AssetServiceTest extends AbstractTestCase
         // Note: Maybe test this dynamic. This command could be useful:
         //    ~> openssl dgst -sha256 -binary Tests/Fixtures/Files/dummy.js | openssl base64 -A
 
-        if ((!extension_loaded('hash') || !function_exists('hash_algos'))
-            && (!extension_loaded('openssl') || !function_exists('openssl_get_md_methods'))
+        if ((!\extension_loaded('hash') || !\function_exists('hash_algos'))
+            && (!\extension_loaded('openssl') || !\function_exists('openssl_get_md_methods'))
         ) {
             $this->markTestSkipped('No hash or openssl support');
         }
 
-        $GLOBALS['TSFE'] = unserialize('O:8:"stdClass":1:{s:4:"tmpl";O:8:"stdClass":1:{s:5:"setup";a:1:{s:7:"plugin.";a:1:{s:7:"tx_vhs.";a:1:{s:7:"assets.";a:0:{}}}}}}');
+        $GLOBALS['TSFE'] = \unserialize('O:8:"stdClass":1:{s:4:"tmpl";O:8:"stdClass":1:{s:5:"setup";a:1:{s:7:"plugin.";a:1:{s:7:"tx_vhs.";a:1:{s:7:"assets.";a:0:{}}}}}}');
 
         // This represents the setting levels, from 0=off over 1 as the weakest to 3 as the strongest
         $expectedIntegrities = [

--- a/Tests/Unit/Utility/ResourceUtilityTest.php
+++ b/Tests/Unit/Utility/ResourceUtilityTest.php
@@ -26,7 +26,7 @@ class ResourceUtilityTest extends AbstractTestCase
     {
         $propertiesFromFile = ['foo' => 123, 'bar' => 321];
         $propertiesFromStorage = ['foo' => 'abc', 'baz' => 123];
-        $expectation = array_merge($propertiesFromFile, $propertiesFromStorage);
+        $expectation = \array_merge($propertiesFromFile, $propertiesFromStorage);
         $mockStorage = $this->getMockBuilder(ResourceStorage::class)->setMethods(['getFileInfo'])->disableOriginalConstructor()->getMock();
         $mockFile = $this->getMockBuilder(File::class)->setMethods(['getProperties', 'getStorage', 'toArray'])->disableOriginalConstructor()->getMock();
         $mockFile->expects($this->once())->method('getProperties')->will($this->returnValue($propertiesFromFile));

--- a/Tests/Unit/View/UncacheTemplateViewTest.php
+++ b/Tests/Unit/View/UncacheTemplateViewTest.php
@@ -76,8 +76,8 @@ class UncacheTemplateViewTest extends AbstractTestCase
      */
     protected function getClassName()
     {
-        $class = substr(get_class($this), 0, -4);
-        $class = str_replace('Tests\\Unit\\', '', $class);
+        $class = \substr(\get_class($this), 0, -4);
+        $class = \str_replace('Tests\\Unit\\', '', $class);
         return $class;
     }
 }

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTest.php
@@ -77,9 +77,9 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
      */
     protected function getViewHelperClassName()
     {
-        $class = get_class($this);
-        $class = substr($class, 0, -4);
-        $class = str_replace('Tests\\Unit\\', '', $class);
+        $class = \get_class($this);
+        $class = \substr($class, 0, -4);
+        $class = \str_replace('Tests\\Unit\\', '', $class);
         return $class;
     }
 
@@ -92,7 +92,7 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
     {
         /** @var NodeInterface $node */
         $className = 'TYPO3\\CMS\\Fluid\\Core\\Parser\\SyntaxTree\\' . $type . 'Node';
-        if (class_exists($className)) {
+        if (\class_exists($className)) {
             $node = new $className($value);
         } else {
             $className = 'TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\' . $type . 'Node';
@@ -125,12 +125,12 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
     {
         $instance = $this->createInstance();
         $node = $this->createViewHelperNode($instance, $arguments);
-        if (method_exists($this->renderingContext, 'getVariableProvider')) {
+        if (\method_exists($this->renderingContext, 'getVariableProvider')) {
             $this->renderingContext->getVariableProvider()->setSource($variables);
         } else {
             /** @var TemplateVariableContainer $container */
             $container = $this->objectManager->get(TemplateVariableContainer::class);
-            if (0 < count($variables)) {
+            if (0 < \count($variables)) {
                 ObjectAccess::setProperty($container, 'variables', $variables, true);
             }
             ObjectAccess::setProperty($this->renderingContext, 'templateVariableContainer', $container, true);
@@ -163,14 +163,14 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
         $instance->setArguments($arguments);
         if ($childNode) {
             $node->expects($this->any())->method('getChildNodes')->willReturn([$childNode]);
-            if (method_exists($instance, 'setChildNodes')) {
+            if (\method_exists($instance, 'setChildNodes')) {
                 $instance->setChildNodes([$childNode]);
             }
         } else {
             $node->expects($this->any())->method('getChildNodes')->willReturn([]);
         }
 
-        if (method_exists($instance, 'injectReflectionService')) {
+        if (\method_exists($instance, 'injectReflectionService')) {
             $instance->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         return $instance;
@@ -225,7 +225,7 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
         $context = $this->renderingContext;
         $instance = $this->buildViewHelperInstance($arguments, $variables, null, $extensionName, $pluginName);
         $instance->setRenderChildrenClosure(function() use ($instance, $nodeValue, $context) {
-            if (method_exists($instance, 'setChildNodes')
+            if (\method_exists($instance, 'setChildNodes')
                 && (
                     $nodeValue instanceof \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode
                     || $nodeValue instanceof \TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode
@@ -292,6 +292,6 @@ abstract class AbstractViewHelperTest extends AbstractTestCase
      */
     protected function usesLegacyFluidVersion()
     {
-        return version_compare(TYPO3_version, '8.0', '<');
+        return \version_compare(TYPO3_version, '8.0', '<');
     }
 }

--- a/Tests/Unit/ViewHelpers/Condition/Form/HasValidatorViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Form/HasValidatorViewHelperTest.php
@@ -22,7 +22,7 @@ class HasValidatorViewHelperTest extends AbstractViewHelperTest
 
     protected function getInstanceOfFoo()
     {
-        if (version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
+        if (\version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
             return new Foo();
         }
         return new LegacyFoo();
@@ -30,7 +30,7 @@ class HasValidatorViewHelperTest extends AbstractViewHelperTest
 
     protected function getNestedPathToFoo()
     {
-        if (version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
+        if (\version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
             return 'foo';
         }
         return 'legacyFoo';

--- a/Tests/Unit/ViewHelpers/Condition/Form/IsRequiredViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Form/IsRequiredViewHelperTest.php
@@ -22,7 +22,7 @@ class IsRequiredViewHelperTest extends AbstractViewHelperTest
 
     protected function getInstanceOfFoo()
     {
-        if (version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
+        if (\version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
             return new Foo();
         }
         return new LegacyFoo();
@@ -30,7 +30,7 @@ class IsRequiredViewHelperTest extends AbstractViewHelperTest
 
     protected function getNestedPathToFoo()
     {
-        if (version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
+        if (\version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
             return 'foo';
         }
         return 'legacyFoo';

--- a/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Page/IsChildPageViewHelperTest.php
@@ -19,7 +19,7 @@ class IsChildPageViewHelperTest extends AbstractViewHelperTest
 
     public function testRender()
     {
-        if (class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
+        if (\class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
             $this->markTestSkipped('Test is skippped on TYPO3v8 for now, due to tested code having tight coupling to Doctrine');
         }
         $GLOBALS['TYPO3_DB'] = $this->getMockBuilder(DatabaseConnection::class)->setMethods(['exec_SELECTquery'])->disableOriginalConstructor()->getMock();

--- a/Tests/Unit/ViewHelpers/Condition/Variable/IssetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Condition/Variable/IssetViewHelperTest.php
@@ -20,7 +20,7 @@ class IssetViewHelperTest extends AbstractViewHelperTest
      */
     public function setUp()
     {
-        if (version_compare(TYPO3_version, '8.0', '<')) {
+        if (\version_compare(TYPO3_version, '8.0', '<')) {
             $this->markTestSkipped('Skipped, ViewHelper does not work on 7.6');
         }
         parent::setUp();

--- a/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -38,8 +38,8 @@ class SelectViewHelperTest extends AbstractViewHelperTest
         $model1->setName('Model1');
         $model2 = new Bar();
         $model2->setName('Model2');
-        $model1id = spl_object_hash($model1);
-        $model2id = spl_object_hash($model2);
+        $model1id = \spl_object_hash($model1);
+        $model2id = \spl_object_hash($model2);
         $model1name = Foo::class . ':';
         $model2name = Bar::class . ':';
         return [

--- a/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Json/EncodeViewHelperTest.php
@@ -22,7 +22,7 @@ class EncodeViewHelperTest extends AbstractViewHelperTest
 
     protected function getInstanceOfFoo()
     {
-        if (version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
+        if (\version_compare(ExtensionManagementUtility::getExtensionVersion('fluid'), 9.3, '>=')) {
             return new Foo();
         }
         return new LegacyFoo();
@@ -166,7 +166,7 @@ class EncodeViewHelperTest extends AbstractViewHelperTest
         $jsTimestamp = $date->getTimestamp() * 1000;
 
         $fixture = ['foo' => $date, 'bar' => ['baz' => $date]];
-        $expected = sprintf('{"foo":%s,"bar":{"baz":%s}}', $jsTimestamp, $jsTimestamp);
+        $expected = \sprintf('{"foo":%s,"bar":{"baz":%s}}', $jsTimestamp, $jsTimestamp);
 
         $this->assertEquals($expected, $this->executeViewHelper(['value' => $fixture]));
     }

--- a/Tests/Unit/ViewHelpers/Format/MarkdownViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/MarkdownViewHelperTest.php
@@ -21,7 +21,7 @@ class MarkdownViewHelperTest extends AbstractViewHelperTest
      */
     public function supportsHtmlEntities()
     {
-        if (trim(shell_exec('which markdown')) === '') {
+        if (\trim(\shell_exec('which markdown')) === '') {
             $this->expectViewHelperException('Use of Markdown requires the "markdown" shell utility to be installed');
         }
         $this->executeViewHelper(['text' => 'test < test', 'trim' => true, 'htmlentities' => true]);
@@ -32,7 +32,7 @@ class MarkdownViewHelperTest extends AbstractViewHelperTest
      */
     public function rendersMarkdown()
     {
-        if (trim(shell_exec('which markdown')) === '') {
+        if (\trim(\shell_exec('which markdown')) === '') {
             $this->expectViewHelperException('Use of Markdown requires the "markdown" shell utility to be installed');
         }
         $this->executeViewHelper(['text' => 'test', 'trim' => true, 'htmlentities' => false]);

--- a/Tests/Unit/ViewHelpers/Format/Placeholder/LipsumViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Placeholder/LipsumViewHelperTest.php
@@ -39,7 +39,7 @@ class LipsumViewHelperTest extends AbstractViewHelperTest
         $firstRender = $this->executeViewHelper($arguments);
         $arguments['paragraphs'] = 6;
         $secondRender = $this->executeViewHelper($arguments);
-        $this->assertLessThan(strlen($secondRender), strlen($firstRender));
+        $this->assertLessThan(\strlen($secondRender), \strlen($firstRender));
     }
 
     /**

--- a/Tests/Unit/ViewHelpers/Format/TidyViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/TidyViewHelperTest.php
@@ -23,7 +23,7 @@ class TidyViewHelperTest extends AbstractViewHelperTest
      */
     public function throwsErrorWhenNoTidyIsInstalled()
     {
-        if (!class_exists('tidy')) {
+        if (!\class_exists('tidy')) {
             // Note: CI setup has tidy on some but not all variants. We can only test for exceptions on those that don't.
             $this->setExpectedException('RuntimeException', null, 1352059753);
         }
@@ -36,7 +36,7 @@ class TidyViewHelperTest extends AbstractViewHelperTest
     public function canTidySource()
     {
         $instance = $this->createInstance();
-        if (false === class_exists('tidy')) {
+        if (false === \class_exists('tidy')) {
             $this->markTestSkipped('No tidy support');
             return;
         }

--- a/Tests/Unit/ViewHelpers/Format/Url/DecodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Url/DecodeViewHelperTest.php
@@ -23,6 +23,6 @@ class DecodeViewHelperTest extends AbstractViewHelperTest
     {
         $encoded = 'Url%20Encoded';
         $result = $this->executeViewHelper(['content' => $encoded]);
-        $this->assertEquals(rawurldecode($encoded), $result);
+        $this->assertEquals(\rawurldecode($encoded), $result);
     }
 }

--- a/Tests/Unit/ViewHelpers/Format/Url/EncodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Format/Url/EncodeViewHelperTest.php
@@ -23,6 +23,6 @@ class EncodeViewHelperTest extends AbstractViewHelperTest
     {
         $decoded = 'Url Decoded';
         $result = $this->executeViewHelper(['content' => $decoded]);
-        $this->assertEquals(rawurlencode($decoded), $result);
+        $this->assertEquals(\rawurlencode($decoded), $result);
     }
 }

--- a/Tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -18,7 +18,7 @@ class IfViewHelperTest extends AbstractViewHelperTest
      */
     public function setUp()
     {
-        if (class_exists(\TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper::class)) {
+        if (\class_exists(\TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper::class)) {
             $this->markTestSkipped('Test not executed on TYPO3v8 (ViewHelper is deprecated from this version and up)');
         }
         parent::setUp();

--- a/Tests/Unit/ViewHelpers/Iterator/NextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/NextViewHelperTest.php
@@ -22,7 +22,7 @@ class NextViewHelperTest extends AbstractViewHelperTest
     public function returnsNextElement()
     {
         $array = ['a', 'b', 'c'];
-        next($array);
+        \next($array);
         $arguments = [
             'haystack' => $array,
             'needle' => 'b',

--- a/Tests/Unit/ViewHelpers/Iterator/PreviousViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Iterator/PreviousViewHelperTest.php
@@ -22,7 +22,7 @@ class PreviousViewHelperTest extends AbstractViewHelperTest
     public function returnsPreviousElement()
     {
         $array = ['a', 'b', 'c'];
-        next($array);
+        \next($array);
         $arguments = [
             'haystack' => $array,
             'needle' => 'c',

--- a/Tests/Unit/ViewHelpers/Media/ExtensionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/ExtensionViewHelperTest.php
@@ -38,7 +38,7 @@ class ExtensionViewHelperTest extends AbstractViewHelperTest
     public function returnsEmptyStringForEmptyArguments()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -54,7 +54,7 @@ class ExtensionViewHelperTest extends AbstractViewHelperTest
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($this->fixturesPath . '/foo.txt'));
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -69,7 +69,7 @@ class ExtensionViewHelperTest extends AbstractViewHelperTest
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($this->fixturesPath . '/noext'));
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));

--- a/Tests/Unit/ViewHelpers/Media/FilesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/FilesViewHelperTest.php
@@ -29,7 +29,7 @@ class FilesViewHelperTest extends AbstractViewHelperTest
     public function setUp()
     {
         parent::setUp();
-        $this->fixturesPath = dirname(__FILE__) . '/../../../Fixtures/Files';
+        $this->fixturesPath = \dirname(__FILE__) . '/../../../Fixtures/Files';
     }
 
     /**
@@ -38,7 +38,7 @@ class FilesViewHelperTest extends AbstractViewHelperTest
     public function returnsEmtpyArrayWhenArgumentsAreNotSet()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -53,7 +53,7 @@ class FilesViewHelperTest extends AbstractViewHelperTest
     public function returnsEmptyArrayWhenPathIsInaccessible()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -69,12 +69,12 @@ class FilesViewHelperTest extends AbstractViewHelperTest
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($this->fixturesPath));
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
-        $actualFiles = glob($this->fixturesPath . '/*');
-        $actualFilesCount = count($actualFiles);
+        $actualFiles = \glob($this->fixturesPath . '/*');
+        $actualFilesCount = \count($actualFiles);
         $viewHelper->setArguments([]);
         $this->assertCount($actualFilesCount, $viewHelper->render());
     }
@@ -87,12 +87,12 @@ class FilesViewHelperTest extends AbstractViewHelperTest
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
         $viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($this->fixturesPath));
         $viewHelper->setArguments(['extensionList' => 'txt']);
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
-        $actualFiles = glob($this->fixturesPath . '/*.txt');
-        $actualFilesCount = count($actualFiles);
+        $actualFiles = \glob($this->fixturesPath . '/*.txt');
+        $actualFilesCount = \count($actualFiles);
 
         $this->assertCount($actualFilesCount, $viewHelper->render());
     }

--- a/Tests/Unit/ViewHelpers/Media/GravatarViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/GravatarViewHelperTest.php
@@ -30,7 +30,7 @@ class GravatarViewHelperTest extends AbstractViewHelperTest
     public function generatesExpectedImgForEmailAddress()
     {
         $expectedSource = 'http://www.gravatar.com/avatar/b1b0eddcbc4468db89f355ebb9cc3007';
-        preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
+        \preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
         $this->assertSame($expectedSource, $actualSource[1]);
         $expectedSource = 'https://secure.gravatar.com/avatar/b1b0eddcbc4468db89f355ebb9cc3007?s=160&amp;d=404&amp;r=pg';
         $this->arguments = [
@@ -40,7 +40,7 @@ class GravatarViewHelperTest extends AbstractViewHelperTest
             'maximumRating' => 'pg',
             'secure' => true,
         ];
-        preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
+        \preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
         $this->assertSame($expectedSource, $actualSource[1]);
     }
 }

--- a/Tests/Unit/ViewHelpers/Media/SizeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/SizeViewHelperTest.php
@@ -38,7 +38,7 @@ class SizeViewHelperTest extends AbstractViewHelperTest
     public function returnsZeroForEmptyArguments()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -53,7 +53,7 @@ class SizeViewHelperTest extends AbstractViewHelperTest
     public function returnsFileSizeAsInteger()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -68,7 +68,7 @@ class SizeViewHelperTest extends AbstractViewHelperTest
     public function throwsExceptionWhenFileNotFound()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));
@@ -84,7 +84,7 @@ class SizeViewHelperTest extends AbstractViewHelperTest
     public function throwsExceptionWhenFileIsNotAccessibleOrIsADirectory()
     {
         $viewHelper = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderChildren'])->getMock();
-        if (method_exists($viewHelper, 'injectReflectionService')) {
+        if (\method_exists($viewHelper, 'injectReflectionService')) {
             $viewHelper->injectReflectionService($this->objectManager->get(ReflectionService::class));
         }
         $viewHelper->setRenderingContext($this->objectManager->get(RenderingContext::class));

--- a/Tests/Unit/ViewHelpers/Media/YoutubeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Media/YoutubeViewHelperTest.php
@@ -46,7 +46,7 @@ class YoutubeViewHelperTest extends AbstractViewHelperTest
         $this->arguments['hideInfo'] = true;
         $this->arguments['start']    = 30;
 
-        preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
+        \preg_match('#src="([^"]*)"#', $this->executeViewHelper($this->arguments), $actualSource);
         $expectedSource = '//www.youtube-nocookie.com/embed/M7lc1UVf-VE?rel=0&amp;showinfo=0&amp;start=30';
 
         $this->assertSame($expectedSource, $actualSource[1]);

--- a/Tests/Unit/ViewHelpers/Once/InstanceViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Once/InstanceViewHelperTest.php
@@ -63,8 +63,8 @@ class InstanceViewHelperTest extends AbstractViewHelperTest
         $instance = $this->createInstance();
         $instance->setArguments(['identifier' => 'test']);
         $this->callInaccessibleMethod($instance, 'storeIdentifier', ['identifier' => 'test']);
-        $this->assertTrue($GLOBALS[get_class($instance)]['test']);
-        unset($GLOBALS[get_class($instance)]['test']);
+        $this->assertTrue($GLOBALS[\get_class($instance)]['test']);
+        unset($GLOBALS[\get_class($instance)]['test']);
     }
 
     /**
@@ -75,8 +75,8 @@ class InstanceViewHelperTest extends AbstractViewHelperTest
         $instance = $this->createInstance();
         $instance->setArguments(['identifier' => 'test']);
         $this->assertFalse($this->callInaccessibleMethod($instance, 'assertShouldSkip', ['identifier' => 'test']));
-        $GLOBALS[get_class($instance)]['test'] = true;
+        $GLOBALS[\get_class($instance)]['test'] = true;
         $this->assertTrue($this->callInaccessibleMethod($instance, 'assertShouldSkip', ['identifier' => 'test']));
-        unset($GLOBALS[get_class($instance)]['test']);
+        unset($GLOBALS[\get_class($instance)]['test']);
     }
 }

--- a/Tests/Unit/ViewHelpers/Once/SessionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Once/SessionViewHelperTest.php
@@ -23,8 +23,8 @@ class SessionViewHelperTest extends AbstractViewHelperTest
     {
         $instance = $this->createInstance();
         $this->callInaccessibleMethod($instance, 'storeIdentifier', ['identifier' => 'test']);
-        $this->assertEquals(time(), $_SESSION[get_class($instance)]['test']);
-        unset($_SESSION[get_class($instance)]['test']);
+        $this->assertEquals(\time(), $_SESSION[\get_class($instance)]['test']);
+        unset($_SESSION[\get_class($instance)]['test']);
     }
 
     /**
@@ -34,9 +34,9 @@ class SessionViewHelperTest extends AbstractViewHelperTest
     {
         $instance = $this->createInstance();
         $this->assertFalse($this->callInaccessibleMethod($instance, 'assertShouldSkip', ['identifier' => 'test']));
-        $_SESSION[get_class($instance)]['test'] = time();
+        $_SESSION[\get_class($instance)]['test'] = \time();
         $this->assertTrue($this->callInaccessibleMethod($instance, 'assertShouldSkip', ['identifier' => 'test']));
-        unset($_SESSION[get_class($instance)]['test']);
+        unset($_SESSION[\get_class($instance)]['test']);
     }
 
     /**
@@ -46,7 +46,7 @@ class SessionViewHelperTest extends AbstractViewHelperTest
     {
         $instance = $this->createInstance();
         $class = $this->getViewHelperClassName();
-        $time = time() - 10;
+        $time = \time() - 10;
         $_SESSION[$class]['test'] = $time;
 
         $this->callInaccessibleMethod($instance, 'removeIfExpired', ['identifier' => 'test', 'ttl' => 15]);

--- a/Tests/Unit/ViewHelpers/Page/InfoViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/InfoViewHelperTest.php
@@ -18,7 +18,7 @@ class InfoViewHelperTest extends AbstractViewHelperTest
 {
     public function testReturnsCorrectSingleFieldValue()
     {
-        if (class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
+        if (\class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
             $this->markTestSkipped('Test is skippped on TYPO3v8 for now, due to tested code having tight coupling to Doctrine');
         }
         $expectedFieldValue = 42;
@@ -30,7 +30,7 @@ class InfoViewHelperTest extends AbstractViewHelperTest
 
     public function testReturnsPageRowIfNoFieldGiven()
     {
-        if (class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
+        if (\class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
             $this->markTestSkipped('Test is skippped on TYPO3v8 for now, due to tested code having tight coupling to Doctrine');
         }
         $expectedRow = ['uid' => 42, 'tx_foo_bar' => 'baz'];
@@ -42,7 +42,7 @@ class InfoViewHelperTest extends AbstractViewHelperTest
 
     public function testThrowsExceptionWhenUsedInBackend()
     {
-        if (class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
+        if (\class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
             $this->markTestSkipped('Test is skippped on TYPO3v8 for now, due to tested code having tight coupling to Doctrine');
         }
         unset($GLOBALS['TSFE']);

--- a/Tests/Unit/ViewHelpers/Page/RootlineViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/RootlineViewHelperTest.php
@@ -20,7 +20,7 @@ class RootlineViewHelperTest extends AbstractViewHelperTest
 
     public function testRender()
     {
-        if (class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
+        if (\class_exists(\TYPO3\CMS\Core\Database\ConnectionPool::class)) {
             $this->markTestSkipped('Test is skippped on TYPO3v8 for now, due to tested code having tight coupling to Doctrine');
         }
         $pageRepository = $this->getMockBuilder(PageRepository::class)->setMethods(['dummy'])->getMock();

--- a/Tests/Unit/ViewHelpers/Random/StringViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Random/StringViewHelperTest.php
@@ -23,7 +23,7 @@ class StringViewHelperTest extends AbstractViewHelperTest
     {
         $arguments = ['minimumLength' => 32, 'maximumLength' => 32, 'characters' => 'abcdef'];
         $result = $this->executeViewHelper($arguments);
-        $this->assertEquals(32, strlen($result));
-        $this->assertEquals(0, preg_match('/[^a-f]+/', $result), 'Random string contained unexpected characters');
+        $this->assertEquals(32, \strlen($result));
+        $this->assertEquals(0, \preg_match('/[^a-f]+/', $result), 'Random string contained unexpected characters');
     }
 }

--- a/Tests/Unit/ViewHelpers/System/TimestampViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/System/TimestampViewHelperTest.php
@@ -21,7 +21,7 @@ class TimestampViewHelperTest extends AbstractViewHelperTest
      */
     public function returnsIntegerAtOrAboveNowAsMeasuredInTest()
     {
-        $now = time();
+        $now = \time();
         $result = $this->executeViewHelper();
         $this->assertGreaterThanOrEqual($now, $result);
     }

--- a/Tests/Unit/ViewHelpers/TryViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/TryViewHelperTest.php
@@ -25,7 +25,7 @@ class TryViewHelperTest extends AbstractViewHelperTest
     public function testRenderWithException()
     {
         $renderingContext = new RenderingContext();
-        if (method_exists($renderingContext, 'injectTemplateVariableContainer')) {
+        if (\method_exists($renderingContext, 'injectTemplateVariableContainer')) {
             $renderingContext->injectTemplateVariableContainer(new TemplateVariableContainer());
         }
         $instance = $this->getMockBuilder($this->getViewHelperClassName())->setMethods(['renderThenChild', 'renderChildren'])->getMock();

--- a/Tests/Unit/ViewHelpers/Variable/ConvertViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/ConvertViewHelperTest.php
@@ -28,7 +28,7 @@ class ConvertViewHelperTest extends AbstractViewHelperTest
      */
     public function executeConversion($value, $type, $expected)
     {
-        if (is_object($expected)) {
+        if (\is_object($expected)) {
             $assertionMethod = 'assertEquals';
         } else {
             $assertionMethod = 'assertSame';

--- a/Tests/Unit/ViewHelpers/Variable/PregMatchViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/PregMatchViewHelperTest.php
@@ -26,7 +26,7 @@ class PregMatchViewHelperTest extends AbstractViewHelperTest
             'pattern' => '/[0-9]{3}/',
         ];
         $test = $this->executeViewHelper($arguments);
-        $this->assertSame(1, count($test));
+        $this->assertSame(1, \count($test));
     }
 
     /**
@@ -38,6 +38,6 @@ class PregMatchViewHelperTest extends AbstractViewHelperTest
             'pattern' => '/[0-9]{3}/',
         ];
         $test = $this->executeViewHelperUsingTagContent('foo123bar', $arguments);
-        $this->assertSame(1, count($test));
+        $this->assertSame(1, \count($test));
     }
 }

--- a/Tests/Unit/ViewHelpers/Variable/Register/GetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/Register/GetViewHelperTest.php
@@ -32,7 +32,7 @@ class GetViewHelperTest extends AbstractViewHelperTest
     public function returnsNullIfRegisterDoesNotExist()
     {
         $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
-        $name = uniqid();
+        $name = \uniqid();
         $this->assertEquals(null, $this->executeViewHelper(['name' => $name]));
     }
 
@@ -42,8 +42,8 @@ class GetViewHelperTest extends AbstractViewHelperTest
     public function returnsValueIfRegisterExists()
     {
         $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
-        $name = uniqid();
-        $value = uniqid();
+        $name = \uniqid();
+        $value = \uniqid();
         $GLOBALS['TSFE']->register[$name] = $value;
         $this->assertEquals($value, $this->executeViewHelper(['name' => $name]));
     }

--- a/Tests/Unit/ViewHelpers/Variable/Register/SetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/Register/SetViewHelperTest.php
@@ -32,8 +32,8 @@ class SetViewHelperTest extends AbstractViewHelperTest
     public function canSetRegister()
     {
         $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
-        $name = uniqid();
-        $value = uniqid();
+        $name = \uniqid();
+        $value = \uniqid();
         $this->executeViewHelper(['name' => $name, 'value' => $value]);
         $this->assertEquals($value, $GLOBALS['TSFE']->register[$name]);
     }
@@ -44,8 +44,8 @@ class SetViewHelperTest extends AbstractViewHelperTest
     public function canSetVariableWithValueFromTagContent()
     {
         $GLOBALS['TSFE'] = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
-        $name = uniqid();
-        $value = uniqid();
+        $name = \uniqid();
+        $value = \uniqid();
         $this->executeViewHelperUsingTagContent($value, ['name' => $name]);
         $this->assertEquals($value, $GLOBALS['TSFE']->register[$name]);
     }

--- a/Tests/Unit/ViewHelpers/Variable/UnsetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/UnsetViewHelperTest.php
@@ -25,7 +25,7 @@ class UnsetViewHelperTest extends AbstractViewHelperTest
         $variables = new \ArrayObject(['test' => 'test']);
         $instance = $this->buildViewHelperInstance(['name' => 'test']);
         $context = ObjectAccess::getProperty($instance, 'renderingContext', true);
-        if (method_exists($context, 'getVariableProvider')) {
+        if (\method_exists($context, 'getVariableProvider')) {
             $provider = $context->getVariableProvider();
         } else {
             $provider = $context->getTemplateVariableContainer();

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 // Register composer autoloader
-if (!file_exists(__DIR__ . '/../vendor/autoload.php')) {
+if (!\file_exists(__DIR__ . '/../vendor/autoload.php')) {
     throw new \RuntimeException(
         'Could not find vendor/autoload.php, make sure you ran composer.'
     );
@@ -30,4 +30,4 @@ $autoloader = require __DIR__ . '/../vendor/autoload.php';
     ]
 );
 
-ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_USER_DEPRECATED);
+\ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_USER_DEPRECATED);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,16 +1,16 @@
 <?php
-if (!defined('TYPO3_MODE')) {
+if (!\defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
 /**
  * Polyfill ext-mbstring if not present. Can be removed with TYPO3 8.7 minimum-compatibility.
  */
-if (false === function_exists('mb_strlen') || false === function_exists('mb_chr')) {
-    if (!function_exists('mb_strlen')) {
-        define('MB_CASE_UPPER', 0);
-        define('MB_CASE_LOWER', 1);
-        define('MB_CASE_TITLE', 2);
+if (false === \function_exists('mb_strlen') || false === \function_exists('mb_chr')) {
+    if (!\function_exists('mb_strlen')) {
+        \define('MB_CASE_UPPER', 0);
+        \define('MB_CASE_LOWER', 1);
+        \define('MB_CASE_TITLE', 2);
 
         function mb_convert_encoding($s, $to, $from = null) { return FluidTYPO3\Vhs\Mbstring::mb_convert_encoding($s, $to, $from); }
         function mb_decode_mimeheader($s) { return FluidTYPO3\Vhs\Mbstring::mb_decode_mimeheader($s); }
@@ -23,7 +23,7 @@ if (false === function_exists('mb_strlen') || false === function_exists('mb_chr'
         function mb_check_encoding($var = null, $encoding = null) { return FluidTYPO3\Vhs\Mbstring::mb_check_encoding($var, $encoding); }
         function mb_detect_encoding($str, $encodingList = null, $strict = false) { return FluidTYPO3\Vhs\Mbstring::mb_detect_encoding($str, $encodingList, $strict); }
         function mb_detect_order($encodingList = null) { return FluidTYPO3\Vhs\Mbstring::mb_detect_order($encodingList); }
-        function mb_parse_str($s, &$result = array()) { parse_str($s, $result); }
+        function mb_parse_str($s, &$result = array()) { \parse_str($s, $result); }
         function mb_strlen($s, $enc = null) { return FluidTYPO3\Vhs\Mbstring::mb_strlen($s, $enc); }
         function mb_strpos($s, $needle, $offset = 0, $enc = null) { return FluidTYPO3\Vhs\Mbstring::mb_strpos($s, $needle, $offset, $enc); }
         function mb_strtolower($s, $enc = null) { return FluidTYPO3\Vhs\Mbstring::mb_strtolower($s, $enc); }
@@ -46,21 +46,21 @@ if (false === function_exists('mb_strlen') || false === function_exists('mb_chr'
         function mb_convert_variables($toEncoding, $fromEncoding, &$a = null, &$b = null, &$c = null, &$d = null, &$e = null, &$f = null) { return FluidTYPO3\Vhs\Mbstring::mb_convert_variables($toEncoding, $fromEncoding, $a, $b, $c, $d, $e, $f); }
     }
 
-    if (!function_exists('mb_chr')) {
+    if (!\function_exists('mb_chr')) {
         function mb_ord($s, $enc = null) { return FluidTYPO3\Vhs\Mbstring::mb_ord($s, $enc); }
         function mb_chr($code, $enc = null) { return FluidTYPO3\Vhs\Mbstring::mb_chr($code, $enc); }
-        function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
+        function mb_scrub($s, $enc = null) { $enc = null === $enc ? \mb_internal_encoding() : $enc; return \mb_convert_encoding($s, $enc, $enc); }
     }
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = unserialize($_EXTCONF);
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = \unserialize($_EXTCONF);
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup']['disableAssetHandling']) || !$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup']['disableAssetHandling']) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['usePageCache'][] = 'FluidTYPO3\\Vhs\\Service\\AssetService';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'FluidTYPO3\\Vhs\\Service\\AssetService->buildAllUncached';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'FluidTYPO3\\Vhs\\Service\\AssetService->clearCacheCommand';
 }
 
-if (FALSE === is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'])) {
+if (FALSE === \is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'])) {
 	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'] = [
 		'frontend' => 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend',
 		'options' => [
@@ -70,7 +70,7 @@ if (FALSE === is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfi
 	];
 }
 
-if (FALSE === is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'])) {
+if (FALSE === \is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'])) {
 	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] = [
 		'frontend' => 'TYPO3\\CMS\\Core\\Cache\\Frontend\\VariableFrontend',
 		'options' => [


### PR DESCRIPTION
Use FQN names to improve performance for function lookups.
See: https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

I used latest php-cs-fixer to do the changes:
`php-cs-fixer fix vhs --rules=native_function_invocation --allow-risky=yes`

Closes #1528
