### PR TITLE
remove getTemplateVariableContainer, use getVariableProvider

### DIFF
--- a/Classes/Traits/TemplateVariableViewHelperTrait.php
+++ b/Classes/Traits/TemplateVariableViewHelperTrait.php
@@ -87,7 +87,7 @@ trait TemplateVariableViewHelperTrait
             $variables = [$as => $variable];
             $content = static::renderChildrenWithVariablesStatic(
                 $variables,
-                $renderingContext->getTemplateVariableContainer(),
+                $renderingContext->getVariableProvider(),
                 $renderChildrenClosure
             );
         }

--- a/Classes/Utility/ViewHelperUtility.php
+++ b/Classes/Utility/ViewHelperUtility.php
@@ -26,9 +26,6 @@ class ViewHelperUtility
      */
     public static function getVariableProviderFromRenderingContext(RenderingContextInterface $renderingContext)
     {
-        if (method_exists($renderingContext, 'getVariableProvider')) {
-            return $renderingContext->getVariableProvider();
-        }
-        return $renderingContext->getTemplateVariableContainer();
+        return $renderingContext->getVariableProvider();
     }
 }

--- a/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Variable/IssetViewHelper.php
@@ -73,7 +73,7 @@ class IssetViewHelper extends AbstractConditionViewHelper
     protected static function evaluateCondition($arguments = null)
     {
         $renderingContext = static::$staticRenderingContext;
-        $variableProvider = method_exists($renderingContext, 'getVariableProvider') ? $renderingContext->getVariableProvider() : $renderingContext->getTemplateVariableContainer();
+        $variableProvider = $renderingContext->getVariableProvider();
         return $variableProvider->exists($arguments['name']);
     }
 

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -54,7 +54,7 @@ class UncacheViewHelper extends AbstractViewHelper implements CompilableInterfac
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $templateVariableContainer = $renderingContext->getTemplateVariableContainer();
+        $templateVariableContainer = $renderingContext->getVariableProvider();
         $partialArguments = $arguments['arguments'];
         if (false === is_array($partialArguments)) {
             $partialArguments = [];

--- a/Tests/Unit/ViewHelpers/Variable/UnsetViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Variable/UnsetViewHelperTest.php
@@ -25,11 +25,7 @@ class UnsetViewHelperTest extends AbstractViewHelperTest
         $variables = new \ArrayObject(['test' => 'test']);
         $instance = $this->buildViewHelperInstance(['name' => 'test']);
         $context = ObjectAccess::getProperty($instance, 'renderingContext', true);
-        if (method_exists($context, 'getVariableProvider')) {
-            $provider = $context->getVariableProvider();
-        } else {
-            $provider = $context->getTemplateVariableContainer();
-        }
+        $provider = $context->getVariableProvider();
         $provider['test'] = 'test';
         $instance->initializeArgumentsAndRender();
         $this->assertNotContains('test', $provider->getAll());


### PR DESCRIPTION
`getTemplateVariableContainer` is deprecated since TYPO3 8 and not working anymore since TYPO3 9, see: [Change Log](https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.0/Deprecation-69863-DeprecateGetTemplateVariableContainerFunction.html?highlight=gettemplatevariablecontainer)