### PR TITLE
Unify exception when second argument is required but missing.

### DIFF
--- a/Classes/ViewHelpers/Math/DivisionViewHelper.php
+++ b/Classes/ViewHelpers/Math/DivisionViewHelper.php
@@ -33,6 +33,9 @@ class DivisionViewHelper extends AbstractMultipleMathViewHelper
     {
         $aIsIterable = static::assertIsArrayOrIterator($a);
         $bIsIterable = static::assertIsArrayOrIterator($b);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             $sum = array_sum($a);
@@ -48,9 +51,6 @@ class DivisionViewHelper extends AbstractMultipleMathViewHelper
                 $a[$index] = static::calculateAction($value, $bSide, $arguments);
             }
             return $a;
-        }
-        if ($b === null && (boolean) $arguments['fail']) {
-            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
         return (0 <> $b ? $a / $b : $a);
     }

--- a/Classes/ViewHelpers/Math/MaximumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MaximumViewHelper.php
@@ -41,12 +41,12 @@ class MaximumViewHelper extends AbstractMultipleMathViewHelper
     protected static function calculateAction($a, $b, array $arguments)
     {
         $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             return max($a);
-        }
-        if ($b === null && (boolean) $arguments['fail']) {
-            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
         return max($a, $b);
     }

--- a/Classes/ViewHelpers/Math/MinimumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MinimumViewHelper.php
@@ -41,12 +41,12 @@ class MinimumViewHelper extends AbstractMultipleMathViewHelper
     protected static function calculateAction($a, $b, array $arguments)
     {
         $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             return min($a);
-        }
-        if ($b === null && (boolean) $arguments['fail']) {
-            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
         return min($a, $b);
     }

--- a/Classes/ViewHelpers/Math/ProductViewHelper.php
+++ b/Classes/ViewHelpers/Math/ProductViewHelper.php
@@ -36,12 +36,12 @@ class ProductViewHelper extends AbstractMultipleMathViewHelper
     protected static function calculateAction($a, $b, array $arguments)
     {
         $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             return array_product($a);
-        }
-        if ($b === null && (boolean) $arguments['fail']) {
-            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
         return $a * $b;
     }

--- a/Classes/ViewHelpers/Math/SubtractViewHelper.php
+++ b/Classes/ViewHelpers/Math/SubtractViewHelper.php
@@ -44,12 +44,12 @@ class SubtractViewHelper extends AbstractMultipleMathViewHelper
     protected static function calculateAction($a, $b, array $arguments)
     {
         $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
+            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
+        }
         if (true === $aIsIterable && null === $b) {
             $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);
             return -array_sum($a);
-        }
-        if ($b === null && (boolean) $arguments['fail']) {
-            ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
         return $a - $b;
     }

--- a/Classes/ViewHelpers/Math/SumViewHelper.php
+++ b/Classes/ViewHelpers/Math/SumViewHelper.php
@@ -44,10 +44,10 @@ class SumViewHelper extends AbstractMultipleMathViewHelper
      */
     protected static function calculateAction($a, $b, array $arguments)
     {
-        if ($b === null && (boolean) $arguments['fail']) {
+        $aIsIterable = static::assertIsArrayOrIterator($a);
+        if (false === $aIsIterable && $b === null && (boolean) $arguments['fail']) {
             ErrorUtility::throwViewHelperException('Required argument "b" was not supplied', 1237823699);
         }
-        $aIsIterable = static::assertIsArrayOrIterator($a);
         if (true === $aIsIterable) {
             if (null === $b) {
                 $a = static::arrayFromArrayOrTraversableOrCSVStatic($a);


### PR DESCRIPTION
The exception is moved up to have the "guard clause" checked first.

Fixes: #1505