### PR TITLE
[TASK] For a TagViewHelper use the trimmed content

### DIFF
--- a/Classes/Traits/TagViewHelperTrait.php
+++ b/Classes/Traits/TagViewHelperTrait.php
@@ -127,7 +127,7 @@ trait TagViewHelperTrait
         $this->tag->addAttributes($attributes);
         $this->tag->forceClosingTag($forceClosingTag);
         if (null !== $content) {
-            $this->tag->setContent($content);
+            $this->tag->setContent($trimmedContent);
         }
         // process some attributes differently - if empty, remove the property:
         foreach ($nonEmptyAttributes as $propertyName) {


### PR DESCRIPTION
The trimmed content was used when the tagname was empty,
but if there was a tag the content was not trimmed.
That should be unified.

Fixes: #1440