### PR TITLE
[BUGFIX] Avoid removed TYPO3_cliMode constant

### DIFF
--- a/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
@@ -40,6 +40,6 @@ class IsCliViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI;
+        return (bool) (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI);
     }
 }

--- a/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Context/IsCliViewHelper.php
@@ -40,6 +40,6 @@ class IsCliViewHelper extends AbstractConditionViewHelper
      */
     protected static function evaluateCondition($arguments = null)
     {
-        return defined('TYPO3_climode');
+        return TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI;
     }
 }


### PR DESCRIPTION
https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.0/Breaking-72368-TYPO3ConstantsRemoved.html