### PR TITLE
[BUGFIX] Fix for #1548

### DIFF
--- a/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/AlternateViewHelper.php
@@ -110,7 +110,7 @@ class AlternateViewHelper extends AbstractViewHelper
         $addQueryString = $this->arguments['addQueryString'];
 
         /** @var UriBuilder $uriBuilder */
-        $uriBuilder = $this->controllerContext->getUriBuilder();
+        $uriBuilder = $this->renderingContext->getControllerContext()->getUriBuilder();
         $uriBuilder = $uriBuilder->reset()
             ->setTargetPageUid($pageUid)
             ->setCreateAbsoluteUri(true)

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -69,7 +69,7 @@ class CanonicalViewHelper extends AbstractTagBasedViewHelper
             );
         }
 
-        $uriBuilder = $this->controllerContext->getUriBuilder();
+        $uriBuilder = $this->renderingContext->getControllerContext()->getUriBuilder();
         $uri = $uriBuilder->reset()
             ->setTargetPageUid($pageUid)
             ->setUseCacheHash(true)


### PR DESCRIPTION
ControllerContext was removed from Viewhelpers with typo3 9.0. Replaced
the two occurences in page/header viewhelpers to fix #1548