### PR TITLE
[BUGFIX] Fix for #1579. Add argument  to UnlessViewHelper

### DIFF
--- a/Classes/ViewHelpers/UnlessViewHelper.php
+++ b/Classes/ViewHelpers/UnlessViewHelper.php
@@ -47,6 +47,18 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class UnlessViewHelper extends AbstractConditionViewHelper
 {
     /**
+     * {@inheritdoc}
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+
+        if (false === array_key_exists('condition', $this->argumentDefinitions)) {
+            $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
+        }
+    }
+
+    /**
      * Rendering with inversion and ignoring any f:then / f:else children.
      *
      * @return string|NULL


### PR DESCRIPTION
Automatic registration of condition argument was removed from AbstractConditionViewHelper since Typo3/Fluid v2.6.0