### PR TITLE
[BUGFIX] Use keyword "root" for default pidInList in language mode

### DIFF
--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -282,7 +282,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
         $limitLanguages = array_filter($limitLanguages);
 
         if (!empty($limitLanguages)) {
-            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => -1, 'uidInList' => implode(',', $limitLanguages)]);
+            $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => 'root', 'uidInList' => implode(',', $limitLanguages)]);
         } else {
             $sysLanguage = $GLOBALS['TSFE']->cObj->getRecords($from, ['selectFields' => $select, 'pidInList' => 'root']);
         }


### PR DESCRIPTION
if variable "language" is set in the viewhelper for example "0,1", nothing return.