### PR TITLE
[FIX] do not rawurlencode first argument of preprocessSourceUrl calls

### DIFF
--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -49,7 +49,7 @@ trait SourceSetViewHelperTrait
             $srcsetVariant = $this->getImgResource($src, $width, $format, $quality, $treatIdAsReference, null, $crop);
 
             $srcsetVariantSrc = rawurldecode($srcsetVariant[3]);
-            $srcsetVariantSrc = static::preprocessSourceUri(str_replace('%2F', '/', rawurlencode($srcsetVariantSrc)), $this->arguments);
+            $srcsetVariantSrc = static::preprocessSourceUri($srcsetVariantSrc, $this->arguments);
 
             $imageSources[$srcsetVariant[0]] = [
                 'src' => $srcsetVariantSrc,


### PR DESCRIPTION
otherwise method "preprocessSourceUri" does another rawurlencode which encodes %2F to %252F