### PR TITLE
[BUGFIX] Restore negative $length support after switch to mb_ functions

### DIFF
--- a/Classes/ViewHelpers/Format/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SubstringViewHelper.php
@@ -45,6 +45,9 @@ class SubstringViewHelper extends AbstractViewHelper
         $start = (integer) $arguments['start'];
         $length = $arguments['length'];
         if (null !== $length) {
+            if ($length < 0) {
+                $length = $length + mb_strlen($content) - $start;
+            }
             return mb_substr($content, $start, $length);
         }
         return mb_substr($content, $start);

--- a/Classes/ViewHelpers/Format/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SubstringViewHelper.php
@@ -46,6 +46,8 @@ class SubstringViewHelper extends AbstractViewHelper
         $length = $arguments['length'];
         if (null !== $length) {
             if ($length < 0) {
+                // mb_substr does not support negative length, therefore we must calculate the length based on
+                // original string length and offset, so we can pass a positive integer to mb_substr.
                 $length = $length + mb_strlen($content) - $start;
             }
             return mb_substr($content, $start, $length);


### PR DESCRIPTION
mb_substr() does not officially support negative $length. Use own calculation to make it work again.

Resolves: #1587