### PR TITLE
[BUGFIX] Allow sorting by DateTimeInterface

### DIFF
--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -215,7 +215,7 @@ class SortViewHelper extends AbstractViewHelper
     {
         $field = $arguments['sortBy'];
         $value = ObjectAccess::getPropertyPath($object, $field);
-        if (true === $value instanceof \DateTime) {
+        if (true === $value instanceof \DateTimeInterface) {
             $value = (integer) $value->format('U');
         } elseif (true === $value instanceof ObjectStorage || true === $value instanceof LazyObjectStorage) {
             $value = $value->count();


### PR DESCRIPTION
`Iterator\SortViewHelper` now checks for all forms of `\DateTimeInterface` when trying to deduce a sort value from objects

fixes #1610 