### PR TITLE
[BUGFIX] Fix extension config handling on TYPO3 10

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -52,8 +52,15 @@ if (false === function_exists('mb_strlen') || false === function_exists('mb_chr'
         function mb_scrub($s, $enc = null) { $enc = null === $enc ? mb_internal_encoding() : $enc; return mb_convert_encoding($s, $enc, $enc); }
     }
 }
-
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = unserialize($_EXTCONF);
+if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+    )->get('vhs');
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility::class
+    )->getCurrentConfiguration('vhs');
+}
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup']['disableAssetHandling']) || !$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['vhs']['setup']['disableAssetHandling']) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['usePageCache'][] = 'FluidTYPO3\\Vhs\\Service\\AssetService';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'FluidTYPO3\\Vhs\\Service\\AssetService->buildAllUncached';


### PR DESCRIPTION
Variable `$_EXTCONF` not exist anymore at TYPO3 10.x.

See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html?highlight=_extconf