### PR TITLE
[BUGFIX] Replaced Deprecated PATH_site Constant, Updated Utility Func…

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -640,7 +640,7 @@ class AssetService implements SingletonInterface
                 $newPath = basename($path);
                 $extension = pathinfo($newPath, PATHINFO_EXTENSION);
                 $temporaryFileName = 'vhs-assets-css-' . $checksum . '.' . $extension;
-                $temporaryFile = constant('PATH_site') . $this->getTempPath() . $temporaryFileName;
+                $temporaryFile = CoreUtility::getSitePath() . $this->getTempPath() . $temporaryFileName;
                 $rawPath = GeneralUtility::getFileAbsFileName(
                     $originalDirectory . (empty($originalDirectory) ? '' : '/')
                 ) . $path;

--- a/Classes/Utility/CoreUtility.php
+++ b/Classes/Utility/CoreUtility.php
@@ -37,7 +37,8 @@ class CoreUtility
         if (defined('PATH_site')) {
             return constant('PATH_site');
         }
-        return Environment::getPublicPath();
+        /** @see https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ApiOverview/GlobalValues/Constants/Index.html#path-site */
+        return Environment::getPublicPath() . '/';
     }
 
     /**

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -233,7 +233,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     {
         $this->tsfeBackup = true === isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
         $this->workingDirectoryBackup = getcwd();
-        chdir(constant(CoreUtility::getSitePath()));
+        chdir(CoreUtility::getSitePath());
         $typoScriptSetup = $this->configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -233,7 +233,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
     {
         $this->tsfeBackup = true === isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
         $this->workingDirectoryBackup = getcwd();
-        chdir(constant('PATH_site'));
+        chdir(constant(CoreUtility::getSitePath()));
         $typoScriptSetup = $this->configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
         );

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -203,7 +203,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = 0;
         $template->init();
-        $template->getFileName_backPath = constant('PATH_site');
+        $template->getFileName_backPath = constant(CoreUtility::getSitePath());
         $GLOBALS['TSFE']->tmpl = $template;
         $GLOBALS['TSFE']->tmpl->setup = $typoScriptSetup;
         $GLOBALS['TSFE']->config = $typoScriptSetup;

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -203,7 +203,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
         $template = GeneralUtility::makeInstance(TemplateService::class);
         $template->tt_track = 0;
         $template->init();
-        $template->getFileName_backPath = constant(CoreUtility::getSitePath());
+        $template->getFileName_backPath = CoreUtility::getSitePath();
         $GLOBALS['TSFE']->tmpl = $template;
         $GLOBALS['TSFE']->tmpl->setup = $typoScriptSetup;
         $GLOBALS['TSFE']->config = $typoScriptSetup;


### PR DESCRIPTION
…tion as documented in Typo3core API

- Refactored usage of Deprecated ```PATH_site``` constant in ```AssetService``` and ```AbstractImageViewHelper```
- Changed ```CoreUtitlity::getSitePath()``` to Return a correct Replacement of the PATH_site constant (see: https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ApiOverview/GlobalValues/Constants/Index.html#path-site)