### PR TITLE
[BUGFIX] Respect page language overlay

### DIFF
--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -37,6 +37,11 @@ class FalViewHelper extends ResourcesFalViewHelper
     protected $field = self::DEFAULT_FIELD;
 
     /**
+     * @var string
+     */
+    protected $localizedIdField = "_PAGES_OVERLAY_UID";
+
+    /**
      * Initialize arguments.
      *
      * @return void

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -62,6 +62,11 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
     protected $escapeOutput = false;
 
     /**
+     * @var string
+     */
+    protected $localizedIdField = "_LOCALIZED_UID";
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -116,10 +121,8 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
 
         if (isset($record['t3ver_oid']) && (integer) $record['t3ver_oid'] !== 0) {
             $sqlRecordUid = $record['t3ver_oid'];
-        } elseif (isset($record['_LOCALIZED_UID'])) {
-            $sqlRecordUid = $record['_LOCALIZED_UID'];
-        } elseif (isset($record['_PAGES_OVERLAY_UID'])) {
-            $sqlRecordUid = $record['_PAGES_OVERLAY_UID'];
+        } elseif (isset($record[$this->localizedIdField])) {
+            $sqlRecordUid = $record[$this->localizedIdField];
         } else {
             $sqlRecordUid = $record[$this->idField];
         }
@@ -141,8 +144,8 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
         } else {
             if (isset($record['t3ver_oid']) && (integer) $record['t3ver_oid'] !== 0) {
                 $sqlRecordUid = $record['t3ver_oid'];
-            } elseif (isset($record['_LOCALIZED_UID'])) {
-                $sqlRecordUid = $record['_LOCALIZED_UID'];
+            } elseif (isset($record[$this->localizedIdField])) {
+                $sqlRecordUid = $record[$this->localizedIdField];
             } else {
                 $sqlRecordUid = $record[$this->idField];
             }

--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -118,6 +118,8 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
             $sqlRecordUid = $record['t3ver_oid'];
         } elseif (isset($record['_LOCALIZED_UID'])) {
             $sqlRecordUid = $record['_LOCALIZED_UID'];
+        } elseif (isset($record['_PAGES_OVERLAY_UID'])) {
+            $sqlRecordUid = $record['_PAGES_OVERLAY_UID'];
         } else {
             $sqlRecordUid = $record[$this->idField];
         }


### PR DESCRIPTION
In `\FluidTYPO3\Vhs\ViewHelpers\Resource\Record\FalViewHelper::getFileReferences`  use `$record['_PAGES_OVERLAY_UID']` to get the correct page uid for the language overlay.

This solution works for me, but I'm not an expert in TYPO3s language handling.
