### PR TITLE
[BUGFIX] Replaced deprecated GeneralUtility::sysLog calls with new logging API

### DIFF
--- a/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -125,7 +127,11 @@ class ExtractViewHelper extends AbstractViewHelper
                 $result = static::extractByKey($content, $key);
             }
         } catch (\Exception $error) {
-            GeneralUtility::sysLog($error->getMessage(), 'vhs', GeneralUtility::SYSLOG_SEVERITY_WARNING);
+            if (class_exists(LogManager::class)) {
+                GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__)->warning($error->getMessage(), ['content' => $content]);
+            } else {
+                GeneralUtility::sysLog($error->getMessage(), 'vhs', GeneralUtility::SYSLOG_SEVERITY_WARNING);
+            }
             $result = [];
         }
 


### PR DESCRIPTION
Fixes #1649 

- Changed FluidTYPO3\Vhs\Service\AssetService to implement LoggerAwareInterface and call $this->logger->warning() instead of GeneralUtility::sysLog()
- Added static getLogger() function to FluidTYPO3\Vhs\ViewHelpers\Iterator\ExtractViewHelper and used it to call self::getLogger()->warning() instead of GeneralUtility::sysLog()