### PR TITLE
Support chain notation for PregMatchViewHelper subject

### DIFF
--- a/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
+++ b/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
@@ -40,7 +40,7 @@ class PregMatchViewHelper extends AbstractViewHelper
     {
         $this->registerAsArgument();
         $this->registerArgument('pattern', 'mixed', 'Regex pattern to match against', true);
-        $this->registerArgument('subject', 'mixed', 'String to match with the regex pattern', true);
+        $this->registerArgument('subject', 'mixed', 'String to match with the regex pattern', false);
         $this->registerArgument('global', 'boolean', 'Match global', false, false);
     }
 


### PR DESCRIPTION
The existing rendering suggested at supporting `{value -> v:variable.pregMatch(...)}` but this was actually not working since the "subject" argument was required.