### PR TITLE
Drop ChildNodeAccessInterface usage

### DIFF
--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -13,7 +13,6 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode as LegacyFluidObjectAccessorNode;
 use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\ViewHelperNode as LegacyFluidViewHelperNode;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode as StandaloneFluidObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode as StandaloneFluidViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -65,7 +64,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * @package Vhs
  * @subpackage ViewHelpers
  */
-class DebugViewHelper extends AbstractViewHelper implements ChildNodeAccessInterface
+class DebugViewHelper extends AbstractViewHelper
 {
 
     /**

--- a/Classes/ViewHelpers/Security/DenyViewHelper.php
+++ b/Classes/ViewHelpers/Security/DenyViewHelper.php
@@ -8,8 +8,6 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Security;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
-
 /**
  * ### Security: Deny
  *
@@ -19,7 +17,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\ChildNodeAccessInterface;
  *
  * Is the mirror opposite of `v:security.allow`.
  */
-class DenyViewHelper extends AbstractSecurityViewHelper implements ChildNodeAccessInterface
+class DenyViewHelper extends AbstractSecurityViewHelper
 {
 
     /**


### PR DESCRIPTION
This has been deprecated in TYPO3v9 and dropped in TYPO3v10.

The interface is not necessary since the switch to standalone Fluid with TYPO3v8 whose `ViewHelperInterface` already contains the `setChildNodes()` method formerly defined by `ChildNodeAccessInterface`.

Fixes #1695