### PR TITLE
[TASK] Add Service.yaml to expose classes as services for DI

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  FluidTYPO3\Vhs\:
+    resource: '../Classes/*'


### PR DESCRIPTION
When migrating from `$objectManager->get()` to constructor dependency injection I got this error:

> Cannot autowire service "Vendor\ExtensionKey\ViewHelpers\MenuViewHelper": argument "$pageService" of method "FluidTYPO3\Vhs\ViewHelpers\Menu\AbstractMenuViewHelper::injectPageService()" references class "FluidTYPO3\Vhs\Service\PageService" but no such service exists.

To be able to use constructor DI, the service needs to be exposed through an Service.yaml file. This PR adds this file.