### PR TITLE
fix unused shortcutuid

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -461,7 +461,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
                     $pages[$index] = $targetPage;
                 }
                 if ($this->pageService->shouldUseShortcutUid($this->arguments)) {
-                    $page['uid'] = $targetPage['uid'];
+                    $pages[$index]['uid'] = $targetPage['uid'];
                 }
             }
             if (true === $this->pageService->isActive($originalPageUid, $showAccessProtected)) {


### PR DESCRIPTION
It just makes no sense to set something on $page, because it is not used afterwards.
Fixes #1639 and reverts the revert of #1422 