### PR TITLE
Mention <f:format.raw> for "whitespaceBetweenHtmlTags"

### DIFF
--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -53,7 +53,7 @@ class EliminateViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'whitespaceBetweenHtmlTags',
             'boolean',
-            'Eliminate ALL whitespace characters between HTML tags',
+            'Eliminate ALL whitespace characters between HTML tags. Use this together with <f:format.raw>',
             false,
             false
         );


### PR DESCRIPTION
.. because output is escaped by default.

See https://github.com/FluidTYPO3/vhs/issues/1475