### PR TITLE
[FEATURE] Handle t3://file?uid=23 URLs in <v:resource.file> view helper

### DIFF
--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -90,6 +90,22 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
              return null;
         }
 
+        if (true === $treatIdAsUid) {
+            foreach ($identifier as $key => $maybeUrl) {
+                if (substr($maybeUrl, 0, 5) !== 't3://') {
+                    continue;
+                }
+                $parts = parse_url($maybeUrl);
+                if (false === isset($parts['host']) || $parts['host'] !== 'file' || false === isset($parts['query'])) {
+                    continue;
+                }
+                parse_str($parts['query'], $queryParts);
+                if (true === isset($queryParts['uid'])) {
+                    $identifier[$key] = $queryParts['uid'];
+                }
+            }
+        }
+
         $files = [];
         /** @var ResourceFactory $resourceFactory */
         $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);


### PR DESCRIPTION
.. when treatAsUid=1

Those URLs appear when using a
 <flux:field type="input" config="{renderType: 'inputLink'}"/>

Resolves: https://github.com/FluidTYPO3/vhs/issues/1710