### PR TITLE
[BUGFIX] Do not process absolute image URIs in the backend

### DIFF
--- a/Classes/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Uri/ImageViewHelper.php
@@ -27,7 +27,12 @@ class ImageViewHelper extends AbstractImageViewHelper
     public function render()
     {
         $this->preprocessImage();
-        $src = static::preprocessSourceUri($this->mediaSource, $this->arguments);
+        if (substr($this->mediaSource, 0, 4) !== 'http') {
+            $src = static::preprocessSourceUri($this->mediaSource, $this->arguments);
+        } else {
+            //in the backend, we sometimes get absolute URIs
+            $src = $this->mediaSource;
+        }
         return $src;
     }
 }


### PR DESCRIPTION
Sometimes the TYPO3v10 backend already returns absolute image URLs that do
not need to be modified anymore.
This happens for a couple of minutes only, afterwards the backend returns relative
URLs.
This patch fixes image URLs in that short timeframe.

Example of such an absolute image URL returned in the backend that needs no
further processing:
 http://localhost:5707/typo3/index.php?route=/image/process&token=414b99de77e22aa555584f4c53fdb5ebb9b2deb9&id=516701

----

This happened with TYPO3 v10.4.14 and vhs 6.0.5.