### PR TITLE
[BUGFIX] Handle both t3:// and normal file names at once

### DIFF
--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -90,19 +90,18 @@ abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
              return null;
         }
 
-        if (true === $treatIdAsUid) {
-            foreach ($identifier as $key => $maybeUrl) {
-                if (substr($maybeUrl, 0, 5) !== 't3://') {
-                    continue;
-                }
-                $parts = parse_url($maybeUrl);
-                if (false === isset($parts['host']) || $parts['host'] !== 'file' || false === isset($parts['query'])) {
-                    continue;
-                }
-                parse_str($parts['query'], $queryParts);
-                if (true === isset($queryParts['uid'])) {
-                    $identifier[$key] = $queryParts['uid'];
-                }
+        foreach ($identifier as $key => $maybeUrl) {
+            if (substr($maybeUrl, 0, 5) !== 't3://') {
+                continue;
+            }
+            $parts = parse_url($maybeUrl);
+            if (false === isset($parts['host']) || $parts['host'] !== 'file' || false === isset($parts['query'])) {
+                continue;
+            }
+            parse_str($parts['query'], $queryParts);
+            if (true === isset($queryParts['uid'])) {
+                $identifier[$key] = $queryParts['uid'];
+                $treatIdAsUid = true;
             }
         }
 


### PR DESCRIPTION
Fixup for "[FEATURE] Handle t3://file?uid=23 URLs in <v:resource.file> view helper"

The value of field

    <flux:field type="input" config="{renderType: 'inputLink'}"/>

gets different values in TYPO3 v9 and v10:

- TYPO3 v9 stored the path to the filename, e.g. "fileadmin/user_upload/image.jpg"
- TYPO3 v10 stores a t3:// URL, e.g. "t3://file?uid=2342"

This patch automatically detects t3:// URLs in all image sources, regardless
if $treatAsUid is given.

That way the view helpers can load an image regardless if they have been stored
in TYPO3 v9 or v10:

    <v:resource.file identifier="fileadmin/user_upload/image.jpg"/>
    <v:resource.file identifier="t3://file?uid=2342"/>