### PR TITLE
Enable stable releases from TYPO3-11-branch with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,9 +60,6 @@
           "cms-package-dir": "{$vendor-dir}/typo3/cms",
           "extension-key": "vhs",
           "web-dir": "build/web"
-        },
-        "branch-alias": {
-          "dev-development": "7.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     },
     "require": {
         "php": "^7.0.0",
-        "typo3/cms-core": "^8.7 || ^9 || ^10 || ^11.1@dev",
-        "typo3/cms-extbase": "^8.7 || ^9 || ^10 || ^11.1@dev",
-        "typo3/cms-fluid": "^8.7 || ^9 || ^10 || ^11.1@dev",
-        "typo3/cms-frontend": "^8.7 || ^9 || ^10 || ^11.1@dev",
-        "typo3/cms-backend": "^8.7 || ^9 || ^10 || ^11.1@dev"
+        "typo3/cms-core": "^8.7 || ^9 || ^10 || ^11.1@dev || dev-master",
+        "typo3/cms-extbase": "^8.7 || ^9 || ^10 || ^11.1@dev || dev-master",
+        "typo3/cms-fluid": "^8.7 || ^9 || ^10 || ^11.1@dev || dev-master",
+        "typo3/cms-frontend": "^8.7 || ^9 || ^10 || ^11.1@dev || dev-master",
+        "typo3/cms-backend": "^8.7 || ^9 || ^10 || ^11.1@dev || dev-master"
     },
     "replace": {
         "typo3-ter/vhs": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
           "cms-package-dir": "{$vendor-dir}/typo3/cms",
           "extension-key": "vhs",
           "web-dir": "build/web"
+        },
+        "branch-alias": {
+          "dev-development": "7.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     },
     "require": {
         "php": "^7.0.0",
-        "typo3/cms-core": "^8.7 || ^9 || ^10 || dev-master",
-        "typo3/cms-extbase": "^8.7 || ^9 || ^10 || dev-master",
-        "typo3/cms-fluid": "^8.7 || ^9 || ^10 || dev-master",
-        "typo3/cms-frontend": "^8.7 || ^9 || ^10 || dev-master",
-        "typo3/cms-backend": "^8.7 || ^9 || ^10 || dev-master"
+        "typo3/cms-core": "^8.7 || ^9 || ^10 || ^11.1@dev",
+        "typo3/cms-extbase": "^8.7 || ^9 || ^10 || ^11.1@dev",
+        "typo3/cms-fluid": "^8.7 || ^9 || ^10 || ^11.1@dev",
+        "typo3/cms-frontend": "^8.7 || ^9 || ^10 || ^11.1@dev",
+        "typo3/cms-backend": "^8.7 || ^9 || ^10 || ^11.1@dev"
     },
     "replace": {
         "typo3-ter/vhs": "self.version"


### PR DESCRIPTION
When upgrading an extension for TYPO3-11 it is desirable to work with as much stable releases as possible. This pull request would allow to use the dev-branch from vhs together with stable TYPO3 releases from the latest branch.