### PR TITLE
migrated deprecated namespace für PageRepository

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
-use TTYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 /**
  * Page Service

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 /**
  * Page Service
  *
- * Wrapper service for \TTYPO3\CMS\Core\Domain\Repository\PageRepository including static caches for
+ * Wrapper service for \TYPO3\CMS\Core\Domain\Repository\PageRepository including static caches for
  * menus, rootlines, pages and page overlays to be implemented in
  * viewhelpers by replacing calls to \TYPO3\CMS\Core\Domain\Repository\PageRepository::getMenu()
  * and the like.

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -14,14 +14,14 @@ use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TTYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 /**
  * Page Service
  *
- * Wrapper service for \TYPO3\CMS\Frontend\Page\PageRepository including static caches for
+ * Wrapper service for \TTYPO3\CMS\Core\Domain\Repository\PageRepository including static caches for
  * menus, rootlines, pages and page overlays to be implemented in
- * viewhelpers by replacing calls to \TYPO3\CMS\Frontend\Page\PageRepository::getMenu()
+ * viewhelpers by replacing calls to \TYPO3\CMS\Core\Domain\Repository\PageRepository::getMenu()
  * and the like.
  */
 class PageService implements SingletonInterface

--- a/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
+++ b/Classes/ViewHelpers/Condition/Page/IsChildPageViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Condition\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**

--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\Service\PageService;
 use FluidTYPO3\Vhs\Traits\PageRecordViewHelperTrait;
 use FluidTYPO3\Vhs\Traits\TagViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**

--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  */
 
 use FluidTYPO3\Vhs\ViewHelpers\Menu\AbstractMenuViewHelper;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepositoryory;
 
 /**
  * ViewHelper to make a breadcrumb link set from a pageUid, automatic or manual.

--- a/Classes/ViewHelpers/Page/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Page/InfoViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;

--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -13,7 +13,7 @@ use FluidTYPO3\Vhs\ViewHelpers\Resource\Record\FalViewHelper as ResourcesFalView
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 /**
  * Page FAL resource ViewHelper.

--- a/Tests/Unit/ViewHelpers/Page/InfoViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/InfoViewHelperTest.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  */
 
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 /**
  * Class InfoViewHelperTest

--- a/Tests/Unit/ViewHelpers/Page/RootlineViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/RootlineViewHelperTest.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTest;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
-use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
 /**
  * Class RootlineViewHelperTest


### PR DESCRIPTION
namespace `TYPO3\CMS\Frontend\Page\PageRepository` for PageRepository marked as deprecated in Typo3 v10 
therefor I changed the namespace notation for this in the whole Project to `TYPO3\CMS\Core\Domain\Repository\PageRepository` according to the  [Typo3 Docs](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-88746-PageRepositoryPHPClassMovedFromFrontendToCoreExtension.html)