### PR TITLE
[BUGFIX] PageService 11LTS compatibility

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -49,6 +49,16 @@ class PageService implements SingletonInterface
      */
     protected static $backendPageRepository;
 
+   /**
+    * Constructor
+    */
+    public function __construct()
+    {
+        if (!class_exists(\TYPO3\CMS\Frontend\Page\PageRepository::class)) {
+            class_alias('\TYPO3\CMS\Core\Domain\Repository\PageRepository', '\TYPO3\CMS\Frontend\Page\PageRepository');
+        }
+    }
+    
     /**
      * @param integer $pageUid
      * @param array $excludePages


### PR DESCRIPTION
I know this is not the wanted solution as @NamelessCoder requested a factory class for creating the PageRepository object. But the [current solution](https://github.com/FluidTYPO3/vhs/pull/1749/commits/52e20042689cb5ca70992b5857a68e22de330563) does not work for me, as calls to constants like PageRepository::DOKTYPE_BE_USER_SECTION are not covered yet.
This one fixes #1749 for me.