### PR TITLE
[DOCS] Align with new TYPO3 documentation standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,20 +2,19 @@
 
 # top-most EditorConfig file
 root = true
-charset = utf-8
 
-# Get rid of whitespace to avoid diffs with a bunch of EOL changes
-trim_trailing_whitespace = true
-
+# Unix-style newlines with a newline ending every file
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{html,js,css}]
 indent_size = 4
 indent_style = tab
 
-[*.{php}]
+[*.php]
 indent_size = 4
 indent_style = space
 
@@ -26,3 +25,8 @@ indent_style = space
 [*.{xml,xlf,xsd}]
 indent_size = 2
 indent_style = tab
+
+[*.md]
+indent_style = space
+indent_size = 4
+max_line_length = 80

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # TYPO3 extension `vhs`
 
-This is a collection of view helpers for performing rendering tasks that are not
+This is a collection of ViewHelpers for performing rendering tasks that are not
 natively provided by TYPO3's [Fluid templating engine](https://docs.typo3.org/other/typo3/view-helper-reference/10.4/en-us/).
 These include advanced formatters, mathematical calculators, special conditions,
 and iterators and array calculators and processors.
@@ -64,7 +64,7 @@ these problems.
 
 ### Asset examples
 
-The following VHS view helper usage:
+The following VHS ViewHelper usage:
 
 ```
 <v:asset.script path="fileadmin/demo.js" />

--- a/README.md
+++ b/README.md
@@ -24,14 +24,13 @@ and iterators and array calculators and processors.
 
 ## Installation
 
-The latest version can be installed via [TER](https://extensions.typo3.org/extension/vhs)
-or via composer by running
+The latest version can be installed via composer by running
 
 ```
 composer require fluidtypo3/vhs
 ```
 
-in a TYPO3 installation.
+in a TYPO3 installation, or via [TER](https://extensions.typo3.org/extension/vhs).
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,82 @@
+[![Latest Stable Version](https://poser.pugx.org/fluidtypo3/vhs/v/stable.svg?style=flat-square)](https://extensions.typo3.org/extension/vhs/)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![TYPO3 9](https://img.shields.io/badge/TYPO3-9-orange.svg?style=flat-square)](https://get.typo3.org/version/9)
+[![TYPO3 8](https://img.shields.io/badge/TYPO3-8-orange.svg?style=flat-square)](https://get.typo3.org/version/8)
+[![Total Downloads](https://poser.pugx.org/fluidtypo3/vhs/d/total?style=flat-square)](https://packagist.org/packages/fluidtypo3/vhs)
+[![Monthly Downloads](https://poser.pugx.org/fluidtypo3/vhs/d/monthly?style=flat-square)](https://packagist.org/packages/fluidtypo3/vhs)
+[![Build Status](https://img.shields.io/travis/FluidTYPO3/vhs.svg?style=flat-square&label=package)](https://travis-ci.org/FluidTYPO3/vhs)
+[![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/vhs/development.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/vhs)
+
 <img src="https://fluidtypo3.org/logo.svgz" width="100%" />
 
-VHS: Fluid ViewHelpers
-======================
+# TYPO3 extension `vhs`
 
-> Collection of general purpose ViewHelpers usable in the Fluid templating engine
-> that's bundled with the TYPO3 CMS.
+This is a collection of view helpers for performing rendering tasks that are not
+natively provided by TYPO3's [Fluid templating engine](https://docs.typo3.org/other/typo3/view-helper-reference/10.4/en-us/).
+These include advanced formatters, mathematical calculators, special conditions,
+and iterators and array calculators and processors.
 
-[![Build Status](https://img.shields.io/travis/FluidTYPO3/vhs.svg?style=flat-square&label=package)](https://travis-ci.org/FluidTYPO3/vhs) [![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/vhs/development.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/vhs) [![Documentation](http://img.shields.io/badge/documentation-online-blue.svg?style=flat-square)](https://viewhelpers.fluidtypo3.org/fluidtypo3/vhs/)
+|                  | URL                                                 |
+|------------------|-----------------------------------------------------|
+| **Repository:**  | https://github.com/FluidTYPO3/vhs                   |
+| **Read online:** | https://viewhelpers.fluidtypo3.org/fluidtypo3/vhs/  |
+| **TER:**         | https://extensions.typo3.org/extension/vhs          |
 
 ## Installation
 
-### Installation using Composer
+The latest version can be installed via [TER](https://extensions.typo3.org/extension/vhs)
+or via composer by running
 
-The recommended way to install the extension is by using [Composer](https://getcomposer.org/). In your Composer based TYPO3 project root, just do `composer require fluidtypo3/vhs`.
+```
+composer require fluidtypo3/vhs
+```
 
-### Installation as extension from TYPO3 Extension Repository (TER)
-
-Download and install as TYPO3 extension. That's it.
+in a TYPO3 installation.
 
 ## Settings
 
-Although there are no static TypoScript files which can be included, VHS does support a few key settings which are defined in TypoScript:
+Although there are no static TypoScript files which can be included, VHS does
+support a few key settings which are defined in TypoScript:
 
 ### Debug settings
 
-* `plugin.tx_vhs.settings.debug = 1` can be used to enable general debugging, which causes Asset inclusions to be debugged right before inclusion in the page
-* `plugin.tx_vhs.settings.asset.debug = 1` can be used to enable debug output from individual Asset ViewHelper instances. Applies when a ViewHelper uses the "debug" parameter (where this is supported) and/or when `plugin.tx_vhs.settings.debug = 1`.
-* `plugin.tx_vhs.settings.useDebugUtility` which causes VHS to use Extbase's DebugUtility to dump variables. If this setting is not defined a value of `1` is assumed.
+* `plugin.tx_vhs.settings.debug = 1` can be used to enable general debugging,
+  which causes Asset inclusions to be debugged right before inclusion in the
+  page.
+
+* `plugin.tx_vhs.settings.asset.debug = 1` can be used to enable debug output
+  from individual Asset ViewHelper instances. Applies when a ViewHelper uses the
+  "debug" parameter (where this is supported) and/or when
+  `plugin.tx_vhs.settings.debug = 1`.
+
+* `plugin.tx_vhs.settings.useDebugUtility` which causes VHS to use Extbase's
+  DebugUtility to dump variables. If this setting is not defined a value of `1`
+  is assumed.
 
 ## Assets
 
-VHS contains a highly useful feature which enables you to define Assets (CSS/JS/etc) in Fluid templates, PHP and TypoScript. What's different from the traditional ways of including such Assets (in Fluid or otherwise) all are used differently, controlled differently and probably worst of all, not all of them are integrator friendly (as in: allows Assets to be affected using TypoScript). VHS Assets solves all of this.
+VHS includes a very useful feature that allows you to define assets (CSS,
+JavaScript, etc.) in Fluid templates, PHP, and TypoScript. The traditional way
+of including such assets in Fluid or elsewhere was that they were all used and
+controlled differently and, probably worst of all, they were not all integration
+friendly as assets could be modified with TypoScript. VHS Assets solves all
+these problems.
 
-### Asset Examples
+### Asset examples
 
-The following Fluid usage:
+The following VHS view helper usage:
 
 ```
 <v:asset.script path="fileadmin/demo.js" />
 ```
 
-Is the exact same as ths PHP:
+is the exact same as this PHP call:
 
 ```
 \FluidTYPO3\Vhs\Asset::createFromFile('fileadmin/demo.js');
 ```
 
-Which is a short form of:
+which is a short form of:
 
 ```
 \FluidTYPO3\Vhs\Asset::createFromSettings(array(
@@ -55,7 +85,7 @@ Which is a short form of:
 ));
 ```
 
-Which is itself a short form of:
+which is itself a short form of:
 
 ```
 $asset = \FluidTYPO3\Vhs\Asset::getInstance();
@@ -67,13 +97,13 @@ $asset->setPath('fileadmin/demo.js');
 $asset->finalize(); // manually created Assets must be finalized before they show up.
 ```
 
-The PHP above does the exact same as this TypoScript:
+The PHP call above does the exact same as this TypoScript:
 
 ```
 plugin.tx_vhs.settings.asset.demo.path = fileadmin/demo.js
 ```
 
-Which is a short form of:
+which is a short form of:
 
 ```
 plugin.tx_vhs.settings.asset.demo {
@@ -82,17 +112,28 @@ plugin.tx_vhs.settings.asset.demo {
 }
 ```
 
-In summary: regardless of where and how you use VHS Assets, they always use the same attributes, they always behave the same, support the same features (such as dependency on other Assets regardless of inclusion order and addressing Assets by a group name to affect multiple Assets - and even rendering JS/CSS as if the file was a Fluid template).
+In summary: regardless of where and how you use VHS Assets, they always use the
+same attributes, they always behave the same, support the same features (such as
+dependency on other assets regardless of inclusion order and addressing assets
+by a group name to affect multiple assets - and even rendering JavaScript and
+CSS as if the file was a Fluid template).
 
 The API for inclusion changes but the result is the same.
 
-But the real benefit of VHS Assets comes in the form of the TypoScript integration, which lets you override settings of individual Assets (regardless of how they were originally defined - Fluid, PHP, TypoScript) by setting their attributes in TypoScript. This allows integrators to control every aspect of every Asset (but not the ones included in traditional ways) all the way down to replacing the script source or CSS content that gets inserted or moving JS file(s) which used by be merged, to a new CDN server without even breaking dependencies and execution order.
+But the real benefit of VHS Assets comes in the form of the TypoScript
+integration, which lets you override settings of individual assets (regardless
+of how they were originally defined - Fluid, PHP, TypoScript) by setting their
+attributes in TypoScript. This allows integrators to control every aspect of
+every asset (but not the ones included in traditional ways) all the way down to
+replacing the script source or CSS content that gets inserted or moving
+JavaScript file(s) which used to be merged, to a new CDN server without even
+breaking dependencies and execution order.
 
 To affect VHS Assets through TypoScript, the following settings can be used:
 
 ### Asset settings
 
-```javascript
+```
 plugin.tx_vhs.settings.asset.ASSETNAME {
 	content = Text # Text which overrides content
 	path = FileReference # If set, turns Asset into a file inclusion
@@ -127,10 +168,23 @@ plugin.tx_vhs.assets {
 
 ## Secondary domain name for resources
 
-You can configure VHS to write path prepends in two ways, one of which allows you to create a so-called "cookie-free domain" on which requests will contain fewer headers. Normally, setting `config.absRefPrefix` causes your resources' paths to be prefixed with a domain, but using this approach will always prepend a domain name which cannot be "cookie-free". VHS allows an alternative setting for path prefix, which can be set to a secondary domain name (pointing to the same virtual host or not) which sets no cookies, causing all asset tags to be written with this prefix prepended:
+You can configure VHS to write path prepends in two ways, one of which allows
+you to create a so-called "cookie-free domain" on which requests will contain
+fewer headers. Normally, setting `config.absRefPrefix` causes your resources'
+paths to be prefixed with a domain, but using this approach will always prepend
+a domain name which cannot be "cookie-free". VHS allows an alternative setting
+for path prefix, which can be set to a secondary domain name (pointing to the
+same virtual host or not) which sets no cookies, causing all asset tags to be
+written with this prefix prepended:
 
-```javascript
-plugin.tx_vhs.settings.prependPath = http://static.mydomain.com/
+```
+plugin.tx_vhs.settings.prependPath = https://static.mydomain.com/
 ```
 
-The setting affects *every* relative-path resource ViewHelper (NB: this does not include links!) in VHS, which is why it is not placed inside the "asset" scope. If you need to output this prefix path in templates you can use the `v:page.staticPrefix` ViewHelper - it accepts no arguments and only outputs the setting if it is set. For example, using `f:image` will not prefix the image path but manually creating an `<img />` tag and using `f:uri.image` as `src` argument will allow you to prefix the path.
+The setting affects *every* relative path resource ViewHelper (NB: this does not
+include links!) in VHS, which is why it is not placed inside the "asset" scope.
+If you need to output this prefix path in templates you can use the `v:page.staticPrefix`
+ViewHelper - it accepts no arguments and only outputs the setting if it is set.
+For example, using `f:image` will not prefix the image path but manually
+creating an `<img />` tag and using `f:uri.image` as `src` argument will allow
+you to prefix the path.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fluidtypo3/vhs",
-    "description": "The vhs package from FluidTYPO3",
+    "description": "This is a collection of view helpers for performing rendering tasks that are not natively provided by TYPO3's Fluid templating engine.",
     "type": "typo3-cms-extension",
     "non-feature-branches": ["development"],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fluidtypo3/vhs",
-    "description": "This is a collection of view helpers for performing rendering tasks that are not natively provided by TYPO3's Fluid templating engine.",
+    "description": "This is a collection of ViewHelpers for performing rendering tasks that are not natively provided by TYPO3's Fluid templating engine.",
     "type": "typo3-cms-extension",
     "non-feature-branches": ["development"],
     "homepage": "https://fluidtypo3.org",

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,12 @@
     "description": "This is a collection of view helpers for performing rendering tasks that are not natively provided by TYPO3's Fluid templating engine.",
     "type": "typo3-cms-extension",
     "non-feature-branches": ["development"],
+    "homepage": "https://fluidtypo3.org",
     "support": {
-        "irc": "irc://irc.freenode.org/fedext",
-        "issues": "https://github.com/FluidTYPO3/vhs/issues"
+        "chat": "https://typo3.slack.com/archives/C79562JES",
+        "docs": "https://viewhelpers.fluidtypo3.org/fluidtypo3/vhs/",
+        "issues": "https://github.com/FluidTYPO3/vhs/issues",
+        "source": "https://github.com/FluidTYPO3/vhs"
     },
     "keywords": [
         "TYPO3 CMS",
@@ -20,7 +23,6 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "homepage": "https://fluidtypo3.org",
     "license": "GPL-2.0-or-later",
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,7 +1,7 @@
 <?php
 $EM_CONF['vhs'] = array (
   'title' => 'VHS: Fluid ViewHelpers',
-  'description' => 'A collection of ViewHelpers to perform rendering tasks which are not natively supported by Fluid - for example: advanced formatters, math calculators, specialized conditions and Iterator/Array calculators and processors',
+  'description' => 'A collection of view helpers for performing rendering tasks that are not natively provided by the Fluid templating engine.',
   'category' => 'misc',
   'author' => 'FluidTYPO3 Team',
   'author_email' => 'claus@namelesscoder.net',
@@ -19,34 +19,34 @@ $EM_CONF['vhs'] = array (
   'clearCacheOnLoad' => 0,
   'lockType' => '',
   'version' => '6.0.5',
-  'constraints' => 
+  'constraints' =>
   array (
-    'depends' => 
+    'depends' =>
     array (
       'php' => '7.4.0-8.1.99',
       'typo3' => '8.7.0-11.5.99',
     ),
-    'conflicts' => 
+    'conflicts' =>
     array (
     ),
-    'suggests' => 
+    'suggests' =>
     array (
     ),
   ),
-  'suggests' => 
+  'suggests' =>
   array (
   ),
   '_md5_values_when_last_written' => '',
-  'autoload' => 
+  'autoload' =>
   array (
-    'psr-4' => 
+    'psr-4' =>
     array (
       'FluidTYPO3\\Vhs\\' => 'Classes/',
     ),
   ),
-  'autoload-dev' => 
+  'autoload-dev' =>
   array (
-    'psr-4' => 
+    'psr-4' =>
     array (
       'FluidTYPO3\\Vhs\\Tests\\' => 'Tests/',
     ),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,7 +1,7 @@
 <?php
 $EM_CONF['vhs'] = array (
   'title' => 'VHS: Fluid ViewHelpers',
-  'description' => 'A collection of view helpers for performing rendering tasks that are not natively provided by the Fluid templating engine.',
+  'description' => 'A collection of ViewHelpers for performing rendering tasks that are not natively provided by the Fluid templating engine.',
   'category' => 'misc',
   'author' => 'FluidTYPO3 Team',
   'author_email' => 'claus@namelesscoder.net',


### PR DESCRIPTION
Hi Claus, hi Björn, hi Cedric, hi VHS team,

this PR is a suggestion to align your extension documentation with the recently introduced [TYPO3 documentation standards](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/GeneralConventions/FileStructure.html) and similar extensions.

The focus is on having one central documentation at Documentation/ and reduce the README to an abstract, badges and further links to all important aspects of the extensions (TER, docs, VCS). 

What is missing: The whole documentation should be rendered and deployed on docs.typo3.org - in perspective. It is currently deployed to the custom page https://viewhelpers.fluidtypo3.org/fluidtypo3/vhs/ and thus not found by the new global search at docs.typo3.org. If you need assistance on how to migrate, i would be happy to support you.

Greetings, Alex

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/182
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185