### PR TITLE
Update AbstractRecordResourceViewHelper.php and resolve deprecation

### DIFF
--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -167,8 +167,11 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
 
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
-
-        if ( GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.preview', 'isPreview') ) {
+        
+        $content = GeneralUtility::makeInstance(Context::class);
+        $fePreview = ($content->hasAspect('frontend.preview')) ? $content->getPropertyFromAspect('frontend.preview', 'isPreview') : false;
+        
+        if ( $fePreview ) {
             $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         }
 

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
@@ -167,7 +168,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
 
-        if (isset($GLOBALS['TSFE']) && $GLOBALS['TSFE']->fePreview) {
+        if ( GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.preview', 'isPreview') ) {
             $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         }
 


### PR DESCRIPTION
replace the deprecated property :php:`TypoScriptFrontendController->fePreview`
The Context API has a new Aspect called "frontend.preview". It can be used to determine whether the frontend is currently in preview mode.
.. code-block:: php
   GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.preview', 'isPreview');