### PR TITLE
[BUGFIX] Fix unsafe array access for 'reverse' argument

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -220,7 +220,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
         $menu = $this->parseMenu($pages);
         $rootLine = $this->pageService->getRootLine(
             $this->arguments['pageUid'],
-            $this->arguments['reverse'],
+            $this->arguments['reverse'] ?? false,
             $this->arguments['showAccessProtected']
         );
         $this->cleanupSubmenuVariables();


### PR DESCRIPTION
The `reverse` ViewHelper argument is not initialized by `AbstractMenuViewHelper` and not by any other MenuViewhelper that is distributed with EXT:vhs.
So most of the times -if not always- `$this->arguments` won't have the `reverse` key and we fall back to `false` which is also the default value of `getRooline()`s 2nd argument.