### PR TITLE
[TASK] Replace TSFE->fePreview with aspect on TYPO3v10+

### DIFF
--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
@@ -167,7 +168,13 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
 
-        if (isset($GLOBALS['TSFE']) && $GLOBALS['TSFE']->fePreview) {
+        if (class_exists('\\TYPO3\\CMS\\Frontend\\Aspect\\PreviewAspect')) {
+            //TYPO3 version >= 10
+            $fePreview = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.preview', 'isPreview');
+        } else {
+            $fePreview = (bool)(isset($GLOBALS['TSFE']) && $GLOBALS['TSFE']->fePreview);
+        }
+        if ($fePreview) {
             $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         }
 


### PR DESCRIPTION
Using $GLOBALS['TSFE']->fePreview has been deprecated in TYPO3v10 and
removed in v11. It generates a deprecation warning:

> TYPO3 Deprecation Notice: Property $TSFE->fePreview is not in use anymore
> as this information is now stored within the FrontendPreview aspect.
> in typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php line 4101

Relevant changelog entries:
- https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.0/Feature-88791-IntroducePreviewAspectInContext.html
- https://docs.typo3.org/c/typo3/cms-core/11.3/en-us/Changelog/11.0/Breaking-91473-DeprecatedFunctionalityRemoved.html

This patch uses the new context aspect if it exists, and falls back
to TSFE->fePreview in old TYPO3 versions.

Resolves: https://github.com/FluidTYPO3/vhs/issues/1775

## How to test
Preview a disabled page in the frontend