### PR TITLE
[TASK] Do not use useCacheHash when generating links on TYPO3 9.5+

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
@@ -254,9 +255,11 @@ class PageService implements SingletonInterface
             'parameter' => $parameter,
             'returnLast' => 'url',
             'additionalParams' => '',
-            'useCacheHash' => false,
             'forceAbsoluteUrl' => $forceAbsoluteUrl,
         ];
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '9.5', '<')) {
+            $config['useCacheHash'] = false;
+        }
 
         return $GLOBALS['TSFE']->cObj->typoLink('', $config);
     }

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Site\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
@@ -96,7 +97,7 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
             false,
             'flag,name'
         );
-        $this->registerArgument('useCHash', 'boolean', 'Use cHash for typolink', false, true);
+        $this->registerArgument('useCHash', 'boolean', 'Use cHash for typolink. Has no effect on TYPO3 v9.5+', false, true);
         $this->registerArgument('flagPath', 'string', 'Overwrites the path to the flag folder', false, '');
         $this->registerArgument('flagImageType', 'string', 'Sets type of flag image: png, gif, jpeg', false, 'svg');
         $this->registerArgument('linkCurrent', 'boolean', 'Sets flag to link current language or not', false, true);
@@ -440,13 +441,15 @@ class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
             'parameter' => $this->getPageUid(),
             'returnLast' => 'url',
             'additionalParams' => '&L=' . $uid,
-            'useCacheHash' => $this->arguments['useCHash'],
             'addQueryString' => 1,
             'addQueryString.' => [
                 'method' => 'GET',
                 'exclude' => 'id,L,cHash' . ($excludedVars ? ',' . $excludedVars : '')
             ]
         ];
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '9.5', '<')) {
+            $config['useCacheHash'] = $this->arguments['useCHash'];
+        }
         if (true === is_array($this->arguments['configuration'])) {
             $config = $this->mergeArrays($config, $this->arguments['configuration']);
         }


### PR DESCRIPTION
Since the introduction of native speaking URLs, the parameter has no effect
anymore:
https://docs.typo3.org/c/typo3/cms-core/9.5/en-us/Changelog/9.5/Feature-86365-RoutingEnhancersAndAspects.html#impact

It has been removed in TYPO3v10 and throws a deprecation notice:
> TYPO3 Deprecation Notice: Setting typolink.useCacheHash has no effect anymore.
> Remove the option in all your TypoScript code and Fluid templates.
> in typo3/sysext/frontend/Classes/Typolink/PageLinkBuilder.php line 155

https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html

Resolves: https://github.com/FluidTYPO3/vhs/issues/1774