### PR TITLE
[BUGFIX] frontend.preview context is not available in backend

### DIFF
--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -170,7 +170,8 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
 
         if (class_exists('\\TYPO3\\CMS\\Frontend\\Aspect\\PreviewAspect')) {
             //TYPO3 version >= 10
-            $fePreview = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.preview', 'isPreview');
+            $context = GeneralUtility::makeInstance(Context::class);
+            $fePreview = ($context->hasAspect('frontend.preview')) ? $context->getPropertyFromAspect('frontend.preview', 'isPreview') : false;
         } else {
             $fePreview = (bool)(isset($GLOBALS['TSFE']) && $GLOBALS['TSFE']->fePreview);
         }


### PR DESCRIPTION
**Description**
When the Viewhelper content.resources.fal is used in the backend preview, the following error message is thrown because the TyposcriptFrontendController is not loaded in the backend and thus the aspect 'frontend.preview' is not present in the context API:

_#1527777868 TYPO3\CMS\Core\Context\Exception\AspectNotFoundException.
No aspect named "frontend.preview" found._

**What did I do:**
Added an additional If query, if the aspect 'frontend.preview' exists in the AbstractResourceViewHelper

**Where did I test it:**
TYPO3 11.5.12
PHP 7.4.26
vhs 6.1.2
