### PR TITLE
[BUGFIX] PHP 8 warning fix if $record is empty in getResources func

### DIFF
--- a/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/FalViewHelper.php
@@ -133,7 +133,7 @@ class FalViewHelper extends AbstractRecordResourceViewHelper
      */
     public function getResources($record)
     {
-        if (!is_array($record)) {
+        if (!is_array($record) || empty($record)) {
             return [];
         }
         if (!empty($GLOBALS['TSFE']->sys_page)) {


### PR DESCRIPTION
I upgraded my project's PHP version to PHP 8.1 and got this PHP warning in the backend layout module. The issue was that $record in getResources function was empty (ViewHelpers/Resource/Record/FalViewHelper.php) and then there was no $record[$this->idField] was trying to fetch uid key's value in $record array (without isset() in else part, Line no. 147).