### PR TITLE
[BUGFIX] Fix for error in TYPO3 v11.5.x

### DIFF
--- a/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
+++ b/Classes/ViewHelpers/Menu/AbstractMenuViewHelper.php
@@ -282,7 +282,7 @@ abstract class AbstractMenuViewHelper extends AbstractTagBasedViewHelper
                 $html[] = '<' . $tagName . $elementId . $class . '>';
             }
             $html[] = $this->renderItemLink($page);
-            if (($page['active'] || $expandAll) && $page['hasSubPages'] && $level < $levels) {
+            if (($page['active'] || $expandAll) && (isset($page['hasSubPages']) && $page['hasSubPages']) && $level < $levels) {
                 $subPages = $this->getMenu($page['uid']);
                 $subMenu = $this->parseMenu($subPages);
                 if (0 < count($subMenu)) {


### PR DESCRIPTION
Error  #1476107295 - Undefined array key "hasSubPages" - displayed in front-end. This simple fix resolves the error.