### PR TITLE
Fixes AbstractContentViewHelper under PHP 8

### DIFF
--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -208,13 +208,13 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
         $parent = $GLOBALS['TSFE']->currentRecord;
         // If the currentRecord is set, we register, that this record has invoked this function.
         // It's should not be allowed to do this again then!!
-        if (!empty($parent)) {
+        if (!empty($parent) && isset($GLOBALS['TSFE']->recordRegister[$parent])) {
             ++$GLOBALS['TSFE']->recordRegister[$parent];
         }
         $html = $GLOBALS['TSFE']->cObj->cObjGetSingle('RECORDS', $conf);
 
         $GLOBALS['TSFE']->currentRecord = $parent;
-        if (!empty($parent)) {
+        if (!empty($parent) && isset($GLOBALS['TSFE']->recordRegister[$parent])) {
             --$GLOBALS['TSFE']->recordRegister[$parent];
         }
         return $html;

--- a/Classes/ViewHelpers/OrViewHelper.php
+++ b/Classes/ViewHelpers/OrViewHelper.php
@@ -58,7 +58,7 @@ class OrViewHelper extends AbstractViewHelper
     protected static function getAlternativeValue(array $arguments, RenderingContextInterface $renderingContext)
     {
         /** @var RenderingContext $renderingContext */
-        $alternative = $arguments['alternative'];
+        $alternative = $arguments['alternative'] ?? '';
         $arguments = (array) $arguments['arguments'];
         if (0 === count($arguments)) {
             $arguments = null;


### PR DESCRIPTION
Fixes AbstractContentViewHelper under PHP 8: #1846 

I also added a change to prevent an exception under PHP 8 if the argument "alternative" of OrViewHelper is null. If the $alternative variable is null, then null is passed as a string type parameter ($haystack) in the strpos() function, which results in an exception.