### PR TITLE
[BUGFIX] Fix Problems with TYPO3 v12.x and cached pages

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -136,7 +136,7 @@ class AssetService implements SingletonInterface
                     $allTypoScript['plugin.']['tx_vhs.']['settings.'] ?? []
                 );
             } catch (\RuntimeException $e) {
-                // If RuntimeException = 1666513645, then generate this over forcedTemplateParsing
+                // If RuntimeException = 1666513645
                 // [Setup array has not been initialized. This happens in cached Frontend scope where full TypoScript is not needed by the system.]
                 if ($e->getCode() === 1666513645) {
                     static::$settingsCache = GeneralUtility::removeDotsFromTS(

--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -128,12 +128,22 @@ class AssetService implements SingletonInterface
     public function getSettings(): array
     {
         if (null === static::$settingsCache) {
-            $allTypoScript = $this->configurationManager->getConfiguration(
-                ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
-            );
-            static::$settingsCache = GeneralUtility::removeDotsFromTS(
-                $allTypoScript['plugin.']['tx_vhs.']['settings.'] ?? []
-            );
+            try {
+                $allTypoScript = $this->configurationManager->getConfiguration(
+                    ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
+                );
+                static::$settingsCache = GeneralUtility::removeDotsFromTS(
+                    $allTypoScript['plugin.']['tx_vhs.']['settings.'] ?? []
+                );
+            } catch (\RuntimeException $e) {
+                // If RuntimeException = 1666513645, then generate this over forcedTemplateParsing
+                // [Setup array has not been initialized. This happens in cached Frontend scope where full TypoScript is not needed by the system.]
+                if ($e->getCode() === 1666513645) {
+                    static::$settingsCache = GeneralUtility::removeDotsFromTS(
+                        []
+                    );
+                }
+            }
         }
         $settings = (array) static::$settingsCache;
         return $settings;


### PR DESCRIPTION
If a page is cached, the determination of the TypoScript setup fails. A RuntimeException with the code 1666513645 is thrown (\TYPO3\CMS\Core\TypoScript\FrontendTypoScript()->getSetupArray()). This happens in the context of the middleware AssetInclusion.

To prevent this, the exception must be caught in the AssetService in the getSettings() function.