### PR TITLE
[BUGFIX] Avoid list() in favor of null-coalesced extraction

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -561,7 +561,8 @@ class AssetService implements SingletonInterface
             if (false === strpos($match, ':') && !preg_match('/url\\s*\\(/i', $match)) {
                 $checksum = md5($originalDirectory . $match);
                 if (0 < preg_match('/([^\?#]+)(.+)?/', $match, $items)) {
-                    list(, $path, $suffix) = $items;
+                    $path = $items[1];
+                    $suffix = $items[2] ?? '';
                 } else {
                     $path = $match;
                     $suffix = '';


### PR DESCRIPTION
Prevents PHP 8.1 from throwing: PHP Warning: Undefined array key 2 in Classes/Service/AssetService.php