### PR TITLE
[BUGFIX] dirname(): Passing null to parameter #1

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -643,9 +643,14 @@ class AssetService implements SingletonInterface
     protected function extractAssetContent($asset): ?string
     {
         $assetSettings = $this->extractAssetSettings($asset);
-        $fileRelativePathAndFilename = $assetSettings['path'];
-        $fileRelativePath = dirname($assetSettings['path']);
-        $absolutePathAndFilename = GeneralUtility::getFileAbsFileName($fileRelativePathAndFilename);
+        $fileRelativePathAndFilename = null;
+        $absolutePathAndFilename = null;
+        $fileRelativePath = null;
+        if (!empty($assetSettings['path'])) {
+            $fileRelativePathAndFilename = $assetSettings['path'];
+            $fileRelativePath = dirname($assetSettings['path']);
+            $absolutePathAndFilename = GeneralUtility::getFileAbsFileName($fileRelativePathAndFilename);
+        }
         $isExternal = $assetSettings['external'] ?? false;
         $isFluidTemplate = $assetSettings['fluid'] ?? false;
         if (!empty($fileRelativePathAndFilename)) {


### PR DESCRIPTION
PHP Runtime Deprecation Notice: dirname(): Passing null to parameter #1 ($path) of type string is deprecated in /var/www/public/typo3conf/ext/vhs/Classes/Service/AssetService.php line 761