### PR TITLE
[BUGFIX] Fixed Image-URL in SourceViewHelper after TYPO3 12 Update

### DIFF
--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -47,7 +47,12 @@ trait SourceSetViewHelperTrait
         foreach ($srcsets as $width) {
             $srcsetVariant = $this->getImgResource($src, $width, $format, $quality, $treatIdAsReference, null, $crop);
 
-            $srcsetVariantSrc = rawurldecode($srcsetVariant[3]);
+            if ($srcsetVariant['processedFile'] ?? false) {
+                $imageUrl = $srcsetVariant['processedFile']->getPublicUrl();
+            } else {
+                $imageUrl = $srcsetVariant[3] ?? '';
+            }
+            $srcsetVariantSrc = rawurldecode($imageUrl);
             $srcsetVariantSrc = static::preprocessSourceUri(
                 str_replace('%2F', '/', rawurlencode($srcsetVariantSrc)),
                 $this->arguments

--- a/Classes/ViewHelpers/Media/SourceViewHelper.php
+++ b/Classes/ViewHelpers/Media/SourceViewHelper.php
@@ -139,7 +139,12 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
 
         FrontendSimulationUtility::resetFrontendEnvironment($tsfeBackup);
 
-        $src = $this->preprocessSourceUri(rawurldecode($result[3] ?? ''));
+        if ($result['processedFile'] ?? false) {
+            $imageUrl = $result['processedFile']->getPublicUrl();
+        } else {
+            $imageUrl = $result[3] ?? '';
+        }
+        $src = $this->preprocessSourceUri(rawurldecode($imageUrl));
 
         /** @var string|null $media */
         $media = $this->arguments['media'];


### PR DESCRIPTION
In TYPO3 12, there is a change in the behavior of the ContentObjectRenderer. The array key 3 of the info-array returned by getImgResource() does not longer contain the relative image path for processed images. Instead, the absolute path is now returned. See https://forge.typo3.org/issues/95379

As a result, the absolute image path is used in the SourceViewHelper and the images on the page are broken. To fix this, i added a check if the image is processed. If so, the relative URL is fetched from the ProcessedFile-object. The rest of the behavior remains the same.