### PR TITLE
Fix exceptions when using UncacheViewHelper on TYPO3 12

### DIFF
--- a/Classes/Utility/RequestResolver.php
+++ b/Classes/Utility/RequestResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FluidTYPO3\Vhs\Utility;
 
 /*
@@ -9,17 +10,14 @@ namespace FluidTYPO3\Vhs\Utility;
  */
 
 use TYPO3\CMS\Extbase\Mvc\Request;
-use TYPO3\CMS\Extbase\Mvc\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 class RequestResolver
 {
-    /**
-     * @return Request&RequestInterface
-     */
     public static function resolveRequestFromRenderingContext(
         RenderingContextInterface $renderingContext
-    ): RequestInterface {
+    ): ServerRequestInterface {
         $request = null;
         if (method_exists($renderingContext, 'getRequest')) {
             $request = $renderingContext->getRequest();

--- a/Classes/View/UncacheTemplateView.php
+++ b/Classes/View/UncacheTemplateView.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FluidTYPO3\Vhs\View;
 
 /*
@@ -40,7 +41,7 @@ class UncacheTemplateView extends TemplateView
 
             if (method_exists($renderingContext, 'setRequest')) {
                 $renderingContext->setRequest(
-                    new Request($GLOBALS['TYPO3_REQUEST']->withAttribute('extbase', $parameters))
+                    $GLOBALS['TYPO3_REQUEST']->withAttribute('extbase', $parameters)
                 );
             }
         } else {


### PR DESCRIPTION
Fixed some exceptions that occured when using the `v:render.uncache` on TYPO3 12.4.