### PR TITLE
[BUGFIX] Fix tidy vh: return string instead of tidy-object

### DIFF
--- a/Classes/ViewHelpers/Format/TidyViewHelper.php
+++ b/Classes/ViewHelpers/Format/TidyViewHelper.php
@@ -48,7 +48,7 @@ class TidyViewHelper extends AbstractViewHelper
                 return $content;
             }
             $tidy->cleanRepair();
-            return $tidy;
+            return $tidy->root()->value;
         }
         throw new \RuntimeException(
             'TidyViewHelper requires the PHP extension "tidy" which is not installed or not loaded.',


### PR DESCRIPTION
The tidy viewhelper returns a tidy object which is no correct and thus throws an error. Now the value of the tidy object - a strings  - is returned.