### PR TITLE
[BUGFIX] Assign resolved Request in TemplateViewHelper

### DIFF
--- a/Classes/ViewHelpers/Render/TemplateViewHelper.php
+++ b/Classes/ViewHelpers/Render/TemplateViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\RequestResolver;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -84,7 +85,9 @@ class TemplateViewHelper extends AbstractRenderViewHelper
 
         $file = GeneralUtility::getFileAbsFileName((string) $file);
         $view = static::getPreparedView();
-        $view->setRequest($this->renderingContext->getRequest());
+        if (method_exists($view, 'setRequest')) {
+            $view->setRequest(RequestResolver::resolveRequestFromRenderingContext($this->renderingContext));
+        }
         $view->setTemplatePathAndFilename($file);
         if (is_array($this->arguments['variables'])) {
             $view->assignMultiple($this->arguments['variables']);

--- a/Classes/ViewHelpers/Render/TemplateViewHelper.php
+++ b/Classes/ViewHelpers/Render/TemplateViewHelper.php
@@ -84,6 +84,7 @@ class TemplateViewHelper extends AbstractRenderViewHelper
 
         $file = GeneralUtility::getFileAbsFileName((string) $file);
         $view = static::getPreparedView();
+        $view->setRequest($this->renderingContext->getRequest());
         $view->setTemplatePathAndFilename($file);
         if (is_array($this->arguments['variables'])) {
             $view->assignMultiple($this->arguments['variables']);


### PR DESCRIPTION
With this, for example the f:link.action() ViewHelper can be used in the rendered template

Resolves: #1902 