### PR TITLE
TYPO3 13 compatibility

### DIFF
--- a/Classes/Middleware/AssetInclusion.php
+++ b/Classes/Middleware/AssetInclusion.php
@@ -24,7 +24,7 @@ class AssetInclusion implements MiddlewareInterface
 
         /** @var AssetService $assetService */
         $assetService = GeneralUtility::makeInstance(AssetService::class);
-        $assetService->buildAllUncached([], $GLOBALS['TSFE'], $contents);
+        $assetService->buildAllUncached([], $request->getAttribute('frontend.controller', null) ?? $GLOBALS['TSFE'], $contents);
 
         if ($contentsBefore === $contents) {
             // Content is unchanged, return the original response since there is no need to modify it, or the

--- a/Classes/Utility/CoreUtility.php
+++ b/Classes/Utility/CoreUtility.php
@@ -40,4 +40,14 @@ class CoreUtility
     {
         return VersionNumberUtility::getCurrentTypo3Version();
     }
+
+    public static function getTypo3Version(): string
+    {
+        return (new \TYPO3\CMS\Core\Information\Typo3Version())->getVersion();
+    }
+
+    public static function getTypo3MajorVersion(): int
+    {
+        return (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion();
+    }
 }

--- a/Classes/Utility/TsfeUtility.php
+++ b/Classes/Utility/TsfeUtility.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace FluidTYPO3\Vhs\Utility;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageInformation;
+
+/**
+ * Class TsfeUtility
+ */
+class TsfeUtility
+{
+    /**
+     * @return ServerRequestInterface
+     */
+    public function getRequest(): ServerRequestInterface
+    {
+        return $GLOBALS['TYPO3_REQUEST'];
+    }
+
+    public function getPageId(): int {
+        if(CoreUtility::getTypo3MajorVersion() > 12) {
+            $pageInformation = $this->getRequest()->getAttribute('frontend.page.information');
+            return $pageInformation->getId();
+        }
+
+        return $GLOBALS['TSFE']->id;
+    }
+
+    /**
+     * @return array
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function getPageRecordFromRequest(): array
+    {
+        if (CoreUtility::getTypo3MajorVersion() > 12) {
+            /** @var PageInformation $pageInformation */
+            $pageInformation = $this->getRequest()->getAttribute('frontend.page.information');
+            return $pageInformation->getPageRecord();
+        }
+
+        $pageArguments = $request->getAttribute('routing');
+        $pageId = $pageArguments->getPageId();
+
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+        $pageRecord = $connection->select('*', 'pages', ['uid' => $pageId])->fetchAssociative();
+
+        return $pageRecord;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getTyposcriptSetupArray(): ?array
+    {
+        $setup = CoreUtility::getTypo3MajorVersion() > 11
+            ? $this->getRequest()->getAttribute('frontend.typoscript')->getSetupArray()
+            : $GLOBALS['TSFE']->tmpl->setup;
+
+        return $setup;
+    }
+
+    public function isNoCache(): bool {
+        if(CoreUtility::getTypo3MajorVersion() > 12) {
+            $instructions = $this->getRequest()->getAttribute('frontend.cache.instruction');
+            return !empty($instructions) ? $instructions->isCachingAllowed() === false : false;
+        }
+
+        return (bool)($GLOBALS['TSFE']->no_cache ?? false);
+    }
+}

--- a/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  */
 
 use FluidTYPO3\Vhs\Utility\ContextUtility;
+use FluidTYPO3\Vhs\Utility\TsfeUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
@@ -49,8 +50,10 @@ abstract class AbstractMediaViewHelper extends AbstractTagBasedViewHelper
         if (substr($src, 0, 1) !== '/' && substr($src, 0, 4) !== 'http') {
             $src = $GLOBALS['TSFE']->absRefPrefix . $src;
         }
-        if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
-            $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
+        $typoscript = (new TsfeUtility())->getTyposcriptSetupArray();
+
+        if (!empty($typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
+            $src =$typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
         } elseif (ContextUtility::isBackend() || !$arguments['relative']) {
             /** @var string $siteUrl */
             $siteUrl = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');

--- a/Classes/ViewHelpers/Media/SourceViewHelper.php
+++ b/Classes/ViewHelpers/Media/SourceViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
 
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
+use FluidTYPO3\Vhs\Utility\TsfeUtility;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -165,8 +166,9 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
      */
     public function preprocessSourceUri(string $src): string
     {
-        if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
-            $src = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
+        $typoscript = (new TsfeUtility())->getTyposcriptSetupArray();
+        if (!empty($typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
+            $src = $typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'] . $src;
         } elseif (ContextUtility::isBackend() || !$this->arguments['relative']) {
             if (GeneralUtility::isValidUrl($src)) {
                 $src = ltrim($src, '/');

--- a/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
+++ b/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\TsfeUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
@@ -38,6 +39,6 @@ class StaticPrefixViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        return $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] ?? '';
+        return (new TsfeUtility())->getTyposcriptSetupArray()['plugin.']['tx_vhs.']['settings.']['prependPath'] ?? '';
     }
 }

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use FluidTYPO3\Vhs\Utility\ResourceUtility;
+use FluidTYPO3\Vhs\Utility\TsfeUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -161,8 +162,9 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
      */
     public function preprocessSourceUri(string $source): string
     {
-        if (!empty($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
-            $source = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_vhs.']['settings.']['prependPath'] . $source;
+        $typoscript = (new TsfeUtility())->getTyposcriptSetupArray());
+        if (!empty($typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'])) {
+            $source = $typoscript['plugin.']['tx_vhs.']['settings.']['prependPath'] . $source;
         } elseif (ContextUtility::isBackend() || !$this->arguments['relative']) {
             /** @var string $siteUrl */
             $siteUrl = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,10 +34,7 @@
     }
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['v'] = ['FluidTYPO3\\Vhs\\ViewHelpers'];
-
-    // add navigtion hide to fix menu viewHelpers (e.g. breadcrumb)
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= (empty($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']) ? '' : ',') . 'nav_hide,shortcut,shortcut_mode';
-
+    
     // add and urltype to fix the rendering of external url doktypes
     if (isset($GLOBALS['TCA']['pages']['columns']['urltype'])) {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',url,urltype';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,7 +34,12 @@
     }
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['v'] = ['FluidTYPO3\\Vhs\\ViewHelpers'];
-    
+
+    if(\FluidTYPO3\Vhs\Utility\CoreUtility::getTypo3MajorVersion() < 13) {
+        // add navigtion hide to fix menu viewHelpers (e.g. breadcrumb)
+        $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= (empty($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']) ? '' : ',') . 'nav_hide,shortcut,shortcut_mode';
+    }
+
     // add and urltype to fix the rendering of external url doktypes
     if (isset($GLOBALS['TCA']['pages']['columns']['urltype'])) {
         $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',url,urltype';


### PR DESCRIPTION
Here's my attempt for (beginning) TYPO3 13 compatibility

- added version check for addRootlineFields (obsolete in v13)
- Added a TSFE Utitlity class with version checks to try to substitute references to $GLOBALS['TSFE'] (Most TSFE members marked internal or read-only) while keeping compatiblity with old TYPO3 versions

related to #1901