### PR TITLE
[BUGFIX] Use late instancing of ContentObjectRenderer

### DIFF
--- a/Classes/Traits/SourceSetViewHelperTrait.php
+++ b/Classes/Traits/SourceSetViewHelperTrait.php
@@ -1,10 +1,12 @@
 <?php
 namespace FluidTYPO3\Vhs\Traits;
 
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /*
@@ -94,6 +96,11 @@ trait SourceSetViewHelperTrait
         ?string $params = null,
         ?string $crop = null
     ): array {
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+        if ($contentObject === null) {
+            throw new Exception(static::class . ' requires a ContentObjectRenderer, none found', 1737808465);
+        }
+
         $setup = [
             'width' => $width,
             'treatIdAsReference' => $treatIdAsReference,
@@ -111,7 +118,7 @@ trait SourceSetViewHelperTrait
         if (ContextUtility::isBackend() && '../' === substr($src, 0, 3)) {
             $src = substr($src, 3);
         }
-        return (array) $this->contentObject->getImgResource($src, $setup);
+        return (array) $contentObject->getImgResource($src, $setup);
     }
 
     /**

--- a/Classes/Utility/ContentObjectFetcher.php
+++ b/Classes/Utility/ContentObjectFetcher.php
@@ -18,9 +18,9 @@ class ContentObjectFetcher
     public static function resolve(?ConfigurationManagerInterface $configurationManager = null): ?ContentObjectRenderer
     {
         $contentObject = null;
-        $request = $configurationManager !== null && method_exists($configurationManager, 'getRequest')
+        $request = ($configurationManager !== null && method_exists($configurationManager, 'getRequest')
             ? $configurationManager->getRequest()
-            : ($GLOBALS['TYPO3_REQUEST'] ?? null);
+            : ($GLOBALS['TYPO3_REQUEST'] ?? null)) ?? $GLOBALS['TYPO3_REQUEST'] ?? null;
 
         if ($request && $configurationManager === null) {
             $contentObject = static::resolveFromRequest($request);
@@ -29,7 +29,7 @@ class ContentObjectFetcher
         if ($contentObject === null) {
             if ($configurationManager !== null && method_exists($configurationManager, 'getContentObject')) {
                 $contentObject = $configurationManager->getContentObject();
-            } else {
+            } elseif ($request) {
                 $contentObject = static::resolveFromRequest($request);
             }
         }

--- a/Classes/View/UncacheTemplateView.php
+++ b/Classes/View/UncacheTemplateView.php
@@ -8,7 +8,6 @@ namespace FluidTYPO3\Vhs\View;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Vhs\Utility\RequestResolver;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;

--- a/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
+++ b/Classes/ViewHelpers/Content/AbstractContentViewHelper.php
@@ -13,7 +13,6 @@ use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\DoctrineQueryProxy;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -22,11 +21,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 abstract class AbstractContentViewHelper extends AbstractViewHelper
 {
     use SlideViewHelperTrait;
-
-    /**
-     * @var ContentObjectRenderer|null
-     */
-    protected $contentObject;
 
     /**
      * @var ConfigurationManagerInterface
@@ -41,7 +35,6 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        $this->contentObject = ContentObjectFetcher::resolve($this->configurationManager);
     }
 
     public function initializeArguments(): void
@@ -197,17 +190,19 @@ abstract class AbstractContentViewHelper extends AbstractViewHelper
      */
     protected function getRenderedRecords(array $rows): array
     {
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+
         /** @var array $loadRegister */
         $loadRegister = $this->arguments['loadRegister'];
-        if (!empty($loadRegister) && $this->contentObject !== null) {
-            $this->contentObject->cObjGetSingle('LOAD_REGISTER', $loadRegister);
+        if (!empty($loadRegister) && $contentObject !== null) {
+            $contentObject->cObjGetSingle('LOAD_REGISTER', $loadRegister);
         }
         $elements = [];
         foreach ($rows as $row) {
             $elements[] = static::renderRecord($row);
         }
-        if (!empty($loadRegister) && $this->contentObject !== null) {
-            $this->contentObject->cObjGetSingle('RESTORE_REGISTER', []);
+        if (!empty($loadRegister) && $contentObject !== null) {
+            $contentObject->cObjGetSingle('RESTORE_REGISTER', []);
         }
         return $elements;
     }

--- a/Classes/ViewHelpers/Content/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Content/InfoViewHelper.php
@@ -9,13 +9,13 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  */
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\DoctrineQueryProxy;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
@@ -71,8 +71,12 @@ class InfoViewHelper extends AbstractViewHelper
         $record = false;
 
         if (0 === $contentUid) {
-            /** @var ContentObjectRenderer $cObj */
-            $cObj = $this->configurationManager->getContentObject();
+            $cObj = ContentObjectFetcher::resolve($this->configurationManager);
+
+            if ($cObj === null) {
+                throw new Exception('v:content.info requires a ContentObjectRenderer, none found', 1737807859);
+            }
+
             if ($cObj->getCurrentTable() !== 'tt_content') {
                 throw new Exception(
                     'v:content.info must have contentUid argument outside tt_content context',

--- a/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
+++ b/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
@@ -8,11 +8,13 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format\Placeholder;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
@@ -166,8 +168,11 @@ fKlBugvORmsyOJaRIQ8yH3I1EG2Y/+/6jqtrg4/xnazRv4v3i04aA==';
     {
         /** @var ConfigurationManagerInterface $configurationManager */
         $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
-        /** @var ContentObjectRenderer $contentObject */
-        $contentObject = $configurationManager->getContentObject();
+        /** @var ContentObjectRenderer|null $contentObject */
+        $contentObject = ContentObjectFetcher::resolve($configurationManager);
+        if ($contentObject === null) {
+            throw new Exception('v:format.placeholder.lipsum requires a ContentObjectRenderer, none found', 1737807859);
+        }
         return $contentObject;
     }
 }

--- a/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Media/Image/AbstractImageViewHelper.php
@@ -17,7 +17,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
@@ -27,11 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
 {
-    /**
-     * @var ContentObjectRenderer
-     */
-    protected $contentObject;
-
     /**
      * @var ConfigurationManagerInterface
      */
@@ -45,12 +39,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
 
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
-        $contentObject = ContentObjectFetcher::resolve($configurationManager);
-        if ($contentObject === null) {
-            throw new \UnexpectedValueException(static::class . ' requires a cObj context, none was found', 1737756353);
-        }
         $this->configurationManager = $configurationManager;
-        $this->contentObject = $contentObject;
     }
 
     public function initializeArguments(): void
@@ -143,6 +132,11 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
 
         $tsfeBackup = FrontendSimulationUtility::simulateFrontendEnvironment();
 
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+        if ($contentObject === null) {
+            throw new Exception(static::class . ' requires a ContentObjectRenderer, none found', 1737808465);
+        }
+
         $setup = [
             'width' => $width,
             'height' => $height,
@@ -165,7 +159,7 @@ abstract class AbstractImageViewHelper extends AbstractMediaViewHelper
         if (ContextUtility::isBackend() && strpos($src, '../') === 0) {
             $src = mb_substr($src, 3);
         }
-        $this->imageInfo = $this->contentObject->getImgResource($src, $setup);
+        $this->imageInfo = $contentObject->getImgResource($src, $setup);
 
         if (!is_array($this->imageInfo)) {
             if ($this->arguments['graceful'] ?? false) {

--- a/Classes/ViewHelpers/Media/SourceViewHelper.php
+++ b/Classes/ViewHelpers/Media/SourceViewHelper.php
@@ -8,14 +8,15 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
  * Used in conjuntion with the `v:media.PictureViewHelper`.
@@ -36,12 +37,6 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
      * @api
      */
     protected $tagName = 'source';
-
-    /**
-     * @var ContentObjectRenderer
-     */
-    protected $contentObject;
-
     /**
      * @var ConfigurationManagerInterface
      */
@@ -50,9 +45,6 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        /** @var ContentObjectRenderer $contentObject */
-        $contentObject = $this->configurationManager->getContentObject();
-        $this->contentObject = $contentObject;
     }
 
     public function initializeArguments(): void
@@ -135,7 +127,12 @@ class SourceViewHelper extends AbstractTagBasedViewHelper
         if (is_string($imageSource) && ContextUtility::isBackend() && '../' === mb_substr($imageSource, 0, 3)) {
             $imageSource = mb_substr($imageSource, 3);
         }
-        $result = $this->contentObject->getImgResource($imageSource, $setup);
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+        if ($contentObject === null) {
+            throw new Exception('v:media.source requires a ContentObjectRenderer, none found', 1737807859);
+        }
+
+        $result = $contentObject->getImgResource($imageSource, $setup);
 
         FrontendSimulationUtility::resetFrontendEnvironment($tsfeBackup);
 

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -8,14 +8,18 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\RequestResolver;
 use FluidTYPO3\Vhs\View\UncacheContentObject;
 use FluidTYPO3\Vhs\View\UncacheTemplateView;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
@@ -105,8 +109,7 @@ class UncacheViewHelper extends AbstractViewHelper
             $conf['partialRootPaths'] = $renderingContext->getTemplatePaths()->getPartialRootPaths();
         }
 
-        /** @var ContentObjectRenderer $contentObjectRenderer */
-        $contentObjectRenderer = $GLOBALS['TSFE']->cObj;
+        $contentObjectRenderer = static::getContentObject();
 
         $content = $contentObjectRenderer->cObjGetSingle(
             'COA_INT',
@@ -116,5 +119,17 @@ class UncacheViewHelper extends AbstractViewHelper
             ]
         );
         return $content;
+    }
+
+    protected static function getContentObject(): ContentObjectRenderer
+    {
+        /** @var ConfigurationManagerInterface $configurationManager */
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManagerInterface::class);
+        /** @var ContentObjectRenderer|null $contentObject */
+        $contentObject = ContentObjectFetcher::resolve($configurationManager);
+        if ($contentObject === null) {
+            throw new Exception('v:render.uncache requires a ContentObjectRenderer, none found', 1737808465);
+        }
+        return $contentObject;
     }
 }

--- a/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractImageViewHelper.php
@@ -8,12 +8,12 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use FluidTYPO3\Vhs\Utility\ResourceUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
@@ -27,17 +27,9 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
      */
     protected $configurationManager;
 
-    /**
-     * @var ContentObjectRenderer
-     */
-    protected $contentObject;
-
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        /** @var ContentObjectRenderer $contentObject */
-        $contentObject = $this->configurationManager->getContentObject();
-        $this->contentObject = $contentObject;
     }
 
     public function initializeArguments(): void
@@ -103,6 +95,11 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
 
         $tsfeBackup = FrontendSimulationUtility::simulateFrontendEnvironment();
 
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+        if ($contentObject === null) {
+            throw new Exception(static::class . ' requires a ContentObjectRenderer, none found', 1737807859);
+        }
+
         $setup = [
             'width' => $this->arguments['width'] ?? null,
             'height' => $this->arguments['height'] ?? null,
@@ -116,7 +113,7 @@ abstract class AbstractImageViewHelper extends AbstractResourceViewHelper
         $images = [];
 
         foreach ($files as $file) {
-            $imageInfo = $this->contentObject->getImgResource($file->getUid(), $setup);
+            $imageInfo = $contentObject->getImgResource($file->getUid(), $setup);
 
             if (!is_array($imageInfo)) {
                 if ($this->arguments['graceful'] ?? false) {

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
  */
 
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
+use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\DoctrineQueryProxy;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3\CMS\Core\Context\Context;
@@ -17,8 +18,8 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
  * Base class: Record Resource ViewHelpers
@@ -165,8 +166,10 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
 
     public function getActiveRecord(): array
     {
-        /** @var ContentObjectRenderer $contentObject */
-        $contentObject = $this->configurationManager->getContentObject();
+        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
+        if ($contentObject === null) {
+            throw new Exception(static::class . ' requires a ContentObjectRenderer, none found', 1737807859);
+        }
         return $contentObject->data;
     }
 

--- a/Tests/Fixtures/Classes/DummyConfigurationManagerWithContentObjectRenderer.php
+++ b/Tests/Fixtures/Classes/DummyConfigurationManagerWithContentObjectRenderer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FluidTYPO3\Vhs\Tests\Fixtures\Classes;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+class DummyConfigurationManagerWithContentObjectRenderer implements ConfigurationManagerInterface
+{
+    private ContentObjectRenderer $contentObjectRenderer;
+
+    public function __construct(ContentObjectRenderer $contentObjectRenderer)
+    {
+        $this->contentObjectRenderer = $contentObjectRenderer;
+    }
+
+    public function getConfiguration(
+        string $configurationType,
+        ?string $extensionName = null,
+        ?string $pluginName = null
+    ): array {
+    }
+
+    public function setConfiguration(array $configuration = []): void
+    {
+    }
+
+    public function setRequest(ServerRequestInterface $request): void
+    {
+    }
+
+    public function getContentObject(): ContentObjectRenderer
+    {
+        return $this->contentObjectRenderer;
+    }
+
+    public function isFeatureEnabled(string $featureName): bool
+    {
+        return false;
+    }
+
+    public function setContentObject(ContentObjectRenderer $contentObjectRenderer): void
+    {
+        $this->contentObjectRenderer = $contentObjectRenderer;
+    }
+}

--- a/Tests/Fixtures/Classes/DummySourceSetViewHelper.php
+++ b/Tests/Fixtures/Classes/DummySourceSetViewHelper.php
@@ -3,13 +3,14 @@
 namespace FluidTYPO3\Vhs\Tests\Fixtures\Classes;
 
 use FluidTYPO3\Vhs\Traits\SourceSetViewHelperTrait;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class DummySourceSetViewHelper
 {
     use SourceSetViewHelperTrait;
 
-    public ?ContentObjectRenderer $contentObject = null;
+    public ?ConfigurationManagerInterface $configurationManager = null;
     public array $arguments = [];
 
     public static function preprocessSourceUri(string $src, array $arguments): string


### PR DESCRIPTION
Avoid issues caused by attempting to resolve ContentObjectRenderer in methods that may be called during DI compilation.