### PR TITLE
[FEATURE] Add compatibility layer to basically all ViewHelpers

### DIFF
--- a/Classes/Traits/ArgumentOverride.php
+++ b/Classes/Traits/ArgumentOverride.php
@@ -1,0 +1,28 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
+trait ArgumentOverride
+{
+    protected function overrideArgument(
+        $name,
+        $type,
+        $description,
+        $required = false,
+        $defaultValue = null,
+        $escape = null
+    ) {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '>=')) {
+            return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escape);
+        }
+        return parent::overrideArgument($name, $type, $description, $required, $defaultValue, $escape);
+    }
+}

--- a/Classes/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/Classes/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -1,0 +1,185 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+
+/**
+ * Class CompilableWithContentArgumentAndRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern but has the added common use case that
+ * an argument value must be checked and used instead of
+ * the normal render children closure, if that named
+ * argument is specified and not empty.
+ */
+trait CompileWithContentArgumentAndRenderStatic
+{
+    /**
+     * Name of variable that contains the value to use
+     * instead of render children closure, if specified.
+     * If no name is provided here, the first variable
+     * registered in `initializeArguments` of the ViewHelper
+     * will be used.
+     *
+     * Note: it is significantly better practice defining
+     * this property in your ViewHelper class and so fix it
+     * to one particular argument instead of resolving,
+     * especially when your ViewHelper is called multiple
+     * times within an uncompiled template!
+     *
+     * This property cannot be directly set in consuming
+     * ViewHelper, instead set the property in ViewHelper
+     * constructor '__construct()', for example with
+     * $this->contentArgumentName = 'explicitlyToUseArgumentName';
+     *
+     * Another possible way would be to override the method
+     * 'resolveContentArgumentName()' and return the name.
+     *
+     * public function resolveContentArgumentName()
+     * {
+     *     return 'explicitlyToUseArgumentName';
+     * }
+     *
+     * Note: Setting this through 'initializeArguments()' will
+     *       not work as expected, and other methods should be
+     *       avoided to override this.
+     *
+     * Following test ViewHelpers are tested and demonstrates
+     * that the setting posibillities works.
+     *
+     * @var string
+     */
+    protected $contentArgumentName;
+
+    /**
+     * Default render method to render ViewHelper with
+     * first defined optional argument as content.
+     *
+     * @return mixed Rendered result
+     * @api
+     */
+    public function render()
+    {
+        return static::renderStatic(
+            $this->arguments,
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext,
+        );
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @param ViewHelperNode $node
+     * @param TemplateCompiler $compiler
+     * @return string
+     */
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ) {
+        $initialization = '';
+        $execution = sprintf(
+            '%s::renderStatic(%s, %s, $renderingContext)',
+            get_class($this),
+            $argumentsName,
+            $closureName,
+        );
+
+        $contentArgumentName = $this->resolveContentArgumentName();
+        $initializationPhpCode .= sprintf(
+            '%s = (%s[\'%s\'] !== null) ? function() use (%s) { return %s[\'%s\']; } : %s;',
+            $closureName,
+            $argumentsName,
+            $contentArgumentName,
+            $argumentsName,
+            $argumentsName,
+            $contentArgumentName,
+            $closureName
+        );
+
+        $initializationPhpCode .= $initialization;
+        return $execution;
+    }
+
+    /**
+     * Helper which is mostly needed when calling renderStatic() from within
+     * render().
+     *
+     * No public API yet.
+     *
+     * @return \Closure
+     */
+    protected function buildRenderChildrenClosure()
+    {
+        $argumentName = $this->resolveContentArgumentName();
+        $arguments = $this->arguments;
+        if (!empty($argumentName) && isset($arguments[$argumentName])) {
+            $renderChildrenClosure = function () use ($arguments, $argumentName) {
+                return $arguments[$argumentName];
+            };
+        } else {
+            $self = clone $this;
+            $renderChildrenClosure = function () use ($self) {
+                return $self->renderChildren();
+            };
+        }
+        return $renderChildrenClosure;
+    }
+
+    /**
+     * Helper method which triggers the rendering of everything between the
+     * opening and the closing tag.
+     *
+     * @return mixed The finally rendered child nodes.
+     * @api
+     */
+    public function renderChildren()
+    {
+        if ($this->renderChildrenClosure !== null) {
+            $closure = $this->renderChildrenClosure;
+            return $closure();
+        }
+        return $this->viewHelperNode->evaluateChildNodes($this->renderingContext);
+    }
+
+    /**
+     * @return string
+     */
+    public function resolveContentArgumentName()
+    {
+        if (empty($this->contentArgumentName)) {
+            $registeredArguments = $this->prepareArguments();
+            foreach ($registeredArguments as $registeredArgument) {
+                if (!$registeredArgument->isRequired()) {
+                    $this->contentArgumentName = $registeredArgument->getName();
+                    return $this->contentArgumentName;
+                }
+            }
+            throw new Exception(
+                sprintf('Attempting to compile %s failed. Chosen compile method requires that ViewHelper has ' .
+                    'at least one registered and optional argument', __CLASS__)
+            );
+        }
+        return $this->contentArgumentName;
+    }
+
+    public function getContentArgumentName(): ?string
+    {
+        return $this->resolveContentArgumentName();
+    }
+}

--- a/Classes/Traits/CompileWithRenderStatic.php
+++ b/Classes/Traits/CompileWithRenderStatic.php
@@ -1,0 +1,40 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Class CompilableWithRenderStatic
+ *
+ * Provides default methods for rendering and compiling
+ * any ViewHelper that conforms to the `renderStatic`
+ * method pattern.
+ */
+trait CompileWithRenderStatic
+{
+    /**
+     * Default render method - simply calls renderStatic() with a
+     * prepared set of arguments.
+     *
+     * @return mixed Rendered result
+     * @api
+     */
+    public function render()
+    {
+        return static::renderStatic(
+            $this->arguments,
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext,
+        );
+    }
+
+    /**
+     * @return \Closure
+     */
+    abstract protected function buildRenderChildrenClosure();
+}

--- a/Classes/Traits/TagViewHelperCompatibility.php
+++ b/Classes/Traits/TagViewHelperCompatibility.php
@@ -1,0 +1,66 @@
+<?php
+namespace FluidTYPO3\Vhs\Traits;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
+trait TagViewHelperCompatibility
+{
+    /**
+     * Register a new tag attribute. Tag attributes are all arguments which will be directly appended to a tag if you
+     * call $this->initializeTag()
+     *
+     * @param string $name Name of tag attribute
+     * @param string $type Type of the tag attribute
+     * @param string $description Description of tag attribute
+     * @param bool $required set to true if tag attribute is required. Defaults to false.
+     * @param mixed $defaultValue Optional, default value of attribute if one applies
+     * @return void
+     * @api
+     */
+    protected function registerTagAttribute($name, $type, $description, $required = false, $defaultValue = null)
+    {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '>=')) {
+            $this->registerArgument($name, $type, $description, $required, $defaultValue);
+            return;
+        }
+        parent::registerTagAttribute($name, $type, $description, $required, $defaultValue);
+    }
+
+    /**
+     * Registers all standard HTML universal attributes.
+     * Should be used inside registerArguments();
+     *
+     * @return void
+     * @api
+     */
+    protected function registerUniversalTagAttributes()
+    {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '>=')) {
+            return;
+        }
+        $this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
+        $this->registerTagAttribute(
+            'dir',
+            'string',
+            'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)'
+        );
+        $this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
+        $this->registerTagAttribute(
+            'lang',
+            'string',
+            'Language for this element. Use short names specified in RFC 1766'
+        );
+        $this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
+        $this->registerTagAttribute('title', 'string', 'Tooltip text of element');
+        $this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
+        $this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
+        $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
+    }
+}

--- a/Classes/Traits/TagViewHelperTrait.php
+++ b/Classes/Traits/TagViewHelperTrait.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\Traits;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
 /**
  * Class TagViewHelperTrait
  *
@@ -32,12 +34,50 @@ trait TagViewHelperTrait
     }
 
     /**
+     * Register a new tag attribute. Tag attributes are all arguments which will be directly appended to a tag if you
+     * call $this->initializeTag()
+     *
+     * @param string $name Name of tag attribute
+     * @param string $type Type of the tag attribute
+     * @param string $description Description of tag attribute
+     * @param bool $required set to true if tag attribute is required. Defaults to false.
+     * @param mixed $defaultValue Optional, default value of attribute if one applies
+     * @return void
+     * @api
+     */
+    protected function registerTagAttribute($name, $type, $description, $required = false, $defaultValue = null)
+    {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '>=')) {
+            $this->registerArgument($name, $type, $description, $required, $defaultValue);
+            return;
+        }
+        parent::registerTagAttribute($name, $type, $description, $required, $defaultValue);
+    }
+
+    /**
      * Registers all standard and HTML5 universal attributes.
      * Should be used inside registerArguments();
      */
     protected function registerUniversalTagAttributes(): void
     {
-        parent::registerUniversalTagAttributes();
+        $this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
+        $this->registerTagAttribute(
+            'dir',
+            'string',
+            'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)'
+        );
+        $this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
+        $this->registerTagAttribute(
+            'lang',
+            'string',
+            'Language for this element. Use short names specified in RFC 1766'
+        );
+        $this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
+        $this->registerTagAttribute('title', 'string', 'Tooltip text of element');
+        $this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
+        $this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
+        $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
+
         $this->registerArgument(
             'forceClosingTag',
             'boolean',

--- a/Classes/ViewHelpers/Asset/StyleViewHelper.php
+++ b/Classes/ViewHelpers/Asset/StyleViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Asset;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
+
 /**
  * ### Basic Style ViewHelper
  *
@@ -16,6 +18,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Asset;
  */
 class StyleViewHelper extends AbstractAssetViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\ViewHelpers\Asset\AbstractAssetViewHelper;
 
 /**
@@ -49,6 +50,8 @@ use FluidTYPO3\Vhs\ViewHelpers\Asset\AbstractAssetViewHelper;
  */
 class AssetViewHelper extends AbstractAssetViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/CallViewHelper.php
+++ b/Classes/ViewHelpers/CallViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Call ViewHelper

--- a/Classes/ViewHelpers/ConstViewHelper.php
+++ b/Classes/ViewHelpers/ConstViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Const ViewHelper

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 
 /**
@@ -17,6 +18,8 @@ use FluidTYPO3\Vhs\Utility\ContextUtility;
  */
 class GetViewHelper extends AbstractContentViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/Content/Random/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/Random/GetViewHelper.php
@@ -8,11 +8,15 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content\Random;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
+
 /**
  * ViewHelper for fetching a random content element in Fluid page templates.
  */
 class GetViewHelper extends RenderViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/Content/Random/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Content/Random/RenderViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content\Random;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
 
@@ -16,6 +17,8 @@ use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
  */
 class RenderViewHelper extends AbstractContentViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content\Resources;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
+
 /**
  * Content FAL relations ViewHelper
  *
@@ -39,6 +41,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content\Resources;
  */
 class FalViewHelper extends \FluidTYPO3\Vhs\ViewHelpers\Resource\Record\FalViewHelper
 {
+    use ArgumentOverride;
+
     const DEFAULT_TABLE = 'tt_content';
     const DEFAULT_FIELD = 'image';
 

--- a/Classes/ViewHelpers/Content/ResourcesViewHelper.php
+++ b/Classes/ViewHelpers/Content/ResourcesViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Content;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
 
 /**
@@ -17,6 +18,7 @@ use FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
  */
 class ResourcesViewHelper extends RecordViewHelper
 {
+    use ArgumentOverride;
 
     const DEFAULT_TABLE = 'tt_content';
     const DEFAULT_FIELD = 'image';

--- a/Classes/ViewHelpers/Context/GetViewHelper.php
+++ b/Classes/ViewHelpers/Context/GetViewHelper.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Context: Get

--- a/Classes/ViewHelpers/Count/BytesViewHelper.php
+++ b/Classes/ViewHelpers/Count/BytesViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Count;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Counts bytes (multibyte-safe) in a string.

--- a/Classes/ViewHelpers/Count/LinesViewHelper.php
+++ b/Classes/ViewHelpers/Count/LinesViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Count;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Counts number of lines in a string.

--- a/Classes/ViewHelpers/Count/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Count/SubstringViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Count;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Counts number of lines in a string.

--- a/Classes/ViewHelpers/Count/WordsViewHelper.php
+++ b/Classes/ViewHelpers/Count/WordsViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Count;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Counts words in a string.

--- a/Classes/ViewHelpers/Extension/IconViewHelper.php
+++ b/Classes/ViewHelpers/Extension/IconViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Extension;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Extension: Icon ViewHelper

--- a/Classes/ViewHelpers/Extension/Path/AbsoluteViewHelper.php
+++ b/Classes/ViewHelpers/Extension/Path/AbsoluteViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Extension\Path;
 use FluidTYPO3\Vhs\ViewHelpers\Extension\AbstractExtensionViewHelper;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Path: Absolute Extension Folder Path

--- a/Classes/ViewHelpers/Extension/Path/RelativeViewHelper.php
+++ b/Classes/ViewHelpers/Extension/Path/RelativeViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\ViewHelpers\Extension\AbstractExtensionViewHelper;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Path: Relative Extension Folder Path

--- a/Classes/ViewHelpers/Extension/Path/ResourcesViewHelper.php
+++ b/Classes/ViewHelpers/Extension/Path/ResourcesViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\ViewHelpers\Extension\AbstractExtensionViewHelper;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Path: Relative Extension Resource Path

--- a/Classes/ViewHelpers/Extension/Path/SiteRelativeViewHelper.php
+++ b/Classes/ViewHelpers/Extension/Path/SiteRelativeViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\ViewHelpers\Extension\AbstractExtensionViewHelper;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Path: Relative Extension Folder Path

--- a/Classes/ViewHelpers/Format/AppendViewHelper.php
+++ b/Classes/ViewHelpers/Format/AppendViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Format: Append string content

--- a/Classes/ViewHelpers/Format/CaseViewHelper.php
+++ b/Classes/ViewHelpers/Format/CaseViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Case Formatting ViewHelper

--- a/Classes/ViewHelpers/Format/DateRangeViewHelper.php
+++ b/Classes/ViewHelpers/Format/DateRangeViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Date range calculation/formatting ViewHelper

--- a/Classes/ViewHelpers/Format/EliminateViewHelper.php
+++ b/Classes/ViewHelpers/Format/EliminateViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Character/string/whitespace elimination ViewHelper

--- a/Classes/ViewHelpers/Format/HashViewHelper.php
+++ b/Classes/ViewHelpers/Format/HashViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Hashes a string.

--- a/Classes/ViewHelpers/Format/HideViewHelper.php
+++ b/Classes/ViewHelpers/Format/HideViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Hides output from browser, but still renders tag content

--- a/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/DecodeViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format\Json;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Converts the JSON encoded argument into a PHP variable.

--- a/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Json/EncodeViewHelper.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### JSON Encoding ViewHelper

--- a/Classes/ViewHelpers/Format/MarkdownViewHelper.php
+++ b/Classes/ViewHelpers/Format/MarkdownViewHelper.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Markdown Transformation ViewHelper

--- a/Classes/ViewHelpers/Format/Placeholder/ImageViewHelper.php
+++ b/Classes/ViewHelpers/Format/Placeholder/ImageViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format\Placeholder;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -17,6 +18,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class ImageViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     /**
      * @var string
      */

--- a/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
+++ b/Classes/ViewHelpers/Format/Placeholder/LipsumViewHelper.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Lipsum ViewHelper

--- a/Classes/ViewHelpers/Format/PlaintextViewHelper.php
+++ b/Classes/ViewHelpers/Format/PlaintextViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Processes output as plaintext. Will trim whitespace off

--- a/Classes/ViewHelpers/Format/PregReplaceViewHelper.php
+++ b/Classes/ViewHelpers/Format/PregReplaceViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### PregReplace regular expression ViewHelper

--- a/Classes/ViewHelpers/Format/PrependViewHelper.php
+++ b/Classes/ViewHelpers/Format/PrependViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Format: Prepend string content

--- a/Classes/ViewHelpers/Format/ReplaceViewHelper.php
+++ b/Classes/ViewHelpers/Format/ReplaceViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Replaces $substring in $content with $replacement.

--- a/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SanitizeStringViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * URL text segment sanitizer. Sanitizes the content into a

--- a/Classes/ViewHelpers/Format/SubstringViewHelper.php
+++ b/Classes/ViewHelpers/Format/SubstringViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Gets a substring from a string or string-compatible value.

--- a/Classes/ViewHelpers/Format/TidyViewHelper.php
+++ b/Classes/ViewHelpers/Format/TidyViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Tidy-processes a string (HTML source), applying proper

--- a/Classes/ViewHelpers/Format/TrimViewHelper.php
+++ b/Classes/ViewHelpers/Format/TrimViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Trims $content by stripping off $characters (string list

--- a/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/DecodeViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format\Url;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Urldecodes the provided string.

--- a/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
+++ b/Classes/ViewHelpers/Format/Url/EncodeViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format\Url;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Urlencodes the provided string

--- a/Classes/ViewHelpers/Format/WordWrapViewHelper.php
+++ b/Classes/ViewHelpers/Format/WordWrapViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Wordwrap: Wrap a string at provided character count

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class ChunkViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ColumnViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -75,6 +76,7 @@ class ColumnViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/DiffViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/DiffViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Computes the difference of arrays.

--- a/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExplodeViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -22,6 +23,7 @@ class ExplodeViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ExtractViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
@@ -94,6 +95,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ExtractViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
     /**
      * @var boolean
      */

--- a/Classes/ViewHelpers/Iterator/FilterViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FilterViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -24,6 +25,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class FilterViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
     /**
      * @var boolean
      */

--- a/Classes/ViewHelpers/Iterator/FirstViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/FirstViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -17,6 +18,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class FirstViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
     /**
      * @var boolean
      */

--- a/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ImplodeViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -22,6 +23,7 @@ class ImplodeViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/IntersectViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -18,6 +19,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 class IntersectViewHelper extends AbstractViewHelper
 {
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/KeysViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/KeysViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class KeysViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/LastViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/LastViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -18,6 +19,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 class LastViewHelper extends AbstractViewHelper
 {
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/MergeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/MergeViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -18,6 +19,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 class MergeViewHelper extends AbstractViewHelper
 {
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/PopViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PopViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class PopViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/PushViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/PushViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -28,6 +29,7 @@ class PushViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/RandomViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RandomViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class RandomViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/RangeViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -30,6 +31,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 class RangeViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ReverseViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -23,6 +24,7 @@ class ReverseViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ShiftViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class ShiftViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/SliceViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SliceViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -20,6 +21,7 @@ class SliceViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/SortViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SortViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -35,6 +36,7 @@ class SortViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/SplitViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/SplitViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -19,6 +20,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 class SplitViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/UniqueViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -61,6 +62,7 @@ class UniqueViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ValuesViewHelper.php
@@ -26,6 +26,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Iterator;
  ***************************************************************/
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -37,6 +38,7 @@ class ValuesViewHelper extends AbstractViewHelper
 {
     use TemplateVariableViewHelperTrait;
     use ArrayConsumingViewHelperTrait;
+    use CompileWithRenderStatic;
 
     /**
      * @var boolean

--- a/Classes/ViewHelpers/LViewHelper.php
+++ b/Classes/ViewHelpers/LViewHelper.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### L (localisation) ViewHelper

--- a/Classes/ViewHelpers/Math/AbstractMultipleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractMultipleMathViewHelper.php
@@ -13,7 +13,7 @@ use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Base class: Math ViewHelpers operating on one number or an

--- a/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
+++ b/Classes/ViewHelpers/Math/AbstractSingleMathViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Base class: Math ViewHelpers operating on one number or an

--- a/Classes/ViewHelpers/Math/AverageViewHelper.php
+++ b/Classes/ViewHelpers/Math/AverageViewHelper.php
@@ -8,8 +8,9 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Average
@@ -26,6 +27,7 @@ class AverageViewHelper extends AbstractMultipleMathViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     use ArrayConsumingViewHelperTrait;
+    use ArgumentOverride;
 
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Math/CeilViewHelper.php
+++ b/Classes/ViewHelpers/Math/CeilViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Ceil

--- a/Classes/ViewHelpers/Math/CubeViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubeViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Square

--- a/Classes/ViewHelpers/Math/CubicRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/CubicRootViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: CubicRoot

--- a/Classes/ViewHelpers/Math/DivisionViewHelper.php
+++ b/Classes/ViewHelpers/Math/DivisionViewHelper.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Division

--- a/Classes/ViewHelpers/Math/FloorViewHelper.php
+++ b/Classes/ViewHelpers/Math/FloorViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Floor

--- a/Classes/ViewHelpers/Math/MaximumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MaximumViewHelper.php
@@ -8,9 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Maximum
@@ -22,6 +23,7 @@ class MaximumViewHelper extends AbstractMultipleMathViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     use ArrayConsumingViewHelperTrait;
+    use ArgumentOverride;
 
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Math/MedianViewHelper.php
+++ b/Classes/ViewHelpers/Math/MedianViewHelper.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Median

--- a/Classes/ViewHelpers/Math/MinimumViewHelper.php
+++ b/Classes/ViewHelpers/Math/MinimumViewHelper.php
@@ -8,9 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Minimum
@@ -22,6 +23,7 @@ class MinimumViewHelper extends AbstractMultipleMathViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     use ArrayConsumingViewHelperTrait;
+    use ArgumentOverride;
 
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Math/ModuloViewHelper.php
+++ b/Classes/ViewHelpers/Math/ModuloViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Modulo

--- a/Classes/ViewHelpers/Math/PowerViewHelper.php
+++ b/Classes/ViewHelpers/Math/PowerViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Power

--- a/Classes/ViewHelpers/Math/ProductViewHelper.php
+++ b/Classes/ViewHelpers/Math/ProductViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Math: Product (multiplication)

--- a/Classes/ViewHelpers/Math/RangeViewHelper.php
+++ b/Classes/ViewHelpers/Math/RangeViewHelper.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Range

--- a/Classes/ViewHelpers/Math/RoundViewHelper.php
+++ b/Classes/ViewHelpers/Math/RoundViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Round

--- a/Classes/ViewHelpers/Math/SquareRootViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareRootViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: SquareRoot

--- a/Classes/ViewHelpers/Math/SquareViewHelper.php
+++ b/Classes/ViewHelpers/Math/SquareViewHelper.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Square

--- a/Classes/ViewHelpers/Math/SubtractViewHelper.php
+++ b/Classes/ViewHelpers/Math/SubtractViewHelper.php
@@ -8,9 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Subtract
@@ -26,6 +27,7 @@ class SubtractViewHelper extends AbstractMultipleMathViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     use ArrayConsumingViewHelperTrait;
+    use ArgumentOverride;
 
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Math/SumViewHelper.php
+++ b/Classes/ViewHelpers/Math/SumViewHelper.php
@@ -8,9 +8,10 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Math;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Math: Sum
@@ -26,6 +27,7 @@ class SumViewHelper extends AbstractMultipleMathViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     use ArrayConsumingViewHelperTrait;
+    use ArgumentOverride;
 
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
+++ b/Classes/ViewHelpers/Media/AbstractMediaViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -18,6 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 abstract class AbstractMediaViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     protected string $mediaSource = '';
 
     public function initializeArguments(): void

--- a/Classes/ViewHelpers/Media/ExtensionViewHelper.php
+++ b/Classes/ViewHelpers/Media/ExtensionViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Returns the extension of the provided file.

--- a/Classes/ViewHelpers/Media/FilesViewHelper.php
+++ b/Classes/ViewHelpers/Media/FilesViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Returns an array of files found in the provided path.

--- a/Classes/ViewHelpers/Media/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Media/GravatarViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -15,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class GravatarViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     /**
      * Base url
      *

--- a/Classes/ViewHelpers/Media/PictureViewHelper.php
+++ b/Classes/ViewHelpers/Media/PictureViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
@@ -35,6 +36,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  */
 class PictureViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     const SCOPE = 'FluidTYPO3\Vhs\ViewHelpers\Media\PictureViewHelper';
     const SCOPE_VARIABLE_SRC = 'src';
     const SCOPE_VARIABLE_ID = 'treatIdAsReference';

--- a/Classes/ViewHelpers/Media/SizeViewHelper.php
+++ b/Classes/ViewHelpers/Media/SizeViewHelper.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * Returns the size of the provided file in bytes.

--- a/Classes/ViewHelpers/Media/SourceViewHelper.php
+++ b/Classes/ViewHelpers/Media/SourceViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\FrontendSimulationUtility;
@@ -26,6 +27,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  */
 class SourceViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     const SCOPE = 'FluidTYPO3\Vhs\ViewHelpers\Media\PictureViewHelper';
     const SCOPE_VARIABLE_SRC = 'src';
     const SCOPE_VARIABLE_ID = 'treatIdAsReference';

--- a/Classes/ViewHelpers/Media/SpotifyViewHelper.php
+++ b/Classes/ViewHelpers/Media/SpotifyViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -15,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class SpotifyViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     /**
      * Play button base url
      */

--- a/Classes/ViewHelpers/Media/VimeoViewHelper.php
+++ b/Classes/ViewHelpers/Media/VimeoViewHelper.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -15,6 +17,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class VimeoViewHelper extends AbstractTagBasedViewHelper
 {
+    use ArgumentOverride;
+    use TagViewHelperCompatibility;
+
     /**
      * Base URL for Vimeo video player
      */

--- a/Classes/ViewHelpers/Media/YoutubeViewHelper.php
+++ b/Classes/ViewHelpers/Media/YoutubeViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Media;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -15,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class YoutubeViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     /**
      * Base url
      *

--- a/Classes/ViewHelpers/Menu/DeferredViewHelper.php
+++ b/Classes/ViewHelpers/Menu/DeferredViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Menu;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**
@@ -20,6 +21,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  */
 class DeferredViewHelper extends AbstractMenuViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/OrViewHelper.php
+++ b/Classes/ViewHelpers/OrViewHelper.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * If content is empty use alternative text (can also be LLL:labelname shortcut or LLL:EXT: file paths).

--- a/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
+++ b/Classes/ViewHelpers/Page/AbsoluteUrlViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Returns a full, absolute URL to this page with all arguments.

--- a/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
+++ b/Classes/ViewHelpers/Page/BreadCrumbViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\ViewHelpers\Menu\AbstractMenuViewHelper;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 
@@ -16,6 +17,8 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
  */
 class BreadCrumbViewHelper extends AbstractMenuViewHelper
 {
+    use ArgumentOverride;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/CanonicalViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Header;
  */
 
 use FluidTYPO3\Vhs\Traits\PageRendererTrait;
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use FluidTYPO3\Vhs\Utility\RequestResolver;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -21,6 +22,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 class CanonicalViewHelper extends AbstractTagBasedViewHelper
 {
     use PageRendererTrait;
+    use TagViewHelperCompatibility;
 
     /**
      * @var string

--- a/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
+++ b/Classes/ViewHelpers/Page/Header/TitleViewHelper.php
@@ -12,7 +12,7 @@ use FluidTYPO3\Vhs\Traits\PageRendererTrait;
 use FluidTYPO3\Vhs\Utility\ContextUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### ViewHelper used to override page title

--- a/Classes/ViewHelpers/Page/InfoViewHelper.php
+++ b/Classes/ViewHelpers/Page/InfoViewHelper.php
@@ -13,7 +13,7 @@ use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ViewHelper to access data of the current page record.

--- a/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageMenuViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  */
 
 use FluidTYPO3\Vhs\Traits\ArrayConsumingViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\CoreUtility;
 use FluidTYPO3\Vhs\Utility\DoctrineQueryProxy;
@@ -33,6 +34,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 class LanguageMenuViewHelper extends AbstractTagBasedViewHelper
 {
     use ArrayConsumingViewHelperTrait;
+    use TagViewHelperCompatibility;
 
     protected array $languageMenu = [];
     protected int $defaultLangUid = 0;

--- a/Classes/ViewHelpers/Page/LanguageViewHelper.php
+++ b/Classes/ViewHelpers/Page/LanguageViewHelper.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Returns the current language from languages depending on l18n settings.

--- a/Classes/ViewHelpers/Page/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Page/LinkViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use FluidTYPO3\Vhs\Service\PageService;
 use FluidTYPO3\Vhs\Traits\PageRecordViewHelperTrait;
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use FluidTYPO3\Vhs\Utility\RequestResolver;
 use TYPO3\CMS\Core\Context\Context;
@@ -36,9 +37,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 class LinkViewHelper extends AbstractTagBasedViewHelper
 {
-
     use PageRecordViewHelperTrait;
     use TemplateVariableViewHelperTrait;
+    use TagViewHelperCompatibility;
 
     /**
      * @var PageService

--- a/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Page/Resources/FalViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page\Resources;
  */
 
 use FluidTYPO3\Vhs\Service\PageService;
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\Traits\SlideViewHelperTrait;
 use FluidTYPO3\Vhs\ViewHelpers\Resource\Record\FalViewHelper as ResourcesFalViewHelper;
 use TYPO3\CMS\Core\Context\Context;
@@ -27,6 +28,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class FalViewHelper extends ResourcesFalViewHelper
 {
     use SlideViewHelperTrait;
+    use ArgumentOverride;
 
     const DEFAULT_TABLE = 'pages';
     const DEFAULT_FIELD = 'media';

--- a/Classes/ViewHelpers/Page/ResourcesViewHelper.php
+++ b/Classes/ViewHelpers/Page/ResourcesViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 use FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
 
 /**
@@ -15,6 +16,8 @@ use FluidTYPO3\Vhs\ViewHelpers\Resource\RecordViewHelper;
  */
 class ResourcesViewHelper extends RecordViewHelper
 {
+    use ArgumentOverride;
+
     const DEFAULT_TABLE = 'pages';
     const DEFAULT_FIELD = 'media';
 

--- a/Classes/ViewHelpers/Page/RootlineViewHelper.php
+++ b/Classes/ViewHelpers/Page/RootlineViewHelper.php
@@ -13,7 +13,7 @@ use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ViewHelper to get the rootline of a page.

--- a/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
+++ b/Classes/ViewHelpers/Page/StaticPrefixViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Page;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Page: Static Prefix

--- a/Classes/ViewHelpers/Random/NumberViewHelper.php
+++ b/Classes/ViewHelpers/Random/NumberViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Random;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Random: Number Generator

--- a/Classes/ViewHelpers/Random/StringViewHelper.php
+++ b/Classes/ViewHelpers/Random/StringViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Random;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Random: String Generator

--- a/Classes/ViewHelpers/Render/AsciiViewHelper.php
+++ b/Classes/ViewHelpers/Render/AsciiViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Render: ASCII Character

--- a/Classes/ViewHelpers/Render/CacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/CacheViewHelper.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Cache Rendering ViewHelper

--- a/Classes/ViewHelpers/Render/InlineViewHelper.php
+++ b/Classes/ViewHelpers/Render/InlineViewHelper.php
@@ -9,7 +9,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
  */
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Render: Inline

--- a/Classes/ViewHelpers/Render/RecordViewHelper.php
+++ b/Classes/ViewHelpers/Render/RecordViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Render;
 
 use FluidTYPO3\Vhs\ViewHelpers\Content\AbstractContentViewHelper;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ViewHelper used to render raw content records typically fetched

--- a/Classes/ViewHelpers/Render/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Render/RequestViewHelper.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Response;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Render: Request

--- a/Classes/ViewHelpers/Render/UncacheViewHelper.php
+++ b/Classes/ViewHelpers/Render/UncacheViewHelper.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Uncaches partials. Use like ``f:render``.

--- a/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/AbstractResourceViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Utility\DoctrineQueryProxy;
 use FluidTYPO3\Vhs\Utility\ResourceUtility;
 use TYPO3\CMS\Core\Database\Connection;
@@ -23,6 +24,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
  */
 abstract class AbstractResourceViewHelper extends AbstractTagBasedViewHelper
 {
+    use TagViewHelperCompatibility;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();

--- a/Classes/ViewHelpers/Site/NameViewHelper.php
+++ b/Classes/ViewHelpers/Site/NameViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Site: Name

--- a/Classes/ViewHelpers/Site/UrlViewHelper.php
+++ b/Classes/ViewHelpers/Site/UrlViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Site: URL

--- a/Classes/ViewHelpers/System/DateTimeViewHelper.php
+++ b/Classes/ViewHelpers/System/DateTimeViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### System: DateTime

--- a/Classes/ViewHelpers/System/TimestampViewHelper.php
+++ b/Classes/ViewHelpers/System/TimestampViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### System: UNIX Timestamp

--- a/Classes/ViewHelpers/System/UniqIdViewHelper.php
+++ b/Classes/ViewHelpers/System/UniqIdViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\System;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### System: Unique ID

--- a/Classes/ViewHelpers/TagViewHelper.php
+++ b/Classes/ViewHelpers/TagViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Vhs\Traits\TagViewHelperCompatibility;
 use FluidTYPO3\Vhs\Traits\TagViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 

--- a/Classes/ViewHelpers/Uri/GravatarViewHelper.php
+++ b/Classes/ViewHelpers/Uri/GravatarViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * Renders Gravatar URI.

--- a/Classes/ViewHelpers/Uri/RequestViewHelper.php
+++ b/Classes/ViewHelpers/Uri/RequestViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Uri: Request

--- a/Classes/ViewHelpers/Variable/ConvertViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ConvertViewHelper.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Convert ViewHelper

--- a/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
+++ b/Classes/ViewHelpers/Variable/ExtensionConfigurationViewHelper.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### ExtConf ViewHelper

--- a/Classes/ViewHelpers/Variable/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/GetViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Variable: Get

--- a/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
+++ b/Classes/ViewHelpers/Variable/PregMatchViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### PregMatch regular expression ViewHelper

--- a/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/GetViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable\Register: Get

--- a/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/Register/SetViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable\Register;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable\Register: Set

--- a/Classes/ViewHelpers/Variable/SetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/SetViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable: Set

--- a/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
+++ b/Classes/ViewHelpers/Variable/TyposcriptViewHelper.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
  * ### Variable: TypoScript

--- a/Classes/ViewHelpers/Variable/UnsetViewHelper.php
+++ b/Classes/ViewHelpers/Variable/UnsetViewHelper.php
@@ -10,7 +10,7 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Variable;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use FluidTYPO3\Vhs\Traits\CompileWithRenderStatic;
 
 /**
  * ### Variable: Unset
@@ -48,7 +48,7 @@ class UnsetViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @return void
+     * @return null
      */
     public static function renderStatic(
         array $arguments,
@@ -61,5 +61,6 @@ class UnsetViewHelper extends AbstractViewHelper
         if ($variableProvider->exists($name)) {
             $variableProvider->remove($name);
         }
+        return null;
     }
 }


### PR DESCRIPTION
Adds a massive number of backwards/cross compatibility handlers, because Fluid decided to introduce a large number of completely unnecessary breaking changes in v4, because "it's cleaner" and apparently nobody cares about devs anymore.