### PR TITLE
[BUGFIX] Handle new TS-not-set limitation on v13

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,6 +27,7 @@
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] = [
             'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
             'options' => [
+                // You should keep this value HIGHER than the lifetime of TYPO3's page caches at all times.
                 'defaultLifetime' => 804600
             ],
             'groups' => ['pages', 'all']


### PR DESCRIPTION
Uncached rendering context no longer provides TS through ConfigurationManager. An exception is raised instead. To avoid this, we store a representation of the plugin.tx_vhs TS scope in a separate cache when the page is rendered before it is cached - and retrieve this cached TS when needed.