### PR TITLE
[BUGFIX] Always fetch ContentObject from request in TYPO3v12+

### DIFF
--- a/Classes/Utility/ContentObjectFetcher.php
+++ b/Classes/Utility/ContentObjectFetcher.php
@@ -22,16 +22,15 @@ class ContentObjectFetcher
             ? $configurationManager->getRequest()
             : ($GLOBALS['TYPO3_REQUEST'] ?? null)) ?? $GLOBALS['TYPO3_REQUEST'] ?? null;
 
-        if ($request && $configurationManager === null) {
+        if ($request) {
             $contentObject = static::resolveFromRequest($request);
         }
 
-        if ($contentObject === null) {
-            if ($configurationManager !== null && method_exists($configurationManager, 'getContentObject')) {
-                $contentObject = $configurationManager->getContentObject();
-            } elseif ($request) {
-                $contentObject = static::resolveFromRequest($request);
-            }
+        if ($contentObject === null
+            && $configurationManager !== null
+            && method_exists($configurationManager, 'getContentObject')
+        ) {
+            $contentObject = $configurationManager->getContentObject();
         }
 
         return $contentObject;


### PR DESCRIPTION
The ContentObjectFetcher was introduced to have a common API for fetching the current content object across different TYPO3 versions.

This class logs a deprecation notice in TYPO3v12:
> TYPO3 Deprecation Notice:
> ConfigurationManager->getContentObject() is deprecated since TYPO3 v12.4
> and will be removed in v13.0.
> Fetch the current content object from request attribute
> "currentContentObject" instead in
> vendor/typo3/cms-extbase/Classes/Configuration/ConfigurationManager.php
> line 96

To prevent this from happening, we check for the TYPO3 version and always use the request instead of the configuration manager in TYPO3v12+.

Related: https://github.com/FluidTYPO3/vhs/pull/1920
Related: https://github.com/FluidTYPO3/vhs/pull/1921
Related: https://github.com/FluidTYPO3/flux/pull/2229

Documentation: https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/RequestLifeCycle/RequestAttributes/CurrentContentObject.html