### PR TITLE
[BUGFIX] Use addRootLineFields on v12.4

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -36,7 +36,7 @@
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['v'] = ['FluidTYPO3\\Vhs\\ViewHelpers'];
 
-    if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version(), '12.4', '<=')) {
+    if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version(), '13.0', '<')) {
         // add navigtion hide to fix menu viewHelpers (e.g. breadcrumb)
         $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= (empty($GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']) ? '' : ',') . 'nav_hide,shortcut,shortcut_mode';
 


### PR DESCRIPTION
Commit "[BUGFIX] Avoid addRootLineFields on v13" prevented loading rootline fields on TYPO3 v12.4.26,
leading to a missing "nav_hide" field needed by the breadcrumb viewhelper.

We correctly check that it's a TYPO3 version less than 13, instead of less-or-equal than 12.4.

Related: 3b9720203c1df47fa943c01061f35116f93954ff