### PR TITLE
BUGFIX: trim only if not empty

### DIFF
--- a/Classes/ViewHelpers/Format/TrimViewHelper.php
+++ b/Classes/ViewHelpers/Format/TrimViewHelper.php
@@ -41,7 +41,7 @@ class TrimViewHelper extends AbstractViewHelper
         $content = $renderChildrenClosure();
         if (!empty($characters)) {
             $content = trim($content, $characters);
-        } else {
+        } else if (!empty($content)) {
             $content = trim($content);
         }
         return $content;


### PR DESCRIPTION
PHP Runtime Deprecation Notice: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/fluidtypo3/vhs/Classes/ViewHelpers/Format/TrimViewHelper.php line 45