### PR TITLE
[BUGFIX] Fixed deprecation notice in AbstractSecurityViewHelper

### DIFF
--- a/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
+++ b/Classes/ViewHelpers/Security/AbstractSecurityViewHelper.php
@@ -230,7 +230,7 @@ abstract class AbstractSecurityViewHelper extends AbstractConditionViewHelper
     /**
      * Returns TRUE only if currently logged in frontend user is in list.
      */
-    public function assertFrontendUsersLoggedIn(ObjectStorage $frontendUsers = null): bool
+    public function assertFrontendUsersLoggedIn(?ObjectStorage $frontendUsers = null): bool
     {
         if ($frontendUsers === null) {
             return false;


### PR DESCRIPTION
Fixed deprecation notice in AbstractSecurityViewHelper for implicitly marking parameter $frontendUsers as nullable:

```
  [ TYPO3\CMS\Core\Error\Exception ]                                           
  PHP Runtime Deprecation Notice: FluidTYPO3\Vhs\ViewHelpers\Security\Abstrac  
  tSecurityViewHelper::assertFrontendUsersLoggedIn(): Implicitly marking para  
  meter $frontendUsers as nullable is deprecated, the explicit nullable type   
  must be used instead in /var/www/app/vendor/fluidtypo3/vhs/Classes/ViewHelp  
  ers/Security/AbstractSecurityViewHelper.php line 233
```

$frontendUsers is now explicitly nullable.
