### PR TITLE
[BUGFIX] rename Operation not permitted during cache flush

### DIFF
--- a/Classes/Service/AssetService.php
+++ b/Classes/Service/AssetService.php
@@ -752,9 +752,7 @@ class AssetService implements SingletonInterface
         foreach ($assetCacheFiles as $assetCacheFile) {
             if (!@touch($assetCacheFile, 0)) {
                 $content = (string) file_get_contents($assetCacheFile);
-                $temporaryAssetCacheFile = (string) GeneralUtility::tempnam(basename($assetCacheFile) . '.');
-                $this->writeFile($temporaryAssetCacheFile, $content);
-                rename($temporaryAssetCacheFile, $assetCacheFile);
+                $this->writeFile($assetCacheFile, $content);
                 touch($assetCacheFile, 0);
             }
         }
@@ -778,6 +776,13 @@ class AssetService implements SingletonInterface
                 1733258066
             );
         }
+        if (realpath(dirname($file)) !== dirname($tmpFile)) {
+            throw new \RuntimeException(
+                "Failed to write file {$file}: No new files can be created in directory",
+                1750681587
+            );
+        }
+        $tmpFile = dirname($file) . '/' . basename($tmpFile);
         GeneralUtility::writeFile($tmpFile, $contents, true);
         if (@rename($tmpFile, $file) === false) {
             $error = error_get_last();


### PR DESCRIPTION
Remove the duplicate rename around the writes in
AssertService::clearCacheCommand(). AssetService::writeFile() itself is already implemented in an atomic fashion by using rename internally. Additionally, the use of GeneralUtility::tempnam() removed in this change triggered the following Exception in certain TYPO3 deployments when flushing the cache:

    PHP Warning:
    rename(
        /var/www/var/transient/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css.8B47TF,
        /var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css
    ): Operation not permitted
    in /var/www/public/typo3conf/ext/vhs/Classes/Service/AssetService.php line 757

Deployments are affected if they satisfy the following two conditions:

- TYPO3 cli and php-fpm are ran by different users, and
- "var/transient" and "public/typo3temp/assets" are located on different mount points.

If some existing cache file is owned by the other user, the utime(2) system call issued for the \touch() PHP function call fails with EPERM (Operation not permitted). The rename(2) system call issued for the \rename() PHP function call in the fallback path always fails with EXDEV (Invalid cross-device link). The PHP interpreter implicitly falls back to an alternative rename [1] that doesn't use rename(2) and is roughly equivalent to \fopen('w'), \fwrite(\file_get_contents($orig)), \chown() and \chmod(). But the \chown() and \chmod() operations cannot succeed because we aren't the owner of the file, as otherwise the utime(2) system call in the \touch() PHP function call would have succeeded. The same is true for the final utime(2) in the \touch() PHP function call which also just silently fails if PHP warnings are disabled. The following are the relevant system calls collected by inspecting php-fpm with strace:

    access("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", F_OK) = 0
    utime("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", {actime=0, modtime=0}) = -1 EPERM (Operation not permitted)
    rename("/var/www/var/transient/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css.nIoApp", "/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css") = -1 EXDEV (Invalid cross-device link)
    openat(AT_FDCWD, "/var/www/var/transient/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css.nIoApp", O_RDONLY) = 17
    openat(AT_FDCWD, "/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 18
    mmap(NULL, 20698, PROT_READ, MAP_SHARED, 17, 0) = 0x749df6db6000
    write(18, "/*!*****************************"..., 8192) = 8192
    write(18, "adding-top:5px}@media(min-width:"..., 8192) = 8192
    write(18, "in-top--xs{margin-top:15px}@medi"..., 4314) = 4314
    munmap(0x749df6db6000, 20698) = 0
    close(17)                  = 0
    close(18)                  = 0
    chown("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", 83, 86800513) = -1 EPERM (Operation not permitted)
    chmod("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", 0100600) = -1 EPERM (Operation not permitted)
    unlink("/var/www/var/transient/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css.nIoApp") = 0
    access("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", F_OK) = 0
    utime("/var/www/public/typo3temp/assets/vhs/vhs-assets-09d7f183856cad2bc998f81e9e0660f4.css", {actime=0, modtime=0}) = -1 EPERM (Operation not permitted)

The usage of GeneralUtility::tempnam() over \tempnam() was introduced in bb5ae3f8 ("[BUGFIX] Write temp file within TYPO3 project path") to try to fix an issue where TYPO3 doesn't apply the correct permissions to the file due to being outside the project path. The earlier \tempnam() as well as the existing \tempnam() inside AssertService::write() explicitly pass in the directory of the target file. So if
GeneralUtility::fixPermissions() does nothing due to failing the GeneralUtility::isAllowedAbsPath() check it is correct in the sense that it would behave the same if it were called on the target file. Except that this wasn't true for symlinks inside the TYPO3 project pointing outside the TYPO3 project before this change, because \tempnam() expands symlinks. Configuring $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] on a per-file basis is no longer possible as of a70f34cbe14 ("[!!!][SECURITY] Enforce absolute path checks in FAL local driver"), which was ported to all TYPO3 branches.

[1]: https://github.com/php/php-src/blob/php-8.4.8/main/streams/plain_wrapper.c#L1327-L1376
Fixes: bb5ae3f8 ("[BUGFIX] Write temp file within TYPO3 project path")