### PR TITLE
Allows cache configuration to be overridden

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,26 +13,24 @@
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = \FluidTYPO3\Vhs\Service\AssetService::class . '->clearCacheCommand';
     }
 
-    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'] ?? null)) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'] = [
-            'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
-            'options' => [
-                'defaultLifetime' => 804600
-            ],
-            'groups' => ['pages', 'all']
-        ];
-    }
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'] ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_main'] += [
+        'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
+        'options' => [
+            'defaultLifetime' => 804600
+        ],
+        'groups' => ['pages', 'all']
+    ];
 
-    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] ?? null)) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] = [
-            'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
-            'options' => [
-                // You should keep this value HIGHER than the lifetime of TYPO3's page caches at all times.
-                'defaultLifetime' => 804600
-            ],
-            'groups' => ['pages', 'all']
-        ];
-    }
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['vhs_markdown'] += [
+        'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
+        'options' => [
+            // You should keep this value HIGHER than the lifetime of TYPO3's page caches at all times.
+            'defaultLifetime' => 804600
+        ],
+        'groups' => ['pages', 'all']
+    ];
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['v'] = ['FluidTYPO3\\Vhs\\ViewHelpers'];
 


### PR DESCRIPTION
Allows vhs cache configuration to be overridden by additionnal.php while keeping extension defaults for non-overridden values.

if my case, I add 'backend' = 'TYPO3\CMS\Core\Cache\Backend\RedisBackend' and a custom defaultLifetime.