### PR TITLE
[FEATURE] Relay original exception in abstract record resource view h…

### DIFF
--- a/Classes/Utility/ErrorUtility.php
+++ b/Classes/Utility/ErrorUtility.php
@@ -17,8 +17,11 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  */
 class ErrorUtility
 {
-    public static function throwViewHelperException(?string $message = null, ?int $code = null): void
-    {
-        throw new Exception((string) $message, (integer) $code);
+    public static function throwViewHelperException(
+        ?string $message = null,
+        ?int $code = null,
+        ?\Throwable $previous = null
+    ): void {
+        throw new Exception((string) $message, (integer) $code, $previous);
     }
 }

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -211,7 +211,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper imple
             // thrown by the getResources() method in subclasses are not
             // extended from a shared base class like RuntimeException. Thus,
             // we are forced to "catch them all" - but we also output them.
-            ErrorUtility::throwViewHelperException($error->getMessage(), $error->getCode());
+            ErrorUtility::throwViewHelperException($error->getMessage(), $error->getCode(), $error);
         }
         return $content;
     }

--- a/Tests/Unit/Utility/ErrorUtilityTest.php
+++ b/Tests/Unit/Utility/ErrorUtilityTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace FluidTYPO3\Vhs\Utility;
+
+/*
+ * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Vhs\Tests\Unit\AbstractTestCase;
+use FluidTYPO3\Vhs\Utility\ErrorUtility;
+
+class ErrorUtilityTest extends AbstractTestCase
+{
+    /**
+     * @test
+     */
+    public function transfersPreviousException()
+    {
+        try {
+            $previous = new \Exception('a', 23);
+            ErrorUtility::throwViewHelperException('b', 42, $previous);
+        } catch (\Exception $exception) {
+            $this->assertEquals('b', $exception->getMessage());
+            $this->assertEquals(42, $exception->getCode());
+
+            $this->assertEquals('a', $exception->getPrevious()->getMessage());
+            $this->assertEquals(23, $exception->getPrevious()->getCode());
+
+            return;
+        }
+        $this->fail('No exception thrown');
+    }
+}


### PR DESCRIPTION
…elper

.. so we have a way to find out where the original error happened

In my case I got a
> (1/2) #1314085990 TYPO3Fluid\Fluid\Core\ViewHelper\Exception
> Desired storage "AusDriverAmazonS3" is not in the list of available storages.

and needed the original stack trace.