### PR TITLE
[DOC] Document "record" requirement for v:content.resources.fal

### DIFF
--- a/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
@@ -13,6 +13,9 @@ use FluidTYPO3\Vhs\Traits\ArgumentOverride;
 /**
  * Content FAL relations ViewHelper
  *
+ * Since vhs 7.1.0, the "record" argument is required.
+ *
+ *
  * ### Render a single image in a content element
  *
  * We assume that the flux content element has an IRRE file field
@@ -21,7 +24,7 @@ use FluidTYPO3\Vhs\Traits\ArgumentOverride;
  * The file data can be loaded and displayed with:
  *
  * ```
- * {v:content.resources.fal(field: 'settings.image')
+ * {v:content.resources.fal(field: 'settings.image', record: record)
  *   -> v:iterator.first()
  *   -> v:variable.set(name: 'image')}
  * <f:if condition="{image}">

--- a/Documentation/Changelog/7.1.0.md
+++ b/Documentation/Changelog/7.1.0.md
@@ -1,5 +1,7 @@
 ## Release: 7.1.0 (2025/02/27 12:18:18)
 
+Breaking: <v:content.resources.fal> requires the "record" attribute.
+
 * 2025-02-26 [BUGFIX] Cast to string before trim (#1934) (Commit 4b779e00 by Christian Hillebrand)
 * 2025-02-04 [BUGFIX] Always fetch ContentObject from request in TYPO3v12+ (Commit 99129162 by Christian Weiske)
 * 2025-02-05 [BUGFIX] Use addRootLineFields on v12.4 (Commit 41b11dcb by Christian Weiske)
@@ -42,6 +44,5 @@ git log --since="2025/01/24 21:46:04" --until="2025/02/27 12:18:18" --abbrev-com
 
 Full list of changes: https://github.com/FluidTYPO3/vhs/compare/7.0.7...7.1.0
 
-*Please note: the change list above does not contain any TASK commits since they are considered 
+*Please note: the change list above does not contain any TASK commits since they are considered
 infrastructure-only and not relevant to end users. The full list includes these!*
-


### PR DESCRIPTION
Related: https://github.com/FluidTYPO3/vhs/issues/1937

Probably caused by #1921 and #1931.