### PR TITLE
[REMOVAL] Make resource ViewHelpers demand uid or record

### DIFF
--- a/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
+++ b/Classes/ViewHelpers/Content/Resources/FalViewHelper.php
@@ -21,7 +21,7 @@ use FluidTYPO3\Vhs\Traits\ArgumentOverride;
  * The file data can be loaded and displayed with:
  *
  * ```
- * {v:content.resources.fal(field: 'settings.image')
+ * {v:content.resources.fal(field: 'settings.image', record: record)
  *   -> v:iterator.first()
  *   -> v:variable.set(name: 'image')}
  * <f:if condition="{image}">

--- a/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
+++ b/Classes/ViewHelpers/Resource/Record/AbstractRecordResourceViewHelper.php
@@ -11,10 +11,8 @@ namespace FluidTYPO3\Vhs\ViewHelpers\Resource\Record;
 use FluidTYPO3\Vhs\Core\ViewHelper\AbstractViewHelper;
 use FluidTYPO3\Vhs\Proxy\DoctrineQueryProxy;
 use FluidTYPO3\Vhs\Traits\TemplateVariableViewHelperTrait;
-use FluidTYPO3\Vhs\Utility\ContentObjectFetcher;
 use FluidTYPO3\Vhs\Utility\ErrorUtility;
 use FluidTYPO3\Vhs\Utility\RequestResolver;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -55,12 +53,12 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'record',
             'array',
-            'The actual record. Alternatively you can use the "uid" argument.'
+            'The actual record. Alternatively you can use the "uid" argument; you must specify either one.'
         );
         $this->registerArgument(
             'uid',
             'integer',
-            'The uid of the record. Alternatively you can use the "record" argument.'
+            'The uid of the record. Alternatively you can use the "record" argument; you must specify either one.'
         );
         $this->registerArgument(
             'as',
@@ -76,7 +74,7 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper
 
         if (!isset($record[$field])) {
             ErrorUtility::throwViewHelperException(
-                'The "field" argument was not found on the selected record.',
+                'The field "' . $field . '" was not found on the selected record.',
                 1384612728
             );
         }
@@ -151,31 +149,15 @@ abstract class AbstractRecordResourceViewHelper extends AbstractViewHelper
         return $result;
     }
 
-    public function getActiveRecord(): array
-    {
-        $contentObject = ContentObjectFetcher::resolve($this->configurationManager);
-        return $contentObject->data;
-    }
-
-    /**
-     * @return mixed
-     */
     public function render()
     {
-        /** @var array|null $record */
-        $record = $this->arguments['record'] ?? null;
         /** @var int|null $uid */
         $uid = $this->arguments['uid'] ?? null;
 
-        if (null === $record) {
-            if (null === $uid) {
-                $record = $this->getActiveRecord();
-            } else {
-                $record = $this->getRecord($uid);
-            }
-        }
+        /** @var array|null $record */
+        $record = $this->arguments['record'] ?? $this->getRecord((int) $uid);
 
-        if (null === $record) {
+        if ($record === null) {
             ErrorUtility::throwViewHelperException(
                 'No record was found. The "record" or "uid" argument must be specified.',
                 1384611413

--- a/Tests/Unit/ViewHelpers/AbstractViewHelperTestCase.php
+++ b/Tests/Unit/ViewHelpers/AbstractViewHelperTestCase.php
@@ -57,6 +57,9 @@ abstract class AbstractViewHelperTestCase extends AbstractTestCase
     protected array $defaultArguments = [
         'name' => 'test',
     ];
+    protected array $defaultMockMethods = [
+        'dummy',
+    ];
 
     protected function setUp(): void
     {
@@ -199,7 +202,10 @@ abstract class AbstractViewHelperTestCase extends AbstractTestCase
     {
         $className = $this->getViewHelperClassName();
         /** @var AbstractViewHelper $instance */
-        $instance = $this->getMockBuilder($className)->setMethods(['dummy'])->disableOriginalConstructor()->getMock();
+        $instance = $this->getMockBuilder($className)
+            ->setMethods($this->defaultMockMethods)
+            ->disableOriginalConstructor()
+            ->getMock();
         if (method_exists($instance, 'injectConfigurationManager')) {
             $cObject = $this->getMockBuilder(ContentObjectRenderer::class)->disableOriginalConstructor()->getMock();
             $cObject->start(['uid' => 123], 'tt_content');

--- a/Tests/Unit/ViewHelpers/Content/Resources/FalViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Content/Resources/FalViewHelperTest.php
@@ -18,6 +18,15 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTestCase;
  */
 class FalViewHelperTest extends AbstractViewHelperTestCase
 {
+    protected array $defaultArguments = [
+        'record' => ['uid' => 123],
+    ];
+
+    protected array $defaultMockMethods = [
+        'getRecord',
+        'getResources',
+    ];
+
     protected function setUp(): void
     {
         $this->singletonInstances[ResourceFactoryProxy::class] = $this->getMockBuilder(ResourceFactoryProxy::class)->disableOriginalConstructor()->getMock();
@@ -28,6 +37,6 @@ class FalViewHelperTest extends AbstractViewHelperTestCase
 
     public function testRender()
     {
-        $this->assertEmpty($this->executeViewHelper());
+        $this->assertEmpty($this->executeViewHelper($this->defaultArguments));
     }
 }

--- a/Tests/Unit/ViewHelpers/Content/ResourcesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Content/ResourcesViewHelperTest.php
@@ -16,6 +16,11 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTestCase;
  */
 class ResourcesViewHelperTest extends AbstractViewHelperTestCase
 {
+    protected array $defaultMockMethods = [
+        'getRecord',
+        'getResources',
+    ];
+
     public function testRenderFailsWithoutFieldArgument()
     {
         $this->expectViewHelperException();

--- a/Tests/Unit/ViewHelpers/Page/ResourcesViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Page/ResourcesViewHelperTest.php
@@ -16,6 +16,11 @@ use FluidTYPO3\Vhs\Tests\Unit\ViewHelpers\AbstractViewHelperTestCase;
  */
 class ResourcesViewHelperTest extends AbstractViewHelperTestCase
 {
+    protected array $defaultMockMethods = [
+        'getRecord',
+        'getResources',
+    ];
+
     /**
      * @test
      */

--- a/Tests/Unit/ViewHelpers/Resource/Record/FalViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Resource/Record/FalViewHelperTest.php
@@ -20,6 +20,11 @@ use TYPO3\CMS\Core\Resource\ResourceStorage;
 
 class FalViewHelperTest extends AbstractViewHelperTestCase
 {
+    protected array $defaultMockMethods = [
+        'getRecord',
+        'getResources',
+    ];
+
     protected function setUp(): void
     {
         $this->singletonInstances[ResourceFactoryProxy::class] = $this->getMockBuilder(ResourceFactoryProxy::class)
@@ -36,7 +41,7 @@ class FalViewHelperTest extends AbstractViewHelperTestCase
 
     public function testFalViewhHelperWithoutWorkspaces(): void
     {
-        $output = $this->executeViewHelper(['table' => 'pages', 'field' => 'media']);
+        $output = $this->executeViewHelper(['table' => 'pages', 'field' => 'media', 'record' => ['uid' => 123]]);
         $this->assertSame([], $output);
     }
 


### PR DESCRIPTION
FAL etc. resource ViewHelpers no longer allow calling without both record and uid arguments, which previously would have attempted to resolve the current record data from ContentObectRenderer.

Calling these ViewHelpers must now include either record or uid as arguments. Argument descriptions updated accordingly.

Close: #1963